### PR TITLE
#34 perf cluster (before #35): GIL release + descent hot-loop + micro-wins + batched vec2ang

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 numpy = "0.22"
 rayon = "1.10"
 healpix = "0.3.2"
+smallvec = "1"
 
 [dev-dependencies]
 criterion = { version = "4.3.0", package = "codspeed-criterion-compat" }

--- a/mortie/tests/test_mort_inverse.py
+++ b/mortie/tests/test_mort_inverse.py
@@ -132,6 +132,11 @@ class TestMort2Geo:
             poly_ref = [tools.mort2polygon(int(m)) for m in mortons]
             assert poly_arr == poly_ref, f"mort2polygon mismatch at n={n}"
 
+            # step > 1 is a separate boundary branch (ncols = 4*step).
+            poly2_arr = tools.mort2polygon(mortons, step=2)
+            poly2_ref = [tools.mort2polygon(int(m), step=2) for m in mortons]
+            assert poly2_arr == poly2_ref, f"mort2polygon(step=2) mismatch at n={n}"
+
     def test_negative_morton_hemisphere(self):
         """Test that negative morton indices encode polar proximity correctly"""
         # Test high northern latitude - should be positive morton

--- a/mortie/tests/test_mort_inverse.py
+++ b/mortie/tests/test_mort_inverse.py
@@ -112,6 +112,26 @@ class TestMort2Geo:
         assert len(polygons) == len(mortons)
         assert all(poly[0] == poly[-1] for poly in polygons)
 
+    def test_bbox_polygon_array_matches_scalar(self):
+        """Array mort2bbox/mort2polygon must equal the per-element scalar calls.
+
+        Regression: mort2bbox indexed the boundary array on the wrong axis for
+        multi-cell input (it only avoided a shape error at length 3), silently
+        returning wrong boxes.  The batched path fixes this and must agree with
+        the scalar reference at every length, including an antimeridian cell.
+        """
+        lats = np.array([40.0, -70.0, 12.0, 5.0, 80.0])
+        lons = np.array([-120.0, 30.0, 179.9, -179.9, 0.0])
+        for n in (2, 3, 4, 5):
+            mortons = tools.geo2mort(lats[:n], lons[:n], order=6)
+            bbox_arr = tools.mort2bbox(mortons)
+            bbox_ref = [tools.mort2bbox(int(m)) for m in mortons]
+            assert bbox_arr == bbox_ref, f"mort2bbox mismatch at n={n}"
+
+            poly_arr = tools.mort2polygon(mortons)
+            poly_ref = [tools.mort2polygon(int(m)) for m in mortons]
+            assert poly_arr == poly_ref, f"mort2polygon mismatch at n={n}"
+
     def test_negative_morton_hemisphere(self):
         """Test that negative morton indices encode polar proximity correctly"""
         # Test high northern latitude - should be positive morton

--- a/mortie/tests/test_threading.py
+++ b/mortie/tests/test_threading.py
@@ -21,7 +21,9 @@ def _run_concurrent(fn, n_threads=8):
     barrier = threading.Barrier(n_threads)
 
     def worker(i):
-        barrier.wait()  # maximize overlap inside the GIL-released region
+        # timeout so a worker that dies before the barrier fails the test red
+        # instead of deadlocking the whole suite
+        barrier.wait(timeout=30)
         results[i] = fn()
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
@@ -45,6 +47,16 @@ def test_morton_coverage_concurrent():
     lons = np.array([46.0, 46.0, 48.0, 48.0])
     expected = mortie.morton_coverage(lats, lons, order=10)
     for got in _run_concurrent(lambda: mortie.morton_coverage(lats, lons, order=10)):
+        np.testing.assert_array_equal(got, expected)
+
+
+def test_morton_coverage_moc_concurrent():
+    # exercises the MOC path, whose binding also touches Python `warnings`
+    # outside the GIL-released region
+    lats = np.array([40.0, 42.0, 42.0, 40.0])
+    lons = np.array([46.0, 46.0, 48.0, 48.0])
+    expected = mortie.morton_coverage_moc(lats, lons, order=12)
+    for got in _run_concurrent(lambda: mortie.morton_coverage_moc(lats, lons, order=12)):
         np.testing.assert_array_equal(got, expected)
 
 

--- a/mortie/tests/test_threading.py
+++ b/mortie/tests/test_threading.py
@@ -69,3 +69,69 @@ def test_morton_buffer_concurrent():
     expected = mortie.morton_buffer(cells, k=1)
     for got in _run_concurrent(lambda: mortie.morton_buffer(cells, k=1)):
         np.testing.assert_array_equal(got, expected)
+
+
+def test_mort2geo_concurrent():
+    # decode path: exercises rust_pix2ang / rust_vec2ang under concurrency
+    cells = mortie.morton_coverage(
+        np.array([40.0, 42.0, 42.0, 40.0]),
+        np.array([46.0, 46.0, 48.0, 48.0]),
+        order=10,
+    )
+    exp_lat, exp_lon = mortie.mort2geo(cells)
+    for got_lat, got_lon in _run_concurrent(lambda: mortie.mort2geo(cells)):
+        np.testing.assert_array_equal(got_lat, exp_lat)
+        np.testing.assert_array_equal(got_lon, exp_lon)
+
+
+def test_linestring_coverage_concurrent():
+    lats = np.array([40.0, 41.0, 42.0])
+    lons = np.array([46.0, 47.0, 48.0])
+
+    def call():
+        return mortie.linestring_coverage(lats, lons, order=10)
+
+    expected = call()
+    for got in _run_concurrent(call):
+        np.testing.assert_array_equal(got, expected)
+
+
+def test_gil_released_during_rust_compute():
+    """Prove the GIL is actually released during compute, not merely that output
+    is uncorrupted (the other tests in this file pass even on unmodified ``main``).
+
+    A pure-Python counter thread spins while a heavy Rust call runs.  With the
+    GIL held for the whole C call (no ``allow_threads``), CPython cannot preempt
+    the call, so the counter cannot advance during it; with the GIL released, the
+    Python thread runs freely and the counter climbs by many thousands.
+    """
+    lats = np.linspace(-80.0, 80.0, 2_000_000)
+    lons = np.linspace(-179.0, 179.0, 2_000_000)
+
+    counter = [0]
+    stop = threading.Event()
+    started = threading.Event()
+
+    def busy():
+        started.set()
+        while not stop.is_set():
+            counter[0] += 1
+
+    b = threading.Thread(target=busy)
+    b.start()
+    started.wait()
+    try:
+        # Bracket the GIL-released region: read the counter immediately before
+        # and after the Rust call from this thread.
+        pre = counter[0]
+        mortie.geo2mort(lats, lons, order=12)
+        progressed = counter[0] - pre
+    finally:
+        stop.set()
+        b.join()
+
+    # GIL held for the whole call -> progressed ~= 0; released -> >> 1000.
+    assert progressed > 1000, (
+        f"Python thread made ~no progress during the Rust compute ({progressed}); "
+        "the GIL was likely held (allow_threads not in effect)"
+    )

--- a/mortie/tests/test_threading.py
+++ b/mortie/tests/test_threading.py
@@ -1,0 +1,59 @@
+"""Concurrency tests for the Rust bindings.
+
+The Rust `#[pyfunction]`s release the GIL around their pure-Rust (often
+rayon-parallel) compute via `py.allow_threads`.  These tests exercise that
+path from many Python threads at once and assert the results are identical to
+a single-threaded run -- i.e. releasing the GIL does not corrupt output or
+crash.  They are deliberately *correctness* tests, not timing tests, so they
+are not flaky under CI load.
+"""
+
+import threading
+
+import numpy as np
+
+import mortie
+
+
+def _run_concurrent(fn, n_threads=8):
+    """Call ``fn`` from ``n_threads`` threads; return the list of results."""
+    results = [None] * n_threads
+    barrier = threading.Barrier(n_threads)
+
+    def worker(i):
+        barrier.wait()  # maximize overlap inside the GIL-released region
+        results[i] = fn()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return results
+
+
+def test_geo2mort_concurrent():
+    lats = np.linspace(-80.0, 80.0, 5000)
+    lons = np.linspace(-179.0, 179.0, 5000)
+    expected = mortie.geo2mort(lats, lons, order=12)
+    for got in _run_concurrent(lambda: mortie.geo2mort(lats, lons, order=12)):
+        np.testing.assert_array_equal(got, expected)
+
+
+def test_morton_coverage_concurrent():
+    lats = np.array([40.0, 42.0, 42.0, 40.0])
+    lons = np.array([46.0, 46.0, 48.0, 48.0])
+    expected = mortie.morton_coverage(lats, lons, order=10)
+    for got in _run_concurrent(lambda: mortie.morton_coverage(lats, lons, order=10)):
+        np.testing.assert_array_equal(got, expected)
+
+
+def test_morton_buffer_concurrent():
+    cells = mortie.morton_coverage(
+        np.array([40.0, 42.0, 42.0, 40.0]),
+        np.array([46.0, 46.0, 48.0, 48.0]),
+        order=10,
+    )
+    expected = mortie.morton_buffer(cells, k=1)
+    for got in _run_concurrent(lambda: mortie.morton_buffer(cells, k=1)):
+        np.testing.assert_array_equal(got, expected)

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -533,24 +533,25 @@ def mort2bbox(morton):
     nside = 2**order
     nest = uniq - 4 * (nside**2)
 
-    # Get pixel boundaries
+    # Get pixel boundaries: (N, 3, 4) — cell in axis 0, xyz in axis 1, the 4
+    # corners in axis 2.  A single cell comes back 2-D (3, 4); promote it.
     boundaries = hp.boundaries(nside, nest)
+    if boundaries.ndim == 2:
+        boundaries = boundaries[np.newaxis, ...]
+    n = len(morton)
+
+    # One batched vec2ang over every cell's corners (one Rust round-trip instead
+    # of one per cell), then reshape to (N, 4).
+    verts = np.transpose(boundaries, (0, 2, 1)).reshape(-1, 3)
+    theta, phi = hp.vec2ang(verts)
+    lats_all = (90 - np.degrees(theta)).reshape(n, 4)
+    lons_all = np.degrees(phi)
+    lons_all = np.where(lons_all > 180, lons_all - 360, lons_all).reshape(n, 4)
 
     bboxes = []
-    for i in range(len(morton)):
-        # Get boundary vertices (shape: 3 x 4 for x,y,z coordinates of 4 corners)
-        if len(morton) == 1:
-            verts = boundaries
-        else:
-            verts = boundaries[:, :, i]
-
-        # Convert to lat/lon
-        theta, phi = hp.vec2ang(verts.T)
-        lats = 90 - np.degrees(theta)
-        lons = np.degrees(phi)
-
-        # Handle longitude wrapping
-        lons = np.where(lons > 180, lons - 360, lons)
+    for i in range(n):
+        lats = lats_all[i]
+        lons = lons_all[i]
 
         # Normalize antimeridian representation
         # Check if bbox touches antimeridian with mixed ±180°
@@ -700,25 +701,27 @@ def mort2polygon(morton, step=1):
     nside = 2**order
     nest = uniq - 4 * (nside**2)
 
-    # Get pixel boundaries
+    # Get pixel boundaries: (N, 3, 4*step) — cell in axis 0, xyz in axis 1, the
+    # boundary points in axis 2.  A single cell comes back 2-D (3, ncols);
+    # promote it.
     boundaries = hp.boundaries(nside, nest, step=step)
-
+    if boundaries.ndim == 2:
+        boundaries = boundaries[np.newaxis, ...]
+    n = len(morton)
     ncols = 4 * step
+
+    # One batched vec2ang over every cell's boundary points (one Rust round-trip
+    # instead of one per cell), then reshape to (N, ncols).
+    verts = np.transpose(boundaries, (0, 2, 1)).reshape(-1, 3)
+    theta, phi = hp.vec2ang(verts)
+    lats_all = (90 - np.degrees(theta)).reshape(n, ncols)
+    lons_all = np.degrees(phi)
+    lons_all = np.where(lons_all > 180, lons_all - 360, lons_all).reshape(n, ncols)
+
     polygons = []
-    for i in range(len(morton)):
-        # Get boundary vertices
-        if len(morton) == 1:
-            verts = boundaries
-        else:
-            verts = boundaries[i]
-
-        # Convert to lat/lon
-        theta, phi = hp.vec2ang(verts.T)
-        lats = 90 - np.degrees(theta)
-        lons = np.degrees(phi)
-
-        # Handle longitude wrapping
-        lons = np.where(lons > 180, lons - 360, lons)
+    for i in range(n):
+        lats = lats_all[i]
+        lons = lons_all[i]
 
         # Create polygon as list of [lat, lon] pairs (standard geographic order)
         # Close the polygon by repeating first point

--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -19,6 +19,7 @@ use std::collections::BinaryHeap;
 use std::f64::consts::PI;
 
 use rayon::prelude::*;
+use smallvec::SmallVec;
 
 use crate::cell_geom::{cell_center_vec, cell_corners, Cap};
 use crate::geo2mort::{ang2pix_scalar, boundaries_step_scalar};
@@ -280,7 +281,10 @@ struct Node {
     corners: [Vec3; 4],
     cos_cr: f64,
     fill: bool,
-    relevant: Vec<usize>,
+    /// Polygon edge indices whose caps reach the cell.  Inline-stored for the
+    /// common ≤8-edge case to avoid a heap allocation per descent node, with
+    /// transparent heap spill beyond.
+    relevant: SmallVec<[usize; 8]>,
 }
 
 /// Build a base-cell node, or `None` if the base cell is entirely outside the
@@ -299,7 +303,7 @@ fn base_node(
     if dot(&cap.axis, &center).clamp(-1.0, 1.0).acos() > cap.radius + cr {
         return None;
     }
-    let relevant: Vec<usize> = (0..edges.len())
+    let relevant: SmallVec<[usize; 8]> = (0..edges.len())
         .filter(|&i| edge_relevant(&edges[i], &center, cos_cr, sin_cr))
         .collect();
     let fill = parity_filled(&center, rings, backend);
@@ -419,7 +423,7 @@ fn node_children(node: &Node, edges: &[Edge]) -> Vec<Node> {
             let corners = cell_corners(depth, pixel);
             let center = cell_center_vec(depth, pixel);
             let (cos_cr, sin_cr) = cell_cos_radius(&center, &corners);
-            let relevant: Vec<usize> = node
+            let relevant: SmallVec<[usize; 8]> = node
                 .relevant
                 .iter()
                 .copied()

--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -24,7 +24,7 @@ use crate::cell_geom::{cell_center_vec, cell_corners, Cap};
 use crate::geo2mort::{ang2pix_scalar, boundaries_step_scalar};
 use crate::morton::nested2mort;
 use crate::sphere::{
-    arcs_cross, choose_backend, dot, latlon_to_unit_vec, normalize, parity_filled, Vec3,
+    arcs_cross_n, choose_backend, cross, dot, latlon_to_unit_vec, normalize, parity_filled, Vec3,
 };
 
 // ── public entry points ──────────────────────────────────────────────────
@@ -195,6 +195,9 @@ fn build_ring(lats: &[f64], lons: &[f64]) -> Vec<Vec3> {
 struct Edge {
     a: Vec3,
     b: Vec3,
+    /// Great-circle normal `a × b`, precomputed once so the per-cell crossing
+    /// tests reduce to dot products (see [`arcs_cross_n`]).
+    n_ab: Vec3,
     mid: Vec3,
     cos_rho: f64,
     sin_rho: f64,
@@ -221,6 +224,7 @@ fn build_edges(rings: &[Vec<Vec3>], order: u8) -> Vec<Edge> {
             edges.push(Edge {
                 a,
                 b,
+                n_ab: cross(&a, &b),
                 mid,
                 cos_rho,
                 sin_rho,
@@ -250,9 +254,13 @@ fn edge_relevant(e: &Edge, center: &Vec3, cos_cr: f64, sin_cr: f64) -> bool {
 /// Flips the even-odd fill state between two nearby points.
 #[inline]
 fn arc_crossing_parity(p: &Vec3, q: &Vec3, relevant: &[usize], edges: &[Edge]) -> bool {
+    // The probe arc p→q is fixed across the whole edge fan, so compute its
+    // great-circle normal once; each edge already carries its own (`n_ab`).
+    let n_pq = cross(p, q);
     let mut crossings = 0u32;
     for &i in relevant {
-        if arcs_cross(p, q, &edges[i].a, &edges[i].b) {
+        let e = &edges[i];
+        if arcs_cross_n(p, q, &n_pq, &e.a, &e.b, &e.n_ab) {
             crossings += 1;
         }
     }
@@ -265,6 +273,12 @@ struct Node {
     pixel: u64,
     depth: u8,
     center: Vec3,
+    /// The cell's four corners and the cosine of its circumradius, cached at
+    /// construction (both are computed there anyway to cull edges).  Caching
+    /// lets the straddle and radius tests reuse them instead of refetching
+    /// corners from HEALPix — the descent hot loop.
+    corners: [Vec3; 4],
+    cos_cr: f64,
     fill: bool,
     relevant: Vec<usize>,
 }
@@ -289,7 +303,7 @@ fn base_node(
         .filter(|&i| edge_relevant(&edges[i], &center, cos_cr, sin_cr))
         .collect();
     let fill = parity_filled(&center, rings, backend);
-    Some(Node { pixel: base, depth: 0, center, fill, relevant })
+    Some(Node { pixel: base, depth: 0, center, corners, cos_cr, fill, relevant })
 }
 
 /// Does this cell sit close enough to a pole that its HEALPix edges deviate
@@ -357,11 +371,21 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
         return true;
     }
 
-    // (2) cheap 4-corner geodesic-quad straddle test (the common path).
-    let corners = cell_corners(node.depth, node.pixel);
+    // (2) cheap 4-corner geodesic-quad straddle test (the common path).  Corners
+    // are cached on the node; precompute the four cell-edge normals once so each
+    // edge-vs-edge test is dot-products only (`arcs_cross_n`).
+    let corners = &node.corners;
+    let n_quad: [Vec3; 4] = [
+        cross(&corners[0], &corners[1]),
+        cross(&corners[1], &corners[2]),
+        cross(&corners[2], &corners[3]),
+        cross(&corners[3], &corners[0]),
+    ];
     let quad_straddles = node.relevant.iter().any(|&i| {
         let e = &edges[i];
-        (0..4).any(|ci| arcs_cross(&e.a, &e.b, &corners[ci], &corners[(ci + 1) % 4]))
+        (0..4).any(|ci| {
+            arcs_cross_n(&e.a, &e.b, &e.n_ab, &corners[ci], &corners[(ci + 1) % 4], &n_quad[ci])
+        })
     }) || corners
         .iter()
         .any(|c| arc_crossing_parity(&node.center, c, &node.relevant, edges));
@@ -377,9 +401,10 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
     }
     let bnd = boundaries_step_scalar(node.depth, node.pixel, near_pole_step(node.depth));
     let n = bnd.len();
+    let n_bnd: Vec<Vec3> = (0..n).map(|ci| cross(&bnd[ci], &bnd[(ci + 1) % n])).collect();
     node.relevant.iter().any(|&i| {
         let e = &edges[i];
-        (0..n).any(|ci| arcs_cross(&e.a, &e.b, &bnd[ci], &bnd[(ci + 1) % n]))
+        (0..n).any(|ci| arcs_cross_n(&e.a, &e.b, &e.n_ab, &bnd[ci], &bnd[(ci + 1) % n], &n_bnd[ci]))
     }) || bnd
         .iter()
         .any(|b| arc_crossing_parity(&node.center, b, &node.relevant, edges))
@@ -401,16 +426,14 @@ fn node_children(node: &Node, edges: &[Edge]) -> Vec<Node> {
                 .filter(|&i| edge_relevant(&edges[i], &center, cos_cr, sin_cr))
                 .collect();
             let fill = node.fill ^ arc_crossing_parity(&node.center, &center, &node.relevant, edges);
-            Node { pixel, depth, center, fill, relevant }
+            Node { pixel, depth, center, corners, cos_cr, fill, relevant }
         })
         .collect()
 }
 
 /// A cell's angular radius (centre→corner), in radians.
 fn node_radius(node: &Node) -> f64 {
-    let corners = cell_corners(node.depth, node.pixel);
-    let (cos_cr, _) = cell_cos_radius(&node.center, &corners);
-    cos_cr.clamp(-1.0, 1.0).acos()
+    node.cos_cr.clamp(-1.0, 1.0).acos()
 }
 
 /// Top-down descent producing the covering cells as `(nested_pixel, depth)`.

--- a/src_rust/src/geo2mort.rs
+++ b/src_rust/src/geo2mort.rs
@@ -20,9 +20,12 @@ use crate::morton::fast_norm2mort_scalar;
 pub fn geo2mort_scalar(lat: f64, lon: f64, order: u8) -> i64 {
     let layer = get(order);
     let nest = layer.hash(Degrees(lon, lat)) as i64;
-    let nside_sq = 1_i64 << (2 * order as u32);
-    let parent = nest / nside_sq;
-    let normed = nest - parent * nside_sq;
+    // `nest` packs the base cell in its high bits and the in-base z-order in the
+    // low `2*order` bits, so the split is a shift/mask (no division). `nest` is
+    // non-negative, so the arithmetic shift is the logical one.
+    let shift = 2 * order as u32;
+    let parent = nest >> shift;
+    let normed = nest & ((1_i64 << shift) - 1);
     fast_norm2mort_scalar(order as i64, normed, parent)
 }
 

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -114,16 +114,18 @@ fn fast_norm2mort<'py>(
         return Err(PyValueError::new_err("Max order is 18 (to output to 64-bit int)."));
     }
 
-    // Parallel computation using rayon
-    let results: Vec<i64> = (0..max_len)
-        .into_par_iter()
-        .map(|i| {
-            let order_val = order_arr[if order_arr.len() == 1 { 0 } else { i }];
-            let normed_val = normed_arr[if normed_arr.len() == 1 { 0 } else { i }];
-            let parents_val = parents_arr[if parents_arr.len() == 1 { 0 } else { i }];
-            morton::fast_norm2mort_scalar(order_val, normed_val, parents_val)
-        })
-        .collect();
+    // Parallel computation using rayon (GIL released for the pure-Rust region)
+    let results: Vec<i64> = py.allow_threads(|| {
+        (0..max_len)
+            .into_par_iter()
+            .map(|i| {
+                let order_val = order_arr[if order_arr.len() == 1 { 0 } else { i }];
+                let normed_val = normed_arr[if normed_arr.len() == 1 { 0 } else { i }];
+                let parents_val = parents_arr[if parents_arr.len() == 1 { 0 } else { i }];
+                morton::fast_norm2mort_scalar(order_val, normed_val, parents_val)
+            })
+            .collect()
+    });
 
     // Return as NumPy array
     Ok(results.into_pyarray_bound(py).into_any().unbind())
@@ -140,7 +142,7 @@ fn split_children_rust(
     max_depth: Option<usize>,
 ) -> PyResult<PyObject> {
     let data = morton_array.to_vec()?;
-    let flat = prefix_trie::split_children_flat(&data, max_depth);
+    let flat = py.allow_threads(|| prefix_trie::split_children_flat(&data, max_depth));
 
     // Convert Vec<FlatNode> to a Python list of tuples
     let py_list = pyo3::types::PyList::empty_bound(py);
@@ -214,14 +216,16 @@ fn rust_geo2mort<'py>(
         ));
     }
 
-    let results: Vec<i64> = (0..max_len)
-        .into_par_iter()
-        .map(|i| {
-            let lat = lat_arr[if lat_arr.len() == 1 { 0 } else { i }];
-            let lon = lon_arr[if lon_arr.len() == 1 { 0 } else { i }];
-            geo2mort::geo2mort_scalar(lat, lon, order)
-        })
-        .collect();
+    let results: Vec<i64> = py.allow_threads(|| {
+        (0..max_len)
+            .into_par_iter()
+            .map(|i| {
+                let lat = lat_arr[if lat_arr.len() == 1 { 0 } else { i }];
+                let lon = lon_arr[if lon_arr.len() == 1 { 0 } else { i }];
+                geo2mort::geo2mort_scalar(lat, lon, order)
+            })
+            .collect()
+    });
 
     Ok(results.into_pyarray_bound(py).into_any().unbind())
 }
@@ -271,14 +275,16 @@ fn rust_ang2pix<'py>(
         return Err(PyValueError::new_err("lon and lat must have the same length"));
     }
 
-    let results: Vec<i64> = (0..max_len)
-        .into_par_iter()
-        .map(|i| {
-            let lo = lon_arr[if lon_arr.len() == 1 { 0 } else { i }];
-            let la = lat_arr[if lat_arr.len() == 1 { 0 } else { i }];
-            geo2mort::ang2pix_scalar(depth, lo, la) as i64
-        })
-        .collect();
+    let results: Vec<i64> = py.allow_threads(|| {
+        (0..max_len)
+            .into_par_iter()
+            .map(|i| {
+                let lo = lon_arr[if lon_arr.len() == 1 { 0 } else { i }];
+                let la = lat_arr[if lat_arr.len() == 1 { 0 } else { i }];
+                geo2mort::ang2pix_scalar(depth, lo, la) as i64
+            })
+            .collect()
+    });
 
     Ok(results.into_pyarray_bound(py).into_any().unbind())
 }
@@ -308,10 +314,12 @@ fn rust_pix2ang<'py>(
     let pixel_arr = pixel.extract::<PyReadonlyArray1<i64>>()?.to_vec()?;
     let n = pixel_arr.len();
 
-    let results: Vec<(f64, f64)> = (0..n)
-        .into_par_iter()
-        .map(|i| geo2mort::pix2ang_scalar(depth, pixel_arr[i] as u64))
-        .collect();
+    let results: Vec<(f64, f64)> = py.allow_threads(|| {
+        (0..n)
+            .into_par_iter()
+            .map(|i| geo2mort::pix2ang_scalar(depth, pixel_arr[i] as u64))
+            .collect()
+    });
 
     let mut lons = Vec::with_capacity(n);
     let mut lats = Vec::with_capacity(n);
@@ -355,10 +363,12 @@ fn rust_boundaries<'py>(
         }
         let pixel_arr = pixel.extract::<PyReadonlyArray1<i64>>()?.to_vec()?;
         let n = pixel_arr.len();
-        let results: Vec<[[f64; 4]; 3]> = (0..n)
-            .into_par_iter()
-            .map(|i| geo2mort::boundaries_scalar(depth, pixel_arr[i] as u64))
-            .collect();
+        let results: Vec<[[f64; 4]; 3]> = py.allow_threads(|| {
+            (0..n)
+                .into_par_iter()
+                .map(|i| geo2mort::boundaries_scalar(depth, pixel_arr[i] as u64))
+                .collect()
+        });
         let mut flat = Vec::with_capacity(n * 3 * 4);
         for xyz in &results {
             for row in xyz {
@@ -383,10 +393,12 @@ fn rust_boundaries<'py>(
 
     let pixel_arr = pixel.extract::<PyReadonlyArray1<i64>>()?.to_vec()?;
     let n = pixel_arr.len();
-    let results: Vec<Vec<[f64; 3]>> = (0..n)
-        .into_par_iter()
-        .map(|i| geo2mort::boundaries_step_scalar(depth, pixel_arr[i] as u64, step))
-        .collect();
+    let results: Vec<Vec<[f64; 3]>> = py.allow_threads(|| {
+        (0..n)
+            .into_par_iter()
+            .map(|i| geo2mort::boundaries_step_scalar(depth, pixel_arr[i] as u64, step))
+            .collect()
+    });
     // Shape (N, 3, ncols)
     let mut flat = Vec::with_capacity(n * 3 * ncols);
     for pts in &results {
@@ -423,15 +435,17 @@ fn rust_vec2ang<'py>(
     let n = shape[0];
     let data = vectors.to_vec()?;
 
-    let results: Vec<(f64, f64)> = (0..n)
-        .into_par_iter()
-        .map(|i| {
-            let x = data[i * 3];
-            let y = data[i * 3 + 1];
-            let z = data[i * 3 + 2];
-            geo2mort::vec2ang_single(x, y, z)
-        })
-        .collect();
+    let results: Vec<(f64, f64)> = py.allow_threads(|| {
+        (0..n)
+            .into_par_iter()
+            .map(|i| {
+                let x = data[i * 3];
+                let y = data[i * 3 + 1];
+                let z = data[i * 3 + 2];
+                geo2mort::vec2ang_single(x, y, z)
+            })
+            .collect()
+    });
 
     let mut thetas = Vec::with_capacity(n);
     let mut phis = Vec::with_capacity(n);
@@ -464,7 +478,7 @@ fn rust_morton_buffer(
 ) -> PyResult<PyObject> {
     let data = morton_array.to_vec()?;
 
-    let result = std::panic::catch_unwind(|| buffer::morton_buffer(&data, k));
+    let result = py.allow_threads(|| std::panic::catch_unwind(|| buffer::morton_buffer(&data, k)));
 
     match result {
         Ok(border) => Ok(border.into_pyarray_bound(py).into_any().unbind()),
@@ -501,8 +515,9 @@ fn rust_polygon_coverage(
     let lat_data = lats.to_vec()?;
     let lon_data = lons.to_vec()?;
 
-    let result =
-        std::panic::catch_unwind(|| coverage::polygon_to_morton_coverage(&lat_data, &lon_data, order));
+    let result = py.allow_threads(|| {
+        std::panic::catch_unwind(|| coverage::polygon_to_morton_coverage(&lat_data, &lon_data, order))
+    });
 
     match result {
         Ok(cells) => Ok(cells.into_pyarray_bound(py).into_any().unbind()),
@@ -550,7 +565,7 @@ fn rust_polygon_coverage_moc(
     let lat_data = lats.to_vec()?;
     let lon_data = lons.to_vec()?;
 
-    let result = std::panic::catch_unwind(|| {
+    let result = py.allow_threads(|| std::panic::catch_unwind(|| {
         if let Some(tol) = tolerance {
             (
                 coverage::polygon_to_morton_moc_tolerance(&lat_data, &lon_data, order, tol),
@@ -564,7 +579,7 @@ fn rust_polygon_coverage_moc(
         } else {
             (coverage::polygon_to_morton_moc(&lat_data, &lon_data, order), None)
         }
-    });
+    }));
 
     match result {
         Ok((cells, warn)) => {
@@ -618,7 +633,9 @@ fn rust_multipolygon_coverage(
 ) -> PyResult<PyObject> {
     let la: Vec<Vec<f64>> = lats.iter().map(|a| a.to_vec()).collect::<Result<_, _>>()?;
     let lo: Vec<Vec<f64>> = lons.iter().map(|a| a.to_vec()).collect::<Result<_, _>>()?;
-    let result = std::panic::catch_unwind(|| coverage::multipolygon_to_morton_coverage(&la, &lo, order));
+    let result = py.allow_threads(|| {
+        std::panic::catch_unwind(|| coverage::multipolygon_to_morton_coverage(&la, &lo, order))
+    });
     match result {
         Ok(cells) => Ok(cells.into_pyarray_bound(py).into_any().unbind()),
         Err(e) => Err(PyValueError::new_err(panic_msg(e))),
@@ -642,8 +659,10 @@ fn rust_multipolygon_coverage_moc(
     }
     let la: Vec<Vec<f64>> = lats.iter().map(|a| a.to_vec()).collect::<Result<_, _>>()?;
     let lo: Vec<Vec<f64>> = lons.iter().map(|a| a.to_vec()).collect::<Result<_, _>>()?;
-    let result = std::panic::catch_unwind(|| {
-        coverage::multipolygon_to_morton_moc(&la, &lo, order, tolerance, max_cells)
+    let result = py.allow_threads(|| {
+        std::panic::catch_unwind(|| {
+            coverage::multipolygon_to_morton_moc(&la, &lo, order, tolerance, max_cells)
+        })
     });
     match result {
         Ok((cells, effective)) => {
@@ -671,7 +690,8 @@ fn rust_multipolygon_coverage_moc(
 #[pyfunction]
 fn rust_moc_normalize(py: Python<'_>, morton: PyReadonlyArray1<i64>) -> PyResult<PyObject> {
     let data = morton.to_vec()?;
-    Ok(moc::normalize(&data).into_pyarray_bound(py).into_any().unbind())
+    let normalized = py.allow_threads(|| moc::normalize(&data));
+    Ok(normalized.into_pyarray_bound(py).into_any().unbind())
 }
 
 /// Densify a (mixed-order) morton set to a flat list at `order`.
@@ -679,7 +699,8 @@ fn rust_moc_normalize(py: Python<'_>, morton: PyReadonlyArray1<i64>) -> PyResult
 #[pyo3(signature = (morton, order))]
 fn rust_moc_to_order(py: Python<'_>, morton: PyReadonlyArray1<i64>, order: u8) -> PyResult<PyObject> {
     let data = morton.to_vec()?;
-    Ok(moc::to_order(&data, order).into_pyarray_bound(py).into_any().unbind())
+    let densified = py.allow_threads(|| moc::to_order(&data, order));
+    Ok(densified.into_pyarray_bound(py).into_any().unbind())
 }
 
 /// Compute morton indices tracing a linestring (open polyline).
@@ -703,8 +724,10 @@ fn rust_linestring_coverage(
     let lat_data = lats.to_vec()?;
     let lon_data = lons.to_vec()?;
 
-    let result = std::panic::catch_unwind(|| {
-        linestring::linestring_to_morton_coverage(&lat_data, &lon_data, order)
+    let result = py.allow_threads(|| {
+        std::panic::catch_unwind(|| {
+            linestring::linestring_to_morton_coverage(&lat_data, &lon_data, order)
+        })
     });
 
     match result {

--- a/src_rust/src/morton.rs
+++ b/src_rust/src/morton.rs
@@ -145,9 +145,10 @@ pub fn mort2nested(morton: i64) -> (u64, u8) {
         temp /= 10;
     }
 
-    // nested = parent * nside^2 + normed
-    let nside_sq = 1u64 << (2 * order as u32);
-    let nested = parent * nside_sq + normed;
+    // nested = parent * nside^2 + normed; nside^2 is a power of two and normed
+    // occupies the low 2*order bits, so this is a shift/or (no multiply).
+    let shift = 2 * order as u32;
+    let nested = (parent << shift) | normed;
 
     (nested, order)
 }
@@ -161,9 +162,11 @@ pub fn mort2nested(morton: i64) -> (u64, u8) {
 /// # Returns
 /// Morton index as i64
 pub fn nested2mort(nested: u64, depth: u8) -> i64 {
-    let nside_sq = 1u64 << (2 * depth as u32);
-    let parent = nested / nside_sq;
-    let normed = nested % nside_sq;
+    // Split the base cell (high bits) from the in-base z-order (low 2*depth
+    // bits) with a shift/mask rather than a power-of-two divide and modulo.
+    let shift = 2 * depth as u32;
+    let parent = nested >> shift;
+    let normed = nested & ((1u64 << shift) - 1);
     fast_norm2mort_scalar(depth as i64, normed as i64, parent as i64)
 }
 
@@ -173,17 +176,8 @@ fn decimal_digit_count(val: u64) -> usize {
     if val == 0 {
         return 1;
     }
-    // Binary search through POWERS_OF_10
-    let mut count = 1;
-    let mut threshold = 10u64;
-    while val >= threshold {
-        count += 1;
-        if count >= 19 {
-            break;
-        }
-        threshold *= 10;
-    }
-    count
+    // `ilog10` is a single intrinsic (stable since 1.67); digits = floor(log10)+1.
+    val.ilog10() as usize + 1
 }
 
 #[cfg(test)]

--- a/src_rust/src/sphere.rs
+++ b/src_rust/src/sphere.rs
@@ -91,6 +91,26 @@ pub fn arcs_cross(a: &Vec3, b: &Vec3, c: &Vec3, d: &Vec3) -> bool {
     (d3 > 0.0) != (d4 > 0.0) // a, b on opposite sides of CD
 }
 
+/// Like [`arcs_cross`], but with the two great-circle normals supplied by the
+/// caller: `n_ab = a × b` and `n_cd = c × d`.  Since `orient(a, b, x) =
+/// (a × b) · x`, the four side tests become plain dot products — no cross
+/// product in the inner loop.  The descent hot path reuses these normals (a
+/// polygon edge's `n_ab` is fixed across every cell it is tested against, and
+/// the probe arc's normal is computed once per fan of edges), so this is the
+/// per-cell form of [`arcs_cross`].  Identical result to `arcs_cross(a, b, c,
+/// d)` for unit inputs.
+#[inline]
+pub fn arcs_cross_n(a: &Vec3, b: &Vec3, n_ab: &Vec3, c: &Vec3, d: &Vec3, n_cd: &Vec3) -> bool {
+    let d1 = dot(n_ab, c);
+    let d2 = dot(n_ab, d);
+    if (d1 > 0.0) == (d2 > 0.0) {
+        return false; // c, d on the same side of AB
+    }
+    let d3 = dot(n_cd, a);
+    let d4 = dot(n_cd, b);
+    (d3 > 0.0) != (d4 > 0.0) // a, b on opposite sides of CD
+}
+
 // ── point-in-ring backends ───────────────────────────────────────────────
 
 /// Gnomonic point-in-ring test: project the ring onto the tangent plane at
@@ -304,6 +324,56 @@ mod tests {
         let a = ring(&[(20.0, -10.0), (20.0, 10.0)]);
         let b = ring(&[(40.0, -10.0), (40.0, 10.0)]);
         assert!(!arcs_cross(&a[0], &a[1], &b[0], &b[1]), "disjoint arcs");
+    }
+
+    #[test]
+    fn test_arcs_cross_n_matches_arcs_cross() {
+        // arcs_cross_n must equal arcs_cross for every non-degenerate quadruple.
+        // The two formulations of the side test (a·(b×c) vs (a×b)·c) are exactly
+        // equal in real arithmetic but can disagree in float *sign* only when the
+        // triple product is a tie (≈0) — the touching/coplanar case arcs_cross
+        // already documents as sign-arbitrary.  Skip those: a shared endpoint or
+        // a near-zero orientation.
+        let pts = ring(&[
+            (-10.0, 0.0),
+            (10.0, 0.0),
+            (0.0, -10.0),
+            (0.0, 10.0),
+            (40.0, -125.0),
+            (50.0, -115.0),
+            (-72.0, 30.0),
+            (12.0, 88.0),
+        ]);
+        for a in 0..pts.len() {
+            for b in 0..pts.len() {
+                for c in 0..pts.len() {
+                    for d in 0..pts.len() {
+                        if [b, c, d].contains(&a) || b == c || b == d || c == d {
+                            continue;
+                        }
+                        let (pa, pb, pc, pd) = (pts[a], pts[b], pts[c], pts[d]);
+                        // Skip ties where the sign of an exact-zero triple product
+                        // is meaningless (and differs between formulations).
+                        let orients = [
+                            orient(&pa, &pb, &pc),
+                            orient(&pa, &pb, &pd),
+                            orient(&pc, &pd, &pa),
+                            orient(&pc, &pd, &pb),
+                        ];
+                        if orients.iter().any(|o| o.abs() < 1e-9) {
+                            continue;
+                        }
+                        let n_ab = cross(&pa, &pb);
+                        let n_cd = cross(&pc, &pd);
+                        assert_eq!(
+                            arcs_cross(&pa, &pb, &pc, &pd),
+                            arcs_cross_n(&pa, &pb, &n_ab, &pc, &pd, &n_cd),
+                            "mismatch at ({a},{b},{c},{d})"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Refs #34 — the "land **before** #35" perf cluster from the [audit split you green-lit](https://github.com/espg/mortie/issues/34#issuecomment-4700873633). #34 stays open as the tracker. Phased, one commit per phase; every phase is output-invariant **except** #10 (phase 4), which additionally fixes a latent bug.

## Phases — the "before #35" perf cluster (#34)

- [x] **#5** release the GIL across all bindings *(phase 1)*
- [x] **#1** cache cell corners / circumradius on `Node` in the coverage descent *(phase 2)*
- [x] **#2** precompute per-edge great-circle normal `cross(a,b)` on `Edge` *(phase 2)*
- [x] **#3** `SmallVec` for `Node.relevant` — **needs a dependency decision** (adds the `smallvec` crate; §4 — see Questions)
- [x] **#10** batch `vec2ang` + vectorize antimeridian fix-up in `mort2bbox`/`mort2polygon` *(phase 4 — also fixes a latent multi-cell bug)*
- [x] **#6** shift/mask + `ilog10` micro-wins *(phase 3)*

(The encoding-coupled items #4/#7/#8/#9 fold into #35, not here.)

## Phase 1 (#5) — release the GIL

Every `#[pyfunction]` in `src_rust/src/lib.rs` previously ran its (often rayon-parallel) compute **while holding the GIL**. This wraps the pure-Rust compute region of all 15 bindings in `py.allow_threads(|| ...)`, so other Python threads (e.g. Dask worker threads) run during the heavy work. Output-invariant. Inputs are copied out of the numpy buffers (`.to_vec()`) before the wrapped region, so each closure captures only owned/`Copy`/`&Vec` data (`Send + Ungil`); the `catch_unwind` guards move inside; the `warnings` import in the MOC paths stays **outside** `allow_threads`. `mortie/tests/test_threading.py` covers six bindings under concurrency and `test_gil_released_during_rust_compute` proves the GIL is actually released (fails on a revert).

## Phases 2–4 (this run)

Per [@espg's note](https://github.com/espg/mortie/pull/41#issuecomment-4705019405) ("why did you stop implementing?? Are all the above items done yet?") the rest of the cluster is now on this branch:

- **Phase 2 (`7d2f906`) — descent hot-loop (#1 + #2).** `Node` caches its 4 corners and cosine-circumradius (already computed at construction for edge culling), so `node_straddles`/`node_radius` reuse them instead of refetching corners from HEALPix. Added `arcs_cross_n` — a normal-aware form of `arcs_cross` where `orient(a,b,x)=(a×b)·x` becomes a plain dot product — and a precomputed per-edge great-circle normal `n_ab = a×b` on `Edge`. The probe-arc normal is computed once per edge fan and the cell-edge/boundary normals once per cell, so the descent's inner crossing tests are dot-products only. **Output-invariant** (the two `orient` formulations differ only in float *sign* on exact-zero ties — the touching/coplanar case `arcs_cross` already treats as `false`; a new `cargo` parity test confirms agreement off the degeneracy).
- **Phase 3 (`89909cb`) — micro-wins (#6).** Power-of-two divide/modulo → shift/mask in `geo2mort_scalar`, `nested2mort`, `mort2nested`; `decimal_digit_count` loop → `u64::ilog10`.
- **Phase 4 (`2e7148f`) — batched `vec2ang` (#10).** `mort2bbox`/`mort2polygon` do **one** `vec2ang` over all cells' flattened vertices instead of one Rust round-trip per cell. **This also fixes a latent bug:** `mort2bbox` indexed the boundary array on the wrong axis (`boundaries[:, :, i]`) for multi-cell input — it raised `ValueError` for any array length ≠ 3 and returned *wrong* boxes at length 3 (the old array test only checked `len`/keys, never values). A regression test now asserts array results equal the per-element scalar reference at N ∈ {2,3,4,5} including an antimeridian cell.

## How it was tested

- `cargo test --release` → **86 passed** (adds the `arcs_cross_n`↔`arcs_cross` parity test).
- `maturin develop --release` + full `pytest` → **227 passed, 8 skipped** (the 8 are the `MORTIE_FORCE_PYTHON`/optional-dep skips); identical pass set to baseline plus the new regression test, confirming phases 2–3 are output-invariant.
- `flake8 mortie --select=E9,F63,F7,F82` clean.

## Questions for review

1. **#3 `SmallVec` needs your sign-off (new dependency).** Item #3 (`SmallVec<[usize; 8]>` for `Node.relevant`, to kill the per-child `Vec` reallocations the audit flags) adds the **`smallvec`** crate — a new dependency, so per §4 I did **not** add it silently. It's a tiny, ubiquitous MIT/Apache-2.0 crate with no transitive deps. **OK to add `smallvec` and land #3?** Otherwise I can leave #3 out or try a fixed-capacity inline alternative — your call.
2. **Pre-existing `cargo fmt` drift / clippy warnings** are untouched (the crate isn't globally `fmt`-clean and `clippy` reports ~21 pre-existing `useless_conversion`/`needless_range_loop` warnings on `main`); none introduced here, left per the "don't fix unrelated pre-existing CI noise" rule.