### PR TITLE
Add step parameter to boundaries() and mort2polygon()

### DIFF
--- a/mortie/_healpix.py
+++ b/mortie/_healpix.py
@@ -43,17 +43,32 @@ def pix2ang(nside, pixel):
         np.asarray(result[1], dtype=np.float64)
 
 
-def boundaries(nside, pixel):
+def boundaries(nside, pixel, step=1):
     """Cell boundary vertices as 3-D unit vectors.
 
-    Returns ndarray of shape ``(3, 4)`` for scalar pixel or
-    ``(N, 3, 4)`` for array pixel.
+    Parameters
+    ----------
+    nside : int
+        HEALPix nside parameter (must be a power of 2).
+    pixel : int or array-like
+        NESTED pixel index(es).
+    step : int, optional
+        Points per side (default 1 = 4 corners only).
+        Use step=32 for 128 boundary points that accurately trace
+        curved cell edges near the poles.
+
+    Returns
+    -------
+    ndarray
+        Shape ``(3, 4*step)`` for scalar pixel or
+        ``(N, 3, 4*step)`` for array pixel.
     """
     depth = int(math.log2(nside))
     if np.ndim(pixel) == 0:
-        return rust_boundaries(depth, int(pixel))  # (3, 4)
+        return rust_boundaries(depth, int(pixel), step)
     return rust_boundaries(depth,
-                           np.ascontiguousarray(pixel, dtype=np.int64))
+                           np.ascontiguousarray(pixel, dtype=np.int64),
+                           step)
 
 
 def vec2ang(vectors):

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -661,13 +661,18 @@ def _normalize_antimeridian_polygon(vertices):
     return normalized
 
 
-def mort2polygon(morton):
-    """Convert morton index to polygon representation
+def mort2polygon(morton, step=1):
+    """Convert morton index to polygon representation.
 
     Parameters
     ----------
     morton : int or array-like
-        Morton index
+        Morton index.
+    step : int, optional
+        Points per side for the cell boundary (default 1 = 4 corners).
+        Use step=32 for 128 boundary points that accurately trace
+        curved cell edges, important for polar cells where 4-corner
+        polygons poorly approximate the true HEALPix boundary.
 
     Returns
     -------
@@ -696,15 +701,16 @@ def mort2polygon(morton):
     nest = uniq - 4 * (nside**2)
 
     # Get pixel boundaries
-    boundaries = hp.boundaries(nside, nest)
+    boundaries = hp.boundaries(nside, nest, step=step)
 
+    ncols = 4 * step
     polygons = []
     for i in range(len(morton)):
         # Get boundary vertices
         if len(morton) == 1:
             verts = boundaries
         else:
-            verts = boundaries[:, :, i]
+            verts = boundaries[i]
 
         # Convert to lat/lon
         theta, phi = hp.vec2ang(verts.T)

--- a/src_rust/src/geo2mort.rs
+++ b/src_rust/src/geo2mort.rs
@@ -5,6 +5,7 @@
 //! backend: `ang2pix`, `pix2ang`, `boundaries`, `vec2ang`.
 
 use healpix::coords::Degrees;
+use healpix::dir::Cardinal;
 use healpix::get;
 use std::f64::consts::TAU;
 
@@ -60,6 +61,32 @@ pub fn boundaries_scalar(depth: u8, pixel: u64) -> [[f64; 4]; 3] {
         xyz[0][i] = cos_lat * verts[src].lon.cos();
         xyz[1][i] = cos_lat * verts[src].lon.sin();
         xyz[2][i] = verts[src].lat.sin();
+    }
+    xyz
+}
+
+// ---------------------------------------------------------------------------
+// boundaries with step: NESTED pixel → 3D unit-vector boundary with
+// configurable resolution via path_along_cell_edge.
+// Returns Vec<[f64; 3]> with 4*step points.
+// ---------------------------------------------------------------------------
+
+#[inline]
+pub fn boundaries_step_scalar(depth: u8, pixel: u64, step: u32) -> Vec<[f64; 3]> {
+    let layer = get(depth);
+    let pts = layer.path_along_cell_edge(pixel, Cardinal::S, true, step);
+    // pts has 4*step entries of LonLat (radians).
+    // Roll by 2*step to match healpy vertex ordering (S→E→N→W becomes N→W→S→E).
+    let n = pts.len();
+    let mut xyz = Vec::with_capacity(n);
+    for i in 0..n {
+        let src = (i + 2 * step as usize) % n;
+        let cos_lat = pts[src].lat.cos();
+        xyz.push([
+            cos_lat * pts[src].lon.cos(),
+            cos_lat * pts[src].lon.sin(),
+            pts[src].lat.sin(),
+        ]);
     }
     xyz
 }

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -324,44 +324,74 @@ fn rust_pix2ang<'py>(
 /// # Arguments
 /// * `depth` - HEALPix depth/order
 /// * `pixel` - Pixel index(es) (scalar or array)
+/// * `step` - Points per side (default 1 = 4 corners only; step=32 gives 128 points)
 ///
 /// # Returns
-/// For scalar: ndarray shape (3, 4)
-/// For array of N pixels: ndarray shape (N, 3, 4)
+/// For scalar: ndarray shape (3, 4*step)
+/// For array of N pixels: ndarray shape (N, 3, 4*step)
 #[pyfunction]
+#[pyo3(signature = (depth, pixel, step=1))]
 fn rust_boundaries<'py>(
     py: Python<'py>,
     depth: u8,
     pixel: &Bound<'py, PyAny>,
+    step: u32,
 ) -> PyResult<PyObject> {
     let pixel_is_scalar = pixel.extract::<i64>().is_ok();
+    let ncols = 4 * step as usize;
 
+    if step == 1 {
+        // Fast path: original 4-corner code
+        if pixel_is_scalar {
+            let pix = pixel.extract::<i64>()? as u64;
+            let xyz = geo2mort::boundaries_scalar(depth, pix);
+            let arr = numpy::ndarray::Array2::from_shape_fn((3, 4), |(r, c)| xyz[r][c]);
+            return Ok(PyArray2::from_owned_array_bound(py, arr).into_any().unbind());
+        }
+        let pixel_arr = pixel.extract::<PyReadonlyArray1<i64>>()?.to_vec()?;
+        let n = pixel_arr.len();
+        let results: Vec<[[f64; 4]; 3]> = (0..n)
+            .into_par_iter()
+            .map(|i| geo2mort::boundaries_scalar(depth, pixel_arr[i] as u64))
+            .collect();
+        let mut flat = Vec::with_capacity(n * 3 * 4);
+        for xyz in &results {
+            for row in xyz {
+                for &val in row {
+                    flat.push(val);
+                }
+            }
+        }
+        let arr = numpy::ndarray::Array3::from_shape_vec((n, 3, 4), flat)
+            .map_err(|e| PyValueError::new_err(format!("shape error: {}", e)))?;
+        return Ok(PyArray3::from_owned_array_bound(py, arr).into_any().unbind());
+    }
+
+    // step > 1: use path_along_cell_edge
     if pixel_is_scalar {
         let pix = pixel.extract::<i64>()? as u64;
-        let xyz = geo2mort::boundaries_scalar(depth, pix);
-        // Return as (3, 4) ndarray
-        let arr = numpy::ndarray::Array2::from_shape_fn((3, 4), |(r, c)| xyz[r][c]);
+        let pts = geo2mort::boundaries_step_scalar(depth, pix, step);
+        // pts is Vec<[f64; 3]> with ncols entries → shape (3, ncols)
+        let arr = numpy::ndarray::Array2::from_shape_fn((3, ncols), |(r, c)| pts[c][r]);
         return Ok(PyArray2::from_owned_array_bound(py, arr).into_any().unbind());
     }
 
     let pixel_arr = pixel.extract::<PyReadonlyArray1<i64>>()?.to_vec()?;
     let n = pixel_arr.len();
-
-    let results: Vec<[[f64; 4]; 3]> = (0..n)
+    let results: Vec<Vec<[f64; 3]>> = (0..n)
         .into_par_iter()
-        .map(|i| geo2mort::boundaries_scalar(depth, pixel_arr[i] as u64))
+        .map(|i| geo2mort::boundaries_step_scalar(depth, pixel_arr[i] as u64, step))
         .collect();
-
-    // Shape (N, 3, 4) — matches healpy array output
-    let mut flat = Vec::with_capacity(n * 3 * 4);
-    for xyz in &results {
-        for row in xyz {
-            for &val in row {
-                flat.push(val);
+    // Shape (N, 3, ncols)
+    let mut flat = Vec::with_capacity(n * 3 * ncols);
+    for pts in &results {
+        for r in 0..3 {
+            for c in 0..ncols {
+                flat.push(pts[c][r]);
             }
         }
     }
-    let arr = numpy::ndarray::Array3::from_shape_vec((n, 3, 4), flat)
+    let arr = numpy::ndarray::Array3::from_shape_vec((n, 3, ncols), flat)
         .map_err(|e| PyValueError::new_err(format!("shape error: {}", e)))?;
     Ok(PyArray3::from_owned_array_bound(py, arr).into_any().unbind())
 }


### PR DESCRIPTION
## Summary

- Add configurable boundary resolution via the healpix crate's `path_along_cell_edge()` method
- `step=1` (default) returns the original 4 corners; `step=32` returns 128 boundary points that accurately trace curved cell edges
- Fixes polygon distortion near the poles where 4-corner projections to EPSG:3031 underestimate the true HEALPix cell area by ~3.5km

## Changes

**Rust** (`geo2mort.rs`): New `boundaries_step_scalar()` function using `Layer::path_along_cell_edge(pixel, Cardinal::S, true, n_segments_by_side)`, with vertex ordering rolled to match healpy convention.

**PyO3** (`lib.rs`): `rust_boundaries()` gains a `step` parameter (default 1). Step=1 takes the fast original path; step>1 dispatches to the new function. Output shape: `(3, 4*step)` scalar, `(N, 3, 4*step)` array.

**Python** (`_healpix.py`, `tools.py`): `boundaries(nside, pixel, step=1)` and `mort2polygon(morton, step=1)` pass through the parameter.

