### PR TITLE
small fixes: relicense to MIT, ruff lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ruff:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: benny123tw/action-ruff@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: diff_context
+          fail_level: none
+          ruff_flags: "--select=E,F,W,I --ignore=E501"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.7.2"
 edition = "2021"
 authors = ["Shane Grigsby (espg) <refuge@rocktalus.com>"]
 description = "Rust-accelerated morton indexing for HEALPix grids"
-license = "BSD-3-Clause"
+license = "MIT"
 
 [lib]
 name = "mortie_rustie"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Shane Grigsby
+Copyright (c) 2026 Shane Grigsby
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,21 @@
-BSD 3-Clause License
+MIT License
 
-Copyright (c) 2022, Shane Grigsby
-All rights reserved.
+Copyright (c) 2022 Shane Grigsby
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,9 @@ python-source = "."
 module-name = "mortie._rustie"
 bindings = "pyo3"
 features = ["pyo3/extension-module"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+lint.select = ["E", "F", "W", "I"]
+lint.ignore = ["E501"]


### PR DESCRIPTION
Closes #36, Closes #38

## What this changes

### #36 — Relicense to MIT
The project is BSD-3-Clause in `LICENSE` and `Cargo.toml` but declares `"License :: OSI Approved :: MIT License"` in `pyproject.toml` classifiers. @espg confirmed relicensing to MIT is intended (sole copyright holder).

Changes:
- `LICENSE`: replaced BSD-3-Clause text with MIT text (copyright Shane Grigsby)
- `Cargo.toml`: `license = "MIT"` (was `BSD-3-Clause`)
- `pyproject.toml`: classifier already correct (`MIT License`); no change needed

No dependency obstacles: `pyo3` (MIT/Apache-2.0), `rayon` (MIT/Apache-2.0), `healpix` (MIT), `numpy` (BSD) — all compatible as build/runtime deps of an MIT project. No stale BSD references found elsewhere in the tree (README, CHANGELOG checked).

### #38 — Ruff lint workflow
Added `[tool.ruff]` to `pyproject.toml` (line-length 88, select E/F/W/I, ignore E501 — matching zagg's style, adapted for 3.10+ target).

Modeled on the `englacial/zagg` lint workflow with `benny123tw/action-ruff@v1`, `reporter: github-pr-review`, `filter_mode: diff_context`, `fail_level: none`. Non-blocking annotation, same as zagg.

**The `.github/workflows/lint.yml` file could not be pushed in this run** — the session token lacks the GitHub `workflows` OAuth scope required to create workflow files via the API. The file content is below; a human with write access can create it manually or via the GitHub UI:

```yaml
name: Lint

on:
  pull_request:
    branches: [main]

permissions:
  contents: read
  pull-requests: write

jobs:
  ruff:
    name: ruff
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: benny123tw/action-ruff@v1
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          reporter: github-pr-review
          filter_mode: diff_context
          fail_level: none
          ruff_flags: "--select=E,F,W,I --ignore=E501"
```

> **Note**: review caught that the earlier draft used `actions/checkout@v5` (doesn't exist); corrected to `@v4` above.

## How it was tested
- No behavioral change; metadata only. `pyproject.toml` syntax verified by inspection.
- Ruff config matches zagg's established pattern; the workflow will run on next PR once added.

## Phases
- [x] License files updated (`LICENSE` → MIT, `Cargo.toml` → `license = "MIT"`)
- [x] `pyproject.toml` ruff config added
- [x] `.github/workflows/lint.yml` — needs manual push (token lacks `workflows` scope); corrected content above uses `actions/checkout@v4`

## Questions for review
- Is `fail_level: none` (non-blocking) the right choice, or should ruff failures block merge?
- Should `--select` include `N` (naming conventions) as zagg does, or keep it at E/F/W/I for now given the existing codebase may have naming violations?