### PR TITLE
Fix wheel test import and run on all pushes

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -310,12 +310,11 @@ jobs:
         name: sdist
         path: dist
 
-  # Test the wheels (only on tags before publishing)
+  # Test the built wheels by installing and importing from site-packages
   test-wheels:
     name: Test wheels on ${{ matrix.os }} - Python ${{ matrix.python-version }}
     needs: [build-wheels]
     runs-on: ${{ matrix.os }}
-    if: startsWith(github.ref, 'refs/tags/')
     strategy:
       fail-fast: false
       matrix:
@@ -350,8 +349,14 @@ jobs:
         pip install pytest pytest-cov
 
     - name: Run tests
+      shell: bash
       run: |
-        pytest -v mortie/tests/test_tools.py mortie/tests/test_polygon_regression.py
+        # Run from a temp directory so Python imports the installed wheel,
+        # not the local source tree
+        cp -r mortie/tests /tmp/mortie_tests
+        cp pyproject.toml /tmp/
+        cd /tmp
+        pytest -v mortie_tests/test_tools.py mortie_tests/test_polygon_regression.py
 
   # Publish to TestPyPI on tag (before production publish)
   publish-testpypi:


### PR DESCRIPTION
Earlier we were limiting our build matrix to cut down on CI/CD run time-- this isn't needed anymore given the version 0.6.0 refactor, which significantly streamlines our dependencies. 

  ## Summary

  - Fix `test-wheels` job to run pytest from `/tmp` so Python imports the installed wheel from site-packages, not the local source tree (which lacks the compiled `_rustie` extension)
  - Remove tag-only gate (`if: startsWith(github.ref, 'refs/tags/')`) so `test-wheels` runs on every push to main and PR, surfacing failures before release time

  ## Context

  The `test-wheels` job has been silently broken — it checked out the source tree, installed the wheel, then ran `pytest mortie/tests/...` which resolved `import mortie` to the local source directory (no `_rustie.abi3.so`) instead of
  the installed wheel. This only manifested when pushing the `0.6.0` tag because `test-wheels` was gated to tag pushes only.