### PR TITLE
Efficient conversion of complex polygons to morton coverage

### DIFF
--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -34,6 +34,9 @@ from .tools import (
     mort2healpix,
 )
 
+# Import greedy polygon functions
+from .greedy_polygon import greedy_morton_polygon
+
 __all__ = [
     'tools',
     'geo2mort',
@@ -55,6 +58,7 @@ __all__ = [
     'clip2order',
     'generate_morton_children',
     'mort2healpix',
+    'greedy_morton_polygon',
 ]
 
 # The Rust extension is imported and used internally by fastNorm2Mort in tools.py

--- a/mortie/greedy_polygon.py
+++ b/mortie/greedy_polygon.py
@@ -1,0 +1,285 @@
+"""
+Greedy polygon subdivision for morton indices.
+
+This module provides functions to generate compact morton index coverage
+for arbitrary geometries using greedy subdivision with configurable constraints.
+"""
+
+import numpy as np
+
+
+def greedy_morton_polygon(lat, lon, order=18, max_boxes=16, ordermax=None, verbose=False):
+    """
+    Calculate compact morton index coverage using greedy subdivision.
+
+    This function finds the highest-order morton indices that fully contain
+    all points in the input geometry. It greedily subdivides until reaching
+    the max_boxes ceiling or ordermax limit.
+
+    Parameters
+    ----------
+    lat : array-like
+        Latitude values in degrees
+    lon : array-like
+        Longitude values in degrees
+    order : int, default=18
+        Morton cell order to start with (higher = finer resolution)
+    max_boxes : int, default=16
+        Maximum number of morton boxes allowed
+    ordermax : int, optional
+        Maximum order (resolution) for subdivision. Branches that reach
+        this order will not be subdivided further. If None, no order limit.
+    verbose : bool, default=False
+        Print subdivision progress
+
+    Returns
+    -------
+    mbbox : ndarray
+        Array of morton indices that form the minimum bounding box
+    mbbox_orders : ndarray
+        Array of orders for each morton index
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> lat = np.array([-75, -75, -70, -70])
+    >>> lon = np.array([-80, -70, -70, -80])
+    >>> mbbox, orders = greedy_morton_polygon(lat, lon, max_boxes=16, ordermax=6)
+
+    Notes
+    -----
+    The algorithm uses a greedy strategy that prioritizes splitting coarser
+    (lower-order) boxes first to maintain balanced spatial coverage across
+    the geometry. This prevents over-subdivision of any single region.
+    """
+    from . import geo2mort
+
+    # Convert to numpy arrays
+    lat = np.asarray(lat)
+    lon = np.asarray(lon)
+
+    # Remove NaN values
+    valid = ~(np.isnan(lat) | np.isnan(lon))
+    lat = lat[valid]
+    lon = lon[valid]
+
+    if len(lat) == 0:
+        raise ValueError("No valid points provided")
+
+    # Calculate morton indices at specified order
+    midx = geo2mort(lat, lon, order=order)
+
+    # Convert to string array for character-by-character analysis
+    midx_str = np.array([str(m) for m in midx])
+
+    if verbose:
+        print(f"Starting greedy subdivision with max_boxes={max_boxes}, ordermax={ordermax}")
+        print(f"Total morton indices at order {order}: {len(midx_str):,}\n")
+
+    # Greedy subdivision
+    morton_boxes = _greedy_subdivide(midx_str, max_boxes, ordermax=ordermax, verbose=verbose)
+
+    if verbose:
+        print(f"\n{'='*70}")
+        print(f"Final result: {len(morton_boxes)} morton boxes")
+        print(f"{'='*70}\n")
+
+    # Convert strings back to integers and calculate orders
+    morton_indices = np.array([int(box) for box in morton_boxes])
+    morton_orders = np.array([_estimate_order_from_prefix(box) for box in morton_boxes])
+
+    return morton_indices, morton_orders
+
+
+def _greedy_subdivide(morton_strings, max_boxes, ordermax=None, verbose=False):
+    """
+    Greedily subdivide morton indices until hitting limits.
+
+    Parameters
+    ----------
+    morton_strings : array-like of str
+        Morton indices as strings
+    max_boxes : int
+        Maximum number of boxes allowed
+    ordermax : int, optional
+        Maximum order for subdivision
+    verbose : bool
+        Print progress
+
+    Returns
+    -------
+    boxes : list of str
+        List of morton index prefixes
+    """
+    # Start with one box containing all indices
+    boxes = [{'prefix': _find_common_prefix(morton_strings), 'indices': morton_strings}]
+
+    if verbose:
+        print(f"Initial: 1 box covering {len(morton_strings):,} indices")
+        print(f"  Box 1: prefix='{boxes[0]['prefix']}'\n")
+
+    iteration = 0
+    while len(boxes) < max_boxes:
+        iteration += 1
+        if verbose:
+            print(f"Iteration {iteration}: Current boxes: {len(boxes)}/{max_boxes}")
+
+        # Find which box can be split
+        best_box_idx = None
+        best_split = None
+        max_split_count = 0
+        best_order = float('inf')
+
+        for i, box in enumerate(boxes):
+            # Check if this box has reached ordermax
+            if ordermax is not None:
+                box_order = _estimate_order_from_prefix(box['prefix'])
+                if box_order >= ordermax:
+                    if verbose and iteration == 1:
+                        print(f"  Box {i+1} ('{box['prefix']}') at order {box_order} >= ordermax {ordermax}, skipping")
+                    continue
+
+            # Try to split this box
+            split_result = _try_split(box['prefix'], box['indices'])
+
+            if split_result is not None:
+                n_splits = len(split_result)
+                new_total = len(boxes) - 1 + n_splits
+
+                if new_total <= max_boxes and n_splits > 1:
+                    # Priority: lower order first, then more splits
+                    box_order = _estimate_order_from_prefix(box['prefix'])
+
+                    if best_box_idx is None:
+                        best_box_idx = i
+                        best_split = split_result
+                        max_split_count = n_splits
+                        best_order = box_order
+                    else:
+                        if (box_order < best_order or
+                            (box_order == best_order and n_splits > max_split_count)):
+                            best_box_idx = i
+                            best_split = split_result
+                            max_split_count = n_splits
+                            best_order = box_order
+
+        if best_box_idx is None:
+            if verbose:
+                print(f"  → No more splits possible within budget\n")
+            break
+
+        # Apply the best split
+        old_box = boxes[best_box_idx]
+        if verbose:
+            print(f"  → Splitting box {best_box_idx+1} ('{old_box['prefix']}', order {best_order}) into {len(best_split)} sub-boxes")
+
+        boxes.pop(best_box_idx)
+
+        # Clip children to ordermax if necessary
+        if ordermax is not None:
+            clipped_split = []
+            for child in best_split:
+                child_order = _estimate_order_from_prefix(child['prefix'])
+                if child_order > ordermax:
+                    # Clip prefix to ordermax
+                    clipped_prefix = child['prefix'][:ordermax + 2]  # +2 for minus sign and parent digit
+                    if verbose:
+                        print(f"    Clipping child '{child['prefix']}' (order {child_order}) → '{clipped_prefix}' (order {ordermax})")
+                    child['prefix'] = clipped_prefix
+                clipped_split.append(child)
+            best_split = clipped_split
+
+        boxes.extend(best_split)
+
+        if verbose:
+            print(f"  → New total: {len(boxes)} boxes\n")
+
+    # Extract prefixes
+    result = [box['prefix'] for box in boxes]
+
+    if verbose:
+        print(f"Final subdivision complete:")
+        for i, box in enumerate(boxes, 1):
+            print(f"  Box {i:2d}: '{box['prefix']}' ({len(box['indices']):,} indices)")
+
+    return result
+
+
+def _try_split(prefix, indices):
+    """Try to split a box into sub-boxes."""
+    if len(np.unique(indices)) == 1:
+        return None
+
+    divergence_pos = len(prefix)
+
+    if divergence_pos >= min(len(s) for s in indices):
+        return None
+
+    next_chars = np.array([s[divergence_pos] if divergence_pos < len(s) else ''
+                           for s in indices])
+    unique_next_chars = np.unique(next_chars[next_chars != ''])
+
+    if len(unique_next_chars) <= 1:
+        return None
+
+    # Create sub-boxes
+    sub_boxes = []
+    for char in unique_next_chars:
+        mask = np.array([s[divergence_pos] == char if divergence_pos < len(s) else False
+                        for s in indices])
+        group_indices = indices[mask]
+
+        if len(group_indices) > 0:
+            group_prefix = _find_common_prefix(group_indices)
+            sub_boxes.append({'prefix': group_prefix, 'indices': group_indices})
+
+    return sub_boxes if len(sub_boxes) > 1 else None
+
+
+def _estimate_order_from_prefix(prefix):
+    """
+    Estimate morton order from prefix string.
+
+    Parameters
+    ----------
+    prefix : str
+        Morton index prefix
+
+    Returns
+    -------
+    order : int
+        Estimated order (number of digits - 1)
+    """
+    digits = prefix.lstrip('-')
+    return len(digits) - 1
+
+
+def _find_common_prefix(strings):
+    """
+    Find longest common prefix among strings.
+
+    Parameters
+    ----------
+    strings : array-like of str
+        Array of strings
+
+    Returns
+    -------
+    prefix : str
+        Longest common prefix
+    """
+    if len(strings) == 0:
+        return ""
+
+    if len(strings) == 1:
+        return strings[0]
+
+    prefix = strings[0]
+
+    for i in range(len(prefix)):
+        char = prefix[i]
+        for s in strings[1:]:
+            if i >= len(s) or s[i] != char:
+                return prefix[:i]
+
+    return prefix

--- a/mortie/tests/test_greedy_polygon.py
+++ b/mortie/tests/test_greedy_polygon.py
@@ -1,0 +1,203 @@
+"""
+Tests for greedy_morton_polygon functionality.
+"""
+
+import numpy as np
+import pytest
+from mortie import greedy_morton_polygon, generate_morton_children, geo2mort
+
+
+class TestGreedyMortonPolygon:
+    """Test suite for greedy_morton_polygon function."""
+
+    def test_basic_square(self):
+        """Test with a simple square polygon."""
+        # Define a square
+        lat = np.array([-75, -75, -70, -70, -75])
+        lon = np.array([-80, -70, -70, -80, -80])
+
+        # Generate morton boxes
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=10, ordermax=6, verbose=False
+        )
+
+        # Check outputs
+        assert isinstance(morton_boxes, np.ndarray)
+        assert isinstance(orders, np.ndarray)
+        assert len(morton_boxes) == len(orders)
+        assert len(morton_boxes) <= 10  # Should respect max_boxes
+        assert np.all(orders <= 6)  # Should respect ordermax
+
+    def test_returns_at_least_one_box(self):
+        """Test that at least one box is always returned."""
+        lat = np.array([-75, -75, -70, -70])
+        lon = np.array([-80, -70, -70, -80])
+
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=1, verbose=False
+        )
+
+        assert len(morton_boxes) >= 1
+
+    def test_max_boxes_constraint(self):
+        """Test that max_boxes constraint is respected."""
+        # Use Antarctic data
+        lat = np.random.uniform(-80, -60, 1000)
+        lon = np.random.uniform(-180, 180, 1000)
+
+        for max_boxes in [5, 10, 20]:
+            morton_boxes, orders = greedy_morton_polygon(
+                lat, lon, order=18, max_boxes=max_boxes, ordermax=6, verbose=False
+            )
+            assert len(morton_boxes) <= max_boxes, f"Exceeded max_boxes={max_boxes}"
+
+    def test_ordermax_constraint(self):
+        """Test that ordermax constraint is respected."""
+        lat = np.array([-75, -75, -70, -70])
+        lon = np.array([-80, -70, -70, -80])
+
+        for ordermax in [2, 4, 6]:
+            morton_boxes, orders = greedy_morton_polygon(
+                lat, lon, order=18, max_boxes=25, ordermax=ordermax, verbose=False
+            )
+            assert np.all(orders <= ordermax), f"Exceeded ordermax={ordermax}"
+
+    def test_no_ordermax(self):
+        """Test greedy subdivision without ordermax constraint."""
+        lat = np.array([-75, -75, -70, -70])
+        lon = np.array([-80, -70, -70, -80])
+
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=10, ordermax=None, verbose=False
+        )
+
+        assert len(morton_boxes) <= 10
+
+    def test_empty_input(self):
+        """Test that empty input raises appropriate error."""
+        lat = np.array([])
+        lon = np.array([])
+
+        with pytest.raises(ValueError, match="No valid points"):
+            greedy_morton_polygon(lat, lon)
+
+    def test_nan_handling(self):
+        """Test that NaN values are handled correctly."""
+        lat = np.array([-75, np.nan, -70, -70])
+        lon = np.array([-80, -70, np.nan, -80])
+
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=5, verbose=False
+        )
+
+        # Should still work with valid points
+        assert len(morton_boxes) >= 1
+
+    def test_coverage_completeness(self):
+        """Test that generated boxes cover all input points."""
+        # Generate random points
+        np.random.seed(42)
+        lat = np.random.uniform(-75, -70, 100)
+        lon = np.random.uniform(-80, -70, 100)
+
+        # Get morton boxes
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=10, ordermax=6, verbose=False
+        )
+
+        # Expand all boxes to order 6
+        all_order6_cells = []
+        for morton in morton_boxes:
+            children = generate_morton_children(morton, target_order=6)
+            all_order6_cells.extend(children)
+
+        order6_set = set(all_order6_cells)
+
+        # Check that all input points map to one of the boxes
+        input_morton = geo2mort(lat, lon, order=6)
+        assert np.all(np.isin(input_morton, list(order6_set))), \
+            "Not all input points are covered by generated boxes"
+
+    def test_balanced_subdivision(self):
+        """Test that subdivision is balanced across regions."""
+        # Create points in two distinct regions
+        lat1 = np.random.uniform(-75, -70, 500)
+        lon1 = np.random.uniform(-80, -70, 500)
+
+        lat2 = np.random.uniform(-70, -65, 500)
+        lon2 = np.random.uniform(-60, -50, 500)
+
+        lat = np.concatenate([lat1, lat2])
+        lon = np.concatenate([lon1, lon2])
+
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=20, ordermax=6, verbose=False
+        )
+
+        # With balanced subdivision, we should get multiple boxes
+        # (not just one box covering everything)
+        assert len(morton_boxes) > 1, "Should create multiple boxes for distinct regions"
+
+    def test_output_types(self):
+        """Test that outputs have correct types."""
+        lat = np.array([-75, -75, -70, -70])
+        lon = np.array([-80, -70, -70, -80])
+
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=10, verbose=False
+        )
+
+        assert isinstance(morton_boxes, np.ndarray)
+        assert isinstance(orders, np.ndarray)
+        assert morton_boxes.dtype == np.int64 or morton_boxes.dtype == np.int32
+        assert orders.dtype == np.int64 or orders.dtype == np.int32
+
+    def test_order_inference(self):
+        """Test that order inference is correct."""
+        lat = np.array([-75, -75, -70, -70])
+        lon = np.array([-80, -70, -70, -80])
+
+        morton_boxes, orders = greedy_morton_polygon(
+            lat, lon, order=18, max_boxes=10, ordermax=6, verbose=False
+        )
+
+        # Verify order inference
+        from mortie import infer_order_from_morton
+        for morton, expected_order in zip(morton_boxes, orders):
+            inferred_order = infer_order_from_morton(morton)
+            assert inferred_order == expected_order, \
+                f"Order mismatch for morton {morton}: inferred {inferred_order}, expected {expected_order}"
+
+
+class TestGenerateMortonChildrenFix:
+    """Test suite for fixed generate_morton_children function."""
+
+    def test_same_order_returns_parent(self):
+        """Test that requesting same order returns parent."""
+        parent_morton = -5111131  # order 6
+        children = generate_morton_children(parent_morton, target_order=6)
+
+        assert len(children) == 1
+        assert children[0] == parent_morton
+
+    def test_higher_order_generates_children(self):
+        """Test that higher order generates children."""
+        parent_morton = -511113  # order 5
+        children = generate_morton_children(parent_morton, target_order=6)
+
+        assert len(children) == 4  # 4^(6-5) = 4 children
+
+    def test_lower_order_raises_error(self):
+        """Test that requesting lower order raises error."""
+        parent_morton = -5111131  # order 6
+
+        with pytest.raises(ValueError, match="must be >= parent_order"):
+            generate_morton_children(parent_morton, target_order=5)
+
+    def test_multiple_order_jump(self):
+        """Test generating children with multiple order jump."""
+        parent_morton = -511  # order 2
+        children = generate_morton_children(parent_morton, target_order=6)
+
+        # 4^(6-2) = 256 children
+        assert len(children) == 256

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -741,12 +741,13 @@ def generate_morton_children(parent_morton, target_order):
     parent_morton : int
         Parent morton index
     target_order : int
-        Target order for children (must be > parent order)
+        Target order for children (must be >= parent order)
 
     Returns
     -------
     children : ndarray
-        Array of child morton indices at target_order
+        Array of child morton indices at target_order.
+        If target_order equals parent_order, returns array with parent_morton.
 
     Examples
     --------
@@ -756,17 +757,25 @@ def generate_morton_children(parent_morton, target_order):
     >>> generate_morton_children(-5111131, target_order=8)
     array([-511113111, -511113112, ..., -511113144])
 
+    >>> generate_morton_children(-5111131, target_order=6)
+    array([-5111131])
+
     Notes
     -----
     The function generates children by appending all possible digit combinations
     (1, 2, 3, 4) to the parent morton index for the number of levels between
-    parent_order and target_order.
+    parent_order and target_order. If already at target_order, returns the
+    parent itself.
     """
     # Get parent order
     _, _, parent_order = mort2norm(parent_morton)
 
-    if target_order <= parent_order:
-        raise ValueError(f"target_order ({target_order}) must be > parent_order ({parent_order})")
+    if target_order < parent_order:
+        raise ValueError(f"target_order ({target_order}) must be >= parent_order ({parent_order})")
+
+    # If already at target order, return parent as-is
+    if target_order == parent_order:
+        return np.array([parent_morton])
 
     # Calculate number of levels to descend
     level_diff = target_order - parent_order

--- a/src_rust/src/greedy_polygon.rs
+++ b/src_rust/src/greedy_polygon.rs
@@ -1,0 +1,276 @@
+//! Greedy polygon subdivision for morton indices
+//!
+//! This module provides a greedy algorithm to generate compact morton index
+//! coverage for arbitrary geometries with configurable constraints.
+
+use std::collections::HashSet;
+
+/// A box in the subdivision tree
+#[derive(Clone)]
+struct MortonBox {
+    prefix: String,
+    indices: Vec<String>,
+}
+
+/// Estimate order from a morton prefix string
+fn estimate_order_from_prefix(prefix: &str) -> usize {
+    // Remove minus sign and count digits
+    let digits = prefix.trim_start_matches('-');
+    if digits.is_empty() {
+        return 0;
+    }
+    digits.len() - 1
+}
+
+/// Find longest common prefix among strings
+fn find_common_prefix(strings: &[String]) -> String {
+    if strings.is_empty() {
+        return String::new();
+    }
+
+    if strings.len() == 1 {
+        return strings[0].clone();
+    }
+
+    let first = &strings[0];
+    let mut prefix_len = 0;
+
+    for (i, ch) in first.chars().enumerate() {
+        // Check if all strings have same character at position i
+        let all_match = strings[1..].iter().all(|s| {
+            s.chars().nth(i).map_or(false, |c| c == ch)
+        });
+
+        if all_match {
+            prefix_len = i + 1;
+        } else {
+            break;
+        }
+    }
+
+    first.chars().take(prefix_len).collect()
+}
+
+/// Try to split a box into sub-boxes
+fn try_split(prefix: &str, indices: &[String]) -> Option<Vec<MortonBox>> {
+    // Check if all indices are identical
+    let unique: HashSet<&String> = indices.iter().collect();
+    if unique.len() == 1 {
+        return None;
+    }
+
+    let divergence_pos = prefix.len();
+
+    // Check if we've exhausted string length
+    let min_len = indices.iter().map(|s| s.len()).min().unwrap_or(0);
+    if divergence_pos >= min_len {
+        return None;
+    }
+
+    // Get unique characters at divergence position
+    let mut unique_chars: Vec<char> = indices
+        .iter()
+        .filter_map(|s| s.chars().nth(divergence_pos))
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if unique_chars.len() <= 1 {
+        return None;
+    }
+
+    unique_chars.sort();
+
+    // Create sub-boxes
+    let mut sub_boxes = Vec::new();
+
+    for ch in unique_chars {
+        let group_indices: Vec<String> = indices
+            .iter()
+            .filter(|s| s.chars().nth(divergence_pos) == Some(ch))
+            .cloned()
+            .collect();
+
+        if !group_indices.is_empty() {
+            let group_prefix = find_common_prefix(&group_indices);
+            sub_boxes.push(MortonBox {
+                prefix: group_prefix,
+                indices: group_indices,
+            });
+        }
+    }
+
+    if sub_boxes.len() > 1 {
+        Some(sub_boxes)
+    } else {
+        None
+    }
+}
+
+/// Greedy subdivision of morton indices
+///
+/// # Arguments
+/// * `morton_strings` - Morton indices as strings
+/// * `max_boxes` - Maximum number of boxes allowed
+/// * `ordermax` - Optional maximum order for subdivision
+///
+/// # Returns
+/// Vector of morton index prefix strings
+pub fn greedy_subdivide(
+    morton_strings: Vec<String>,
+    max_boxes: usize,
+    ordermax: Option<usize>,
+) -> Vec<String> {
+    // Start with one box containing all indices
+    let mut boxes = vec![MortonBox {
+        prefix: find_common_prefix(&morton_strings),
+        indices: morton_strings,
+    }];
+
+    let mut iteration = 0;
+
+    while boxes.len() < max_boxes {
+        iteration += 1;
+
+        // Find which box can be split
+        let mut best_box_idx: Option<usize> = None;
+        let mut best_split: Option<Vec<MortonBox>> = None;
+        let mut max_split_count = 0;
+        let mut best_order = usize::MAX;
+
+        for (i, box_item) in boxes.iter().enumerate() {
+            // Check if this box has reached ordermax
+            if let Some(om) = ordermax {
+                let box_order = estimate_order_from_prefix(&box_item.prefix);
+                if box_order >= om {
+                    continue;
+                }
+            }
+
+            // Try to split this box
+            if let Some(split_result) = try_split(&box_item.prefix, &box_item.indices) {
+                let n_splits = split_result.len();
+                let new_total = boxes.len() - 1 + n_splits;
+
+                if new_total <= max_boxes && n_splits > 1 {
+                    // Priority: lower order first, then more splits
+                    let box_order = estimate_order_from_prefix(&box_item.prefix);
+
+                    if best_box_idx.is_none()
+                        || box_order < best_order
+                        || (box_order == best_order && n_splits > max_split_count)
+                    {
+                        best_box_idx = Some(i);
+                        best_split = Some(split_result);
+                        max_split_count = n_splits;
+                        best_order = box_order;
+                    }
+                }
+            }
+        }
+
+        // If no splits possible, break
+        let Some(idx) = best_box_idx else {
+            break;
+        };
+
+        // Apply the best split
+        let mut new_split = best_split.unwrap();
+
+        // Clip children to ordermax if necessary
+        if let Some(om) = ordermax {
+            for child in &mut new_split {
+                let child_order = estimate_order_from_prefix(&child.prefix);
+                if child_order > om {
+                    // Clip prefix to ordermax
+                    // ordermax + 2 for minus sign and parent digit
+                    let target_len = om + 2;
+                    if child.prefix.len() > target_len {
+                        child.prefix.truncate(target_len);
+                    }
+                }
+            }
+        }
+
+        // Remove old box and add new sub-boxes
+        boxes.remove(idx);
+        boxes.extend(new_split);
+    }
+
+    // Extract prefixes
+    boxes.iter().map(|b| b.prefix.clone()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_common_prefix_empty() {
+        let strings = vec![];
+        assert_eq!(find_common_prefix(&strings), "");
+    }
+
+    #[test]
+    fn test_find_common_prefix_single() {
+        let strings = vec!["-511".to_string()];
+        assert_eq!(find_common_prefix(&strings), "-511");
+    }
+
+    #[test]
+    fn test_find_common_prefix_multiple() {
+        let strings = vec!["-511111".to_string(), "-511222".to_string(), "-511333".to_string()];
+        assert_eq!(find_common_prefix(&strings), "-511");
+    }
+
+    #[test]
+    fn test_estimate_order() {
+        assert_eq!(estimate_order_from_prefix("-6"), 0);
+        assert_eq!(estimate_order_from_prefix("-61"), 1);
+        assert_eq!(estimate_order_from_prefix("-611"), 2);
+        assert_eq!(estimate_order_from_prefix("-6111"), 3);
+    }
+
+    #[test]
+    fn test_greedy_subdivide_basic() {
+        let morton_strings = vec![
+            "-311111".to_string(),
+            "-311222".to_string(),
+            "-411111".to_string(),
+            "-411222".to_string(),
+        ];
+
+        let result = greedy_subdivide(morton_strings, 10, None);
+        assert!(result.len() >= 2);
+        assert!(result.len() <= 10);
+    }
+
+    #[test]
+    fn test_greedy_subdivide_respects_max_boxes() {
+        let morton_strings = vec![
+            "-311111".to_string(),
+            "-322222".to_string(),
+            "-411111".to_string(),
+            "-422222".to_string(),
+        ];
+
+        let result = greedy_subdivide(morton_strings, 3, None);
+        assert!(result.len() <= 3);
+    }
+
+    #[test]
+    fn test_greedy_subdivide_ordermax() {
+        let morton_strings = vec![
+            "-3111111111".to_string(),
+            "-3222222222".to_string(),
+        ];
+
+        let result = greedy_subdivide(morton_strings, 10, Some(2));
+
+        // All results should be order <= 2 (3 digits or less)
+        for prefix in &result {
+            let order = estimate_order_from_prefix(prefix);
+            assert!(order <= 2, "Order {} exceeds ordermax 2 for prefix {}", order, prefix);
+        }
+    }
+}

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -4,6 +4,7 @@
 //! replacing the numba-accelerated functions to eliminate Dask conflicts.
 
 pub mod morton;
+pub mod greedy_polygon;
 
 use numpy::{IntoPyArray, PyArrayMethods, PyReadonlyArray1};
 use pyo3::prelude::*;
@@ -119,9 +120,28 @@ fn fast_norm2mort<'py>(
     Ok(results.into_pyarray(py).to_object(py))
 }
 
+/// Greedy subdivision of morton indices (Python binding)
+///
+/// # Arguments
+/// * `morton_strings` - List of morton indices as strings
+/// * `max_boxes` - Maximum number of boxes allowed
+/// * `ordermax` - Optional maximum order for subdivision
+///
+/// # Returns
+/// List of morton index prefix strings
+#[pyfunction]
+fn rust_greedy_subdivide(
+    morton_strings: Vec<String>,
+    max_boxes: usize,
+    ordermax: Option<usize>,
+) -> PyResult<Vec<String>> {
+    Ok(greedy_polygon::greedy_subdivide(morton_strings, max_boxes, ordermax))
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _rustie(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fast_norm2mort, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_greedy_subdivide, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
This is a first pass at calculating the minimum spanning tree of morton index coverage for a complex polygon.

Currently, the base healpix bindings will do this, but only for polygons that are convex... and we often have polygons that aren't convex.

There are many ways to do this, the implementation here is a greedy algorithm that tries to minimize the spatial coverage given an integer value of boxes to use for the morton polygon. 