### PR TITLE
Fix package namespace: Include mortie Python package in wheel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Rust-accelerated morton indexing for HEALPix grids"
 license = "BSD-3-Clause"
 
 [lib]
-name = "rustie"
+name = "mortie_rustie"
 crate-type = ["cdylib"]
 path = "src_rust/src/lib.rs"
 

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -38,9 +38,9 @@ __all__ = [
 
 # Import Rust-accelerated functions
 try:
-    import rustie
+    from . import _rustie
     # Alias the Rust function to the expected Python API
-    geo2mort = rustie.fast_norm2mort
+    geo2mort = _rustie.fast_norm2mort
     # mort2geo not yet implemented in Rust
     mort2geo = None
 except (ImportError, AttributeError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,6 @@ test = [
 
 [tool.maturin]
 python-source = "."
-module-name = "rustie"
+module-name = "mortie._rustie"
 bindings = "pyo3"
 features = ["pyo3/extension-module"]

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -121,7 +121,7 @@ fn fast_norm2mort<'py>(
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn rustie(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _rustie(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fast_norm2mort, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Problem

When installing `mortie` via pip, the package structure was broken:
- `pip install mortie` would install successfully
- But `import mortie` would fail with `ModuleNotFoundError`
- Only `import rustie` would work
- Users couldn't access the intended API: `from mortie import geo2mort`

## Root Cause

The issue was in the maturin configuration:
- `module-name = "rustie"` in `pyproject.toml` caused maturin to only package the Rust extension
- The Python package files (`mortie/__init__.py`, `mortie/tools.py`) were not included in the wheel
- This resulted in a wheel that only contained the `rustie` module, not the `mortie` package

## Solution

Changed the module structure to properly include both components:
1. Renamed Rust module from `rustie` to `mortie._rustie` (internal submodule)
2. Updated `pyproject.toml`: `module-name = "mortie._rustie"`
3. Updated `Cargo.toml`: `name = "mortie_rustie"`
4. Updated Rust lib: `fn _rustie(...)`
5. Updated Python imports to use relative import: `from . import _rustie`

## Result

Now the package works as intended:
- ✅ `pip install mortie` installs the complete package
- ✅ `import mortie` works correctly
- ✅ `from mortie import geo2mort` works as expected
- ✅ All Python functions from `tools.py` are accessible
- ✅ Rust-accelerated functions are properly integrated

## Testing

Tested locally:
```python
import mortie  # ✓ Works
from mortie import geo2mort  # ✓ Works
from mortie import clip2order, unique2parent  # ✓ Works

# Test function
result = geo2mort(18, 1000, 2)  # ✓ Returns correct value
```

The wheel now properly contains:
- `mortie/__init__.py`
- `mortie/tools.py`
- `mortie/_rustie.abi3.so`
- `mortie/tests/` (test files)