### PR TITLE
decimal_morton: full-resolution 64-bit Morton MOC kernel (phase 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,8 @@ path = "src_rust/benches/morton_bench.rs"
 name = "coverage_bench"
 harness = false
 path = "src_rust/benches/coverage_bench.rs"
+
+[[bench]]
+name = "decimal_morton_bench"
+harness = false
+path = "src_rust/benches/decimal_morton_bench.rs"

--- a/mortie/prefix_trie.py
+++ b/mortie/prefix_trie.py
@@ -161,7 +161,7 @@ class MortonChild:
     def mantissa_array(self):
         """The original morton indices belonging to this node."""
         if self._original_indices is not None:
-            return self._original_array[np.array(self._original_indices)]
+            return self._original_array[self._original_indices]
         return self._original_array[self._mask]
 
     def __repr__(self):
@@ -171,12 +171,16 @@ class MortonChild:
         )
 
 
-def _rebuild_tree_from_flat(flat_nodes, morton_array):
+def _rebuild_tree_from_flat(flat_nodes, permutation, morton_array):
     """Reconstruct MortonChild tree from flat Rust output.
 
     Parameters
     ----------
-    flat_nodes : list of (characteristic, count, original_indices, child_node_ids, depth)
+    flat_nodes : list of
+        (characteristic, count, idx_start, idx_len, child_node_ids, depth)
+    permutation : ndarray of int
+        Shared buffer of original positions; each node owns the slice
+        ``permutation[idx_start : idx_start + idx_len]`` (issue #34 item 8).
     morton_array : ndarray
         The original integer morton array.
 
@@ -187,12 +191,13 @@ def _rebuild_tree_from_flat(flat_nodes, morton_array):
     """
     # Build all MortonChild objects first (bypass __init__ via __new__)
     objects = []
-    for characteristic, count, indices, child_ids, depth in flat_nodes:
+    for characteristic, count, idx_start, idx_len, child_ids, depth in flat_nodes:
         obj = MortonChild.__new__(MortonChild)
         obj._char_array = None
         obj._mask = None
         obj._original_array = morton_array
-        obj._original_indices = indices
+        # numpy view into the shared permutation buffer (no per-node copy)
+        obj._original_indices = permutation[idx_start:idx_start + idx_len]
         obj._max_depth = None
         obj._depth = depth
         obj.characteristic = characteristic
@@ -202,7 +207,7 @@ def _rebuild_tree_from_flat(flat_nodes, morton_array):
         objects.append(obj)
 
     # Wire up children
-    for i, (_, _, _, child_ids, _) in enumerate(flat_nodes):
+    for i, (_, _, _, _, child_ids, _) in enumerate(flat_nodes):
         objects[i].children = [objects[cid] for cid in child_ids]
 
     # Return root-level nodes
@@ -231,8 +236,10 @@ def split_children(morton_array, max_depth=4):
 
     # Try Rust path first
     if RUST_AVAILABLE and not FORCE_PYTHON:
-        flat_nodes = _rust_split_children(morton_array, max_depth=max_depth)
-        return _rebuild_tree_from_flat(flat_nodes, morton_array)
+        flat_nodes, permutation = _rust_split_children(
+            morton_array, max_depth=max_depth
+        )
+        return _rebuild_tree_from_flat(flat_nodes, permutation, morton_array)
 
     return _split_children_python(morton_array, max_depth=max_depth)
 

--- a/mortie/tests/test_mort_inverse.py
+++ b/mortie/tests/test_mort_inverse.py
@@ -131,6 +131,16 @@ class TestMort2Geo:
         lat_south, _ = tools.mort2geo(morton_south)
         assert lat_south[0] < -45, f"Negative morton {morton_south} should decode to lat < -45"
 
+    def test_mort2norm_empty(self):
+        """Empty input returns empty int64 arrays and order 0, not IndexError."""
+        for empty_in in (np.array([]), np.array([], dtype=np.int64), []):
+            normed, parent, order = tools.mort2norm(empty_in)
+            assert order == 0
+            assert normed.dtype == np.int64
+            assert parent.dtype == np.int64
+            assert normed.size == 0
+            assert parent.size == 0
+
     def test_mort2norm_inverse(self):
         """Test the mort2norm conversion"""
         morton = 3122124

--- a/mortie/tests/test_mort_inverse.py
+++ b/mortie/tests/test_mort_inverse.py
@@ -151,3 +151,48 @@ class TestMort2Geo:
         # Should be able to get back to same morton
         morton2 = tools.geo2mort(lat, lon, order)[0]
         assert morton == morton2
+
+
+class TestRustMortNested:
+    """Direct tests for the rust_mort2nested / rust_nested2mort pyfunctions."""
+
+    def _valid_mortons(self, order, n=50):
+        rng = np.random.default_rng(order + 1)
+        normed = rng.integers(0, 4**order, size=n, dtype=np.int64)
+        parents = (np.arange(n) % 12).astype(np.int64)
+        orders = np.full(n, order, dtype=np.int64)
+        return np.asarray(tools.fastNorm2Mort(orders, normed, parents),
+                          dtype=np.int64)
+
+    def test_imports(self):
+        from mortie import _rustie
+        assert hasattr(_rustie, 'rust_mort2nested')
+        assert hasattr(_rustie, 'rust_nested2mort')
+
+    @pytest.mark.parametrize("order", [1, 6, 10, 14, 18])
+    def test_roundtrip(self, order):
+        from mortie import _rustie
+        mortons = self._valid_mortons(order)
+        nested, depths = _rustie.rust_mort2nested(mortons)
+        assert np.all(depths == order)
+        back = _rustie.rust_nested2mort(nested, depths)
+        np.testing.assert_array_equal(back, mortons)
+
+    def test_nested_matches_parent_normed(self):
+        """nested == parent * nside^2 + normed, consistent with mort2norm."""
+        from mortie import _rustie
+        order = 6
+        mortons = self._valid_mortons(order)
+        nested, depths = _rustie.rust_mort2nested(mortons)
+        normed, parent, o = tools.mort2norm(mortons)
+        assert o == order
+        nside_sq = (1 << (2 * order))
+        np.testing.assert_array_equal(
+            nested.astype(np.int64), parent * nside_sq + normed)
+
+    def test_nested2mort_length_mismatch(self):
+        from mortie import _rustie
+        nested = np.array([0, 1], dtype=np.uint64)
+        depths = np.array([6], dtype=np.uint8)
+        with pytest.raises(ValueError, match="same length"):
+            _rustie.rust_nested2mort(nested, depths)

--- a/mortie/tests/test_mort_inverse.py
+++ b/mortie/tests/test_mort_inverse.py
@@ -196,3 +196,8 @@ class TestRustMortNested:
         depths = np.array([6], dtype=np.uint8)
         with pytest.raises(ValueError, match="same length"):
             _rustie.rust_nested2mort(nested, depths)
+
+    def test_mort2nested_zero_raises(self):
+        from mortie import _rustie
+        with pytest.raises(ValueError):
+            _rustie.rust_mort2nested(np.array([0], dtype=np.int64))

--- a/mortie/tests/test_rust_vs_python.py
+++ b/mortie/tests/test_rust_vs_python.py
@@ -110,3 +110,32 @@ class TestGeo2Mort:
             f"{mismatches:,} mismatches out of {total:,} "
             f"({mismatch_rate:.6%}) exceeds 0.01% tolerance"
         )
+
+
+def _valid_mortons(order, n=64):
+    """Build a spread of valid morton indices at a given order."""
+    from mortie import tools
+    rng = np.random.default_rng(order)
+    normed = rng.integers(0, 4**order, size=n, dtype=np.int64)
+    parents = (np.arange(n) % 12).astype(np.int64)
+    orders = np.full(n, order, dtype=np.int64)
+    return np.asarray(tools.fastNorm2Mort(orders, normed, parents), dtype=np.int64)
+
+
+class TestMort2Norm:
+    """Rust vs Python for mort2norm (must be bit-identical)."""
+
+    @pytest.mark.parametrize("order", [1, 6, 10, 14, 18])
+    def test_array_parity(self, order):
+        mortons = _valid_mortons(order)
+        r_normed, r_parent, r_order = _get_rust_result('mort2norm', mortons)
+        p_normed, p_parent, p_order = _get_python_result('mort2norm', mortons)
+        assert r_order == p_order == order
+        np.testing.assert_array_equal(r_normed, p_normed)
+        np.testing.assert_array_equal(r_parent, p_parent)
+
+    def test_scalar_parity(self):
+        morton = int(_valid_mortons(6, n=1)[0])
+        rust = _get_rust_result('mort2norm', morton)
+        python = _get_python_result('mort2norm', morton)
+        assert rust == python

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -344,6 +344,10 @@ def mort2norm(morton):
         Parent base cell (0-11)
     order : int or array
         HEALPix order inferred from morton index
+
+    Notes
+    -----
+    Empty input returns two empty ``int64`` arrays and ``order == 0``.
     """
     morton = np.atleast_1d(morton).astype(np.int64)
     is_scalar = len(morton) == 1

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -348,6 +348,13 @@ def mort2norm(morton):
     morton = np.atleast_1d(morton).astype(np.int64)
     is_scalar = len(morton) == 1
 
+    # Empty input: nothing to infer an order from. Return empty int64 arrays
+    # (matching the array-path dtype) and order 0, rather than indexing an
+    # empty ``orders`` list below.
+    if morton.size == 0:
+        empty = np.empty(0, dtype=np.int64)
+        return empty, empty.copy(), 0
+
     # Infer order and validate morton indices
     orders = []
     for m in morton:

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -24,6 +24,14 @@ try:
 except (NameError, AttributeError):
     RUST_GEO2MORT = False
 
+# Rust morton <-> NESTED decode/encode (vectorized)
+try:
+    _rust_mort2nested = _rustie.rust_mort2nested
+    _rust_nested2mort = _rustie.rust_nested2mort
+    RUST_MORT2NESTED = True
+except (NameError, AttributeError):
+    RUST_MORT2NESTED = False
+
 
 def order2res(order):
     res = 111 * 58.6323 * .5**order
@@ -352,51 +360,51 @@ def mort2norm(morton):
         raise ValueError(f"Mixed orders in morton array: {set(orders)}")
 
     order = orders[0]
-    num_digits = order
-    divisor = 10**num_digits
 
-    # Initialize arrays
+    if FORCE_PYTHON or not RUST_MORT2NESTED:
+        normed, parent = _python_mort2norm(morton, order)
+    else:
+        # Rust decodes to (nested, depth); split nested into parent/normed.
+        nested, _ = _rust_mort2nested(morton)
+        nested = nested.astype(np.int64)
+        nside_sq = np.int64(1) << np.int64(2 * order)
+        parent = nested // nside_sq
+        normed = nested % nside_sq
+
+    if is_scalar:
+        return normed[0], parent[0], order
+    return normed, parent, order
+
+
+def _python_mort2norm(morton, order):
+    """Pure-Python reference decode of morton indices to (normed, parent).
+
+    Inverse of the morton encoding; kept as the ``MORTIE_FORCE_PYTHON``
+    fallback and parity reference for the Rust ``rust_mort2nested`` path.
+    """
+    divisor = 10**order
     normed = np.zeros_like(morton, dtype=np.int64)
     parent = np.zeros_like(morton, dtype=np.int64)
 
     for idx, m in enumerate(morton):
         if m < 0:
-            # Negative morton: southern hemisphere (parent cells 6-11)
-            # Reverse the encoding steps:
-            # Forward: num = morton_digits + (parent-11)*10^order
-            #          num = -1 * num
-            #          num = num - 6*10^order
-            # Reverse: add 6*10^order, negate, then extract parts
-
-            # Step 1: Add back 6*10^order
-            temp = m + (6 * divisor)  # temp = 2866867
-
-            # Step 2: Negate
-            temp = -temp  # temp = -2866867
-
-            # Step 3: This is morton_digits + (parent-11)*10^order
-            # The tricky part: (parent-11) could be negative
-            # So we need to handle the sign carefully
-
+            # Southern hemisphere (parents 6-11). Reverse the forward steps
+            # num = digits + (parent-11)*10^order; num = -num; num -= 6*10^order
+            # by adding back 6*10^order and negating, then extracting parts.
+            temp = -(m + 6 * divisor)
             if temp >= 0:
                 # Normal case (shouldn't happen for southern hemisphere)
                 parent[idx] = temp // divisor + 11
                 morton_digits = temp % divisor
             else:
-                # temp is negative, meaning (parent-11) is negative
-                # temp = morton_digits + (parent-11)*10^order
-                # Since morton_digits is positive and less than 10^order,
-                # we can extract it by modulo
+                # (parent-11) is negative: digits are positive and < 10^order,
+                # so recover them by modulo, then back out the parent.
                 morton_digits = temp % divisor
                 if morton_digits < 0:
                     morton_digits += divisor
-
-                # Now get parent
-                parent_minus_11 = (temp - morton_digits) // divisor
-                parent[idx] = parent_minus_11 + 11
+                parent[idx] = (temp - morton_digits) // divisor + 11
         else:
-            # Positive morton: northern hemisphere (parent cells 0-5)
-            # Format: (parent+1) * 10**order + morton_digits
+            # Northern hemisphere (parents 0-5): (parent+1)*10^order + digits
             parent[idx] = m // divisor - 1
             morton_digits = m % divisor
 
@@ -407,9 +415,7 @@ def mort2norm(morton):
             bits = digit - 1
             normed[idx] |= bits << (2*(i-1))
 
-    if is_scalar:
-        return normed[0], parent[0], order
-    return normed, parent, order
+    return normed, parent
 
 
 def norm2uniq(normed, parent, order=18):

--- a/src_rust/benches/decimal_morton_bench.rs
+++ b/src_rust/benches/decimal_morton_bench.rs
@@ -1,0 +1,163 @@
+//! Benchmarks comparing the new full-resolution `decimal_morton` 64-bit kernel
+//! (issue #35) against the existing order-<=18 decimal-Morton path, for the
+//! operations @espg asked about on PR #43: **encoding and decoding lat+lon
+//! tuples** at orders the old path supports (6, 12, 17).
+//!
+//! Two pipelines are timed on the *same* inputs:
+//!
+//! * **old** — `geo2mort_scalar` (healpix hash -> `fast_norm2mort_scalar`,
+//!   decimal-packed i64) and its inverse `mort2nested`. Capped at order 18.
+//! * **new** — healpix hash -> per-order 2-bit tuples -> `decimal_morton::encode`
+//!   (packed 64-bit MOC word) and its inverse `decimal_morton::decode`.
+//!
+//! The healpix `hash` is shared by both encoders, so the *delta* the benchmark
+//! isolates is the bit-packing layer (decimal string-digit math vs. the packed
+//! prefix/body/suffix word), which is the part issue #35 replaces.
+//!
+//! Coverage/polygon code is unaffected by this PR — nothing calls
+//! `decimal_morton` yet — so its benchmarks live unchanged in
+//! `coverage_bench.rs`; this file does not duplicate them.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use healpix::coords::Degrees;
+use healpix::get;
+
+use mortie_rustie::decimal_morton;
+use mortie_rustie::geo2mort::geo2mort_scalar;
+use mortie_rustie::morton::mort2nested;
+
+// ---------------------------------------------------------------------------
+// Shared input data
+// ---------------------------------------------------------------------------
+
+/// A deterministic spread of mid-latitude (lat, lon) pairs covering both
+/// hemispheres and a range of base cells, so neither encoder hits a trivial
+/// constant-fold.
+fn sample_points(n: usize) -> Vec<(f64, f64)> {
+    (0..n)
+        .map(|i| {
+            let f = i as f64;
+            let lat = -70.0 + (f * 7.3) % 140.0;
+            let lon = -180.0 + (f * 13.7) % 360.0;
+            (lat, lon)
+        })
+        .collect()
+}
+
+/// Decompose a HEALPix NESTED index at `order` into the `decimal_morton`
+/// inputs: the base cell and the per-order stored `0..=3` tuples (order 1 is
+/// the most significant 2-bit pair below the base).
+#[inline]
+fn nested_to_tuples(nested: u64, order: u8) -> (u8, Vec<u8>) {
+    let base = (nested >> (2 * order as u32)) as u8;
+    let mut tuples = Vec::with_capacity(order as usize);
+    for n in 1..=order {
+        let shift = 2 * (order - n) as u32;
+        tuples.push(((nested >> shift) & 3) as u8);
+    }
+    (base, tuples)
+}
+
+// ---------------------------------------------------------------------------
+// Encode: lat/lon -> index
+// ---------------------------------------------------------------------------
+
+fn bench_encode(c: &mut Criterion) {
+    let pts = sample_points(10_000);
+    let mut group = c.benchmark_group("encode_latlon");
+
+    for order in [6u8, 12, 17] {
+        // old: geo2mort (healpix hash + decimal-pack)
+        group.bench_with_input(BenchmarkId::new("old_geo2mort", order), &order, |b, &o| {
+            b.iter(|| {
+                let mut acc = 0i64;
+                for &(lat, lon) in &pts {
+                    acc ^= geo2mort_scalar(black_box(lat), black_box(lon), o);
+                }
+                acc
+            })
+        });
+
+        // new: healpix hash + decimal_morton::encode (packed word)
+        group.bench_with_input(
+            BenchmarkId::new("new_decimal_morton", order),
+            &order,
+            |b, &o| {
+                let layer = get(o);
+                b.iter(|| {
+                    let mut acc = 0u64;
+                    for &(lat, lon) in &pts {
+                        let nested = layer.hash(Degrees(black_box(lon), black_box(lat)));
+                        let (base, tuples) = nested_to_tuples(nested, o);
+                        acc ^= decimal_morton::encode(base, &tuples, o);
+                    }
+                    acc
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Decode: index -> components
+// ---------------------------------------------------------------------------
+
+fn bench_decode(c: &mut Criterion) {
+    let pts = sample_points(10_000);
+    let mut group = c.benchmark_group("decode_index");
+
+    for order in [6u8, 12, 17] {
+        // Pre-encode both representations so the loop times only the decode.
+        let layer = get(order);
+        let old_words: Vec<i64> = pts
+            .iter()
+            .map(|&(lat, lon)| geo2mort_scalar(lat, lon, order))
+            .collect();
+        let new_words: Vec<u64> = pts
+            .iter()
+            .map(|&(lat, lon)| {
+                let nested = layer.hash(Degrees(lon, lat));
+                let (base, tuples) = nested_to_tuples(nested, order);
+                decimal_morton::encode(base, &tuples, order)
+            })
+            .collect();
+
+        // old: mort2nested (decimal-digit unpack -> nested + depth)
+        group.bench_with_input(
+            BenchmarkId::new("old_mort2nested", order),
+            &order,
+            |b, _| {
+                b.iter(|| {
+                    let mut acc = 0u64;
+                    for &w in &old_words {
+                        let (nested, depth) = mort2nested(black_box(w));
+                        acc ^= nested ^ depth as u64;
+                    }
+                    acc
+                })
+            },
+        );
+
+        // new: decimal_morton::decode (packed-word unpack)
+        group.bench_with_input(
+            BenchmarkId::new("new_decimal_morton", order),
+            &order,
+            |b, _| {
+                b.iter(|| {
+                    let mut acc = 0u64;
+                    for &w in &new_words {
+                        let dec = decimal_morton::decode(black_box(w)).expect("decode");
+                        acc ^= dec.base_cell as u64 ^ dec.order as u64;
+                    }
+                    acc
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_encode, bench_decode);
+criterion_main!(benches);

--- a/src_rust/benches/decimal_morton_bench.rs
+++ b/src_rust/benches/decimal_morton_bench.rs
@@ -12,7 +12,12 @@
 //!
 //! The healpix `hash` is shared by both encoders, so the *delta* the benchmark
 //! isolates is the bit-packing layer (decimal string-digit math vs. the packed
-//! prefix/body/suffix word), which is the part issue #35 replaces.
+//! prefix/body/suffix word), which is the part issue #35 replaces. To keep that
+//! delta honest, the new encode path decomposes the nested index into a
+//! **stack** tuple buffer (`[u8; 18]`, no per-point heap allocation) before
+//! calling `encode`, matching `geo2mort_scalar`'s alloc-free profile — the
+//! decimal_morton `decode` *does* return an owned `Vec<u8>` (its own API), so the
+//! decode side carries that allocation on the new side only, noted there.
 //!
 //! Coverage/polygon code is unaffected by this PR — nothing calls
 //! `decimal_morton` yet — so its benchmarks live unchanged in
@@ -46,17 +51,20 @@ fn sample_points(n: usize) -> Vec<(f64, f64)> {
 }
 
 /// Decompose a HEALPix NESTED index at `order` into the `decimal_morton`
-/// inputs: the base cell and the per-order stored `0..=3` tuples (order 1 is
-/// the most significant 2-bit pair below the base).
+/// inputs: the base cell and the per-order stored `0..=3` tuples written into a
+/// caller-provided `buf` (order 1 is the most significant 2-bit pair below the
+/// base). Returns the base cell; the first `order` entries of `buf` are filled.
+/// A stack buffer keeps the new encode path allocation-free, so the comparison
+/// against the alloc-free `geo2mort_scalar` isolates the bit-packing layer
+/// rather than a per-point `Vec` malloc (orders here are <=18, hence `[u8; 18]`).
 #[inline]
-fn nested_to_tuples(nested: u64, order: u8) -> (u8, Vec<u8>) {
+fn nested_to_tuples(nested: u64, order: u8, buf: &mut [u8; 18]) -> u8 {
     let base = (nested >> (2 * order as u32)) as u8;
-    let mut tuples = Vec::with_capacity(order as usize);
     for n in 1..=order {
         let shift = 2 * (order - n) as u32;
-        tuples.push(((nested >> shift) & 3) as u8);
+        buf[(n - 1) as usize] = ((nested >> shift) & 3) as u8;
     }
-    (base, tuples)
+    base
 }
 
 // ---------------------------------------------------------------------------
@@ -87,10 +95,11 @@ fn bench_encode(c: &mut Criterion) {
                 let layer = get(o);
                 b.iter(|| {
                     let mut acc = 0u64;
+                    let mut buf = [0u8; 18];
                     for &(lat, lon) in &pts {
                         let nested = layer.hash(Degrees(black_box(lon), black_box(lat)));
-                        let (base, tuples) = nested_to_tuples(nested, o);
-                        acc ^= decimal_morton::encode(base, &tuples, o);
+                        let base = nested_to_tuples(nested, o, &mut buf);
+                        acc ^= decimal_morton::encode(base, &buf[..o as usize], o);
                     }
                     acc
                 })
@@ -119,8 +128,9 @@ fn bench_decode(c: &mut Criterion) {
             .iter()
             .map(|&(lat, lon)| {
                 let nested = layer.hash(Degrees(lon, lat));
-                let (base, tuples) = nested_to_tuples(nested, order);
-                decimal_morton::encode(base, &tuples, order)
+                let mut buf = [0u8; 18];
+                let base = nested_to_tuples(nested, order, &mut buf);
+                decimal_morton::encode(base, &buf[..order as usize], order)
             })
             .collect();
 
@@ -140,7 +150,9 @@ fn bench_decode(c: &mut Criterion) {
             },
         );
 
-        // new: decimal_morton::decode (packed-word unpack)
+        // new: decimal_morton::decode (packed-word unpack). NB: decode returns an
+        // owned `Vec<u8>` of tuples (its API), so the new side alone pays a
+        // per-word allocation here that `mort2nested` (scalar return) does not.
         group.bench_with_input(
             BenchmarkId::new("new_decimal_morton", order),
             &order,

--- a/src_rust/benches/decimal_morton_bench.rs
+++ b/src_rust/benches/decimal_morton_bench.rs
@@ -1,23 +1,26 @@
 //! Benchmarks comparing the new full-resolution `decimal_morton` 64-bit kernel
 //! (issue #35) against the existing order-<=18 decimal-Morton path, for the
 //! operations @espg asked about on PR #43: **encoding and decoding lat+lon
-//! tuples** at orders the old path supports (6, 12, 17).
+//! tuples** at orders the old path supports (6, 12, 17), plus the new kernel's
+//! own primitives (`coarsen`, the `from_nested`/`to_nested` healpix bridge).
 //!
-//! Two pipelines are timed on the *same* inputs:
+//! Encode is timed on the *same* inputs through two pipelines:
 //!
 //! * **old** — `geo2mort_scalar` (healpix hash -> `fast_norm2mort_scalar`,
-//!   decimal-packed i64) and its inverse `mort2nested`. Capped at order 18.
-//! * **new** — healpix hash -> per-order 2-bit tuples -> `decimal_morton::encode`
-//!   (packed 64-bit MOC word) and its inverse `decimal_morton::decode`.
+//!   decimal-packed i64). Capped at order 18.
+//! * **new** — healpix hash -> `decimal_morton::from_nested` (the single-pass
+//!   packed-word encoder, no intermediate tuple buffer).
 //!
-//! The healpix `hash` is shared by both encoders, so the *delta* the benchmark
+//! Both pipelines share the healpix `hash`, so the *delta* the benchmark
 //! isolates is the bit-packing layer (decimal string-digit math vs. the packed
-//! prefix/body/suffix word), which is the part issue #35 replaces. To keep that
-//! delta honest, the new encode path decomposes the nested index into a
-//! **stack** tuple buffer (`[u8; 18]`, no per-point heap allocation) before
-//! calling `encode`, matching `geo2mort_scalar`'s alloc-free profile — the
-//! decimal_morton `decode` *does* return an owned `Vec<u8>` (its own API), so the
-//! decode side carries that allocation on the new side only, noted there.
+//! prefix/body/suffix word), which is the part issue #35 replaces. The new side
+//! uses `from_nested` directly — the real encode path a `healpix::hash` feeds —
+//! rather than decomposing the nested index back into a tuple buffer and calling
+//! `encode` (the tuple path is only hit when a caller already holds per-order
+//! tuples; a raw lat/lon never does).
+//!
+//! `coarsen`, `from_nested` and `to_nested` are timed standalone so CodSpeed
+//! tracks the kernel primitives every later skin sits on, not just encode/decode.
 //!
 //! Coverage/polygon code is unaffected by this PR — nothing calls
 //! `decimal_morton` yet — so its benchmarks live unchanged in
@@ -50,23 +53,6 @@ fn sample_points(n: usize) -> Vec<(f64, f64)> {
         .collect()
 }
 
-/// Decompose a HEALPix NESTED index at `order` into the `decimal_morton`
-/// inputs: the base cell and the per-order stored `0..=3` tuples written into a
-/// caller-provided `buf` (order 1 is the most significant 2-bit pair below the
-/// base). Returns the base cell; the first `order` entries of `buf` are filled.
-/// A stack buffer keeps the new encode path allocation-free, so the comparison
-/// against the alloc-free `geo2mort_scalar` isolates the bit-packing layer
-/// rather than a per-point `Vec` malloc (orders here are <=18, hence `[u8; 18]`).
-#[inline]
-fn nested_to_tuples(nested: u64, order: u8, buf: &mut [u8; 18]) -> u8 {
-    let base = (nested >> (2 * order as u32)) as u8;
-    for n in 1..=order {
-        let shift = 2 * (order - n) as u32;
-        buf[(n - 1) as usize] = ((nested >> shift) & 3) as u8;
-    }
-    base
-}
-
 // ---------------------------------------------------------------------------
 // Encode: lat/lon -> index
 // ---------------------------------------------------------------------------
@@ -87,19 +73,18 @@ fn bench_encode(c: &mut Criterion) {
             })
         });
 
-        // new: healpix hash + decimal_morton::encode (packed word)
+        // new: healpix hash + decimal_morton::from_nested (single-pass packed
+        // word, no intermediate tuple buffer -- the real lat/lon encode path).
         group.bench_with_input(
-            BenchmarkId::new("new_decimal_morton", order),
+            BenchmarkId::new("new_from_nested", order),
             &order,
             |b, &o| {
                 let layer = get(o);
                 b.iter(|| {
                     let mut acc = 0u64;
-                    let mut buf = [0u8; 18];
                     for &(lat, lon) in &pts {
                         let nested = layer.hash(Degrees(black_box(lon), black_box(lat)));
-                        let base = nested_to_tuples(nested, o, &mut buf);
-                        acc ^= decimal_morton::encode(base, &buf[..o as usize], o);
+                        acc ^= decimal_morton::from_nested(nested, o);
                     }
                     acc
                 })
@@ -126,12 +111,7 @@ fn bench_decode(c: &mut Criterion) {
             .collect();
         let new_words: Vec<u64> = pts
             .iter()
-            .map(|&(lat, lon)| {
-                let nested = layer.hash(Degrees(lon, lat));
-                let mut buf = [0u8; 18];
-                let base = nested_to_tuples(nested, order, &mut buf);
-                decimal_morton::encode(base, &buf[..order as usize], order)
-            })
+            .map(|&(lat, lon)| decimal_morton::from_nested(layer.hash(Degrees(lon, lat)), order))
             .collect();
 
         // old: mort2nested (decimal-digit unpack -> nested + depth)
@@ -167,9 +147,91 @@ fn bench_decode(c: &mut Criterion) {
                 })
             },
         );
+
+        // new (alloc-free): to_nested, the healpix-bridge inverse used for
+        // center/vertices/UNIQ. Returns a scalar (depth, nested), so unlike
+        // `decode` it carries no per-word `Vec` allocation -- the fair twin of
+        // `mort2nested` above.
+        group.bench_with_input(BenchmarkId::new("new_to_nested", order), &order, |b, _| {
+            b.iter(|| {
+                let mut acc = 0u64;
+                for &w in &new_words {
+                    let (depth, nested) =
+                        decimal_morton::to_nested(black_box(w)).expect("to_nested");
+                    acc ^= nested ^ depth as u64;
+                }
+                acc
+            })
+        });
     }
     group.finish();
 }
 
-criterion_group!(benches, bench_encode, bench_decode);
+// ---------------------------------------------------------------------------
+// Coarsen: word at order 29 -> word at coarser order k
+// ---------------------------------------------------------------------------
+
+fn bench_coarsen(c: &mut Criterion) {
+    let pts = sample_points(10_000);
+    let mut group = c.benchmark_group("coarsen");
+
+    // Pre-encode an order-29 corpus (the deepest source, so every target k
+    // actually coarsens). from_nested at depth 29 gives canonical area words.
+    let layer = get(29u8);
+    let words: Vec<u64> = pts
+        .iter()
+        .map(|&(lat, lon)| decimal_morton::from_nested(layer.hash(Degrees(lon, lat)), 29))
+        .collect();
+
+    // Coarsen to a spread of targets: a body order, the 29->28 tail-preserving
+    // case, and an order-0 base-cell rollup.
+    for k in [6u8, 17, 28, 0] {
+        group.bench_with_input(BenchmarkId::new("from_29_to", k), &k, |b, &k| {
+            b.iter(|| {
+                let mut acc = 0u64;
+                for &w in &words {
+                    acc ^= decimal_morton::coarsen(black_box(w), k).expect("coarsen");
+                }
+                acc
+            })
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// healpix bridge: from_nested (encode side timed standalone for CodSpeed)
+// ---------------------------------------------------------------------------
+
+fn bench_from_nested(c: &mut Criterion) {
+    let pts = sample_points(10_000);
+    let mut group = c.benchmark_group("from_nested");
+
+    for order in [6u8, 17, 29] {
+        let layer = get(order);
+        // Pre-hash so the loop times only the bit-reshuffle, not the healpix hash.
+        let nested: Vec<u64> = pts
+            .iter()
+            .map(|&(lat, lon)| layer.hash(Degrees(lon, lat)))
+            .collect();
+        group.bench_with_input(BenchmarkId::new("depth", order), &order, |b, &o| {
+            b.iter(|| {
+                let mut acc = 0u64;
+                for &n in &nested {
+                    acc ^= decimal_morton::from_nested(black_box(n), o);
+                }
+                acc
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode,
+    bench_decode,
+    bench_coarsen,
+    bench_from_nested
+);
 criterion_main!(benches);

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -18,13 +18,32 @@
 //!   highest tuple (bits 59..58), order 27 the lowest (bits 7..6). The stored
 //!   value is `0..=3` but is *interpreted* as `1..=4` (a decode-time `+1`,
 //!   matching the existing decimal Morton convention).
-//! * **suffix** -- 6 bits, understood right-to-left (low bit first):
-//!     * rightmost bit `0` => variable length; the 5 bits to its left encode the
-//!       number of tuples to read, valid `0..=27` (0 = base-cell-only / order 0).
-//!     * rightmost two bits `01` => order 28; suffix bits 5..4 hold the order-28
-//!       tuple, bits 3..2 are spare (zero-filled).
-//!     * rightmost two bits `11` => order 29; suffix bits 5..4 hold the order-28
-//!       tuple and bits 3..2 the order-29 tuple.
+//! * **suffix** -- 6 bits read as **one plain unsigned integer `0..=63`** that is
+//!   a preorder numbering of the path tail past tuple 27. Because it is a single
+//!   monotone code, a raw unsigned sort of two words sharing the same body sorts
+//!   parent-before-children across the whole order range -- the Z-order property
+//!   #35 calls paramount, now holding end-to-end (orders 0..=29), not just 0..=27.
+//!
+//!   ```text
+//!     0 ..=27   variable length            (area; order == suffix; just the count)
+//!    28 ..=47   order 28 / 29 AREA cells    (real cell; preorder, div/mod 5)
+//!    48 ..=63   order 29 POINT, max-encoded (no area claim; (t28,t29) keyed)
+//!   ```
+//!
+//!   * **`0..=27`** -- self-describing tuple count: order is literally the suffix
+//!     value (`0` = base-cell-only / order 0). `27` is the order-27 path tail `[]`.
+//!   * **`28..=47`** -- the 20 order-28/29 *area* nodes in preorder. With
+//!     `t28,t29 in {1..4}` stored `0..3`, `r = (t28-1)*5 + (t29_present ? t29 : 0)`
+//!     (`0..=19`) and `suffix = 28 + r`. Each `t28` owns a 5-block: `[t28]`
+//!     (order 28) followed by its four `[t28,t29]` order-29 children, so the
+//!     order-28 parent sorts before its order-29 children (parent-first preorder).
+//!   * **`48..=63`** -- an order-29 *point* cast to maximum resolution: it carries
+//!     no area claim (e.g. a raw lat/lon cast to a Morton index). Keyed by the
+//!     `(t28,t29) in {1..4}^2` combination: `r2 = (t28-1)*4 + (t29-1)` (`0..=15`),
+//!     `suffix = 48 + r2`. A decoded point sets `kind == Kind::Point`. Z-order
+//!     note: a point sorts **after** every area cell sharing the same body (it is
+//!     the highest suffix range), so a max-encoded point sorts after the area
+//!     cells that contain it -- intended (a point is the finest, last thing there).
 //!
 //! Storage is **unsigned**; the signed "negative = southern" form is a
 //! presentation detail applied elsewhere. Encoding **zero-fills** every bit
@@ -39,8 +58,26 @@ pub const BODY_TUPLES: u8 = 27;
 const PREFIX_SHIFT: u32 = 60;
 const SUFFIX_BITS: u32 = 6;
 const SUFFIX_MASK: u64 = (1 << SUFFIX_BITS) - 1; // low 6 bits
-/// Full 54-bit body mask, sitting just above the suffix.
+/// Full 54-bit body mask, sitting just above the suffix (test-only since the
+/// `coarsen` cleanup dropped its sole non-test use).
+#[cfg(test)]
 const BODY_MASK: u64 = ((1u64 << 54) - 1) << SUFFIX_BITS;
+
+/// First suffix value of the order-28/29 AREA preorder region.
+const AREA_TAIL_BASE: u64 = 28;
+/// First suffix value of the order-29 POINT region.
+const POINT_BASE: u64 = 48;
+
+/// Whether a decoded index claims spatial area or is a max-encoded point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    /// A real cell with area (variable-length orders 0..=27, or an explicit
+    /// order-28/29 area cell).
+    Area,
+    /// An order-29 value cast to maximum resolution with **no area claim** --
+    /// e.g. a raw lat/lon point. Distinct from a real order-29 area cell.
+    Point,
+}
 
 /// A decoded `decimal_morton` index.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,6 +86,9 @@ pub struct DecimalMorton {
     pub base_cell: u8,
     /// HEALPix order, `0..=29`.
     pub order: u8,
+    /// Whether this is an area cell or a max-encoded point (only order-29 words
+    /// are ever `Point`).
+    pub kind: Kind,
     /// The per-order tuples, `tuples[i]` for order `i + 1`. Each value is the
     /// stored `0..=3` (not the `1..=4` interpretation). Length == `order`.
     pub tuples: Vec<u8>,
@@ -61,9 +101,6 @@ pub enum DecodeError {
     Empty,
     /// Prefix was `13..=15`; only `1..=12` map to a base cell.
     InvalidPrefix(u8),
-    /// Variable-length suffix pointed at a tuple count of `28..=31`, which is
-    /// nonsensical (orders 28/29 use the dedicated flag forms).
-    InvalidSuffixCount(u8),
 }
 
 impl std::fmt::Display for DecodeError {
@@ -73,38 +110,63 @@ impl std::fmt::Display for DecodeError {
             DecodeError::InvalidPrefix(p) => {
                 write!(f, "invalid base-cell prefix {} (valid 1..=12)", p)
             }
-            DecodeError::InvalidSuffixCount(c) => {
-                write!(
-                    f,
-                    "invalid variable-length suffix count {} (valid 0..=27)",
-                    c
-                )
-            }
         }
     }
 }
 
 impl std::error::Error for DecodeError {}
 
-/// Build the 6-bit suffix value for a given order and its order-28/29 tuples.
+/// Build the 6-bit suffix for an **area** cell at `order` with order-28/29 tuples.
+///
+/// The suffix is a single monotone preorder code (see the module docs):
+/// `0..=27` is the order itself; `28..=47` is the order-28/29 area region.
+/// `t28`/`t29` are the *stored* `0..=3` values (read as `1..=4`).
 #[inline]
 fn build_suffix(order: u8, t28: u8, t29: u8) -> u64 {
     match order {
-        // variable length: low bit 0, count in the 5 bits above it
-        0..=27 => ((order as u64) << 1) & SUFFIX_MASK,
-        // order 28: bits 5..4 = tuple-28, bits 3..2 spare (0), bits 1..0 = 01
-        28 => (((t28 & 3) as u64) << 4) | 0b01,
-        // order 29: bits 5..4 = tuple-28, bits 3..2 = tuple-29, bits 1..0 = 11
-        29 => (((t28 & 3) as u64) << 4) | (((t29 & 3) as u64) << 2) | 0b11,
+        // variable length: the order *is* the suffix value (just the count).
+        0..=27 => order as u64,
+        // order 28: parent node of its t28 block; pos 0 within the 5-block.
+        28 => AREA_TAIL_BASE + ((t28 & 3) as u64) * 5,
+        // order 29: child pos (t29 read as 1..=4) within the t28 5-block.
+        29 => AREA_TAIL_BASE + ((t28 & 3) as u64) * 5 + ((t29 & 3) as u64) + 1,
         _ => unreachable!("order > 29 is rejected before build_suffix"),
     }
 }
 
-/// Encode a base cell, per-order tuples and order into a packed 64-bit word.
+/// Build the 6-bit suffix for an order-29 **point** (no area claim).
+///
+/// Keyed by the `(t28,t29)` combination: `r2 = t28*4 + t29` (stored `0..=3`),
+/// `suffix = 48 + r2`, landing in `48..=63`.
+#[inline]
+fn build_point_suffix(t28: u8, t29: u8) -> u64 {
+    POINT_BASE + ((t28 & 3) as u64) * 4 + ((t29 & 3) as u64)
+}
+
+/// Pack the prefix and body-27 bits for `base_cell` and the first
+/// `min(order, 27)` tuples; the suffix is added by the caller.
+#[inline]
+fn pack_prefix_body(base_cell: u8, tuples: &[u8], order: u8) -> u64 {
+    let prefix = ((base_cell + 1) as u64) << PREFIX_SHIFT;
+    // Body: orders 1..=27 only (orders 28/29 live in the suffix). Order n sits
+    // at the tuple `BODY_TUPLES - n` counting from the body's low end.
+    let body_orders = order.min(BODY_TUPLES);
+    let mut body: u64 = 0;
+    for n in 1..=body_orders {
+        let pair = (tuples[(n - 1) as usize] & 3) as u64;
+        // Order 1 is the highest pair; shift it furthest left within the body.
+        let shift = SUFFIX_BITS + 2 * (BODY_TUPLES - n) as u32;
+        body |= pair << shift;
+    }
+    prefix | body
+}
+
+/// Encode an **area** cell from a base cell, per-order tuples and order.
 ///
 /// `tuples` supplies the stored `0..=3` value for each order `1..=order`; only
 /// the first `order` entries are read. Any bit below the element's order is
-/// zero-filled, so the result is canonical.
+/// zero-filled, so the result is canonical. The result is always `Kind::Area`;
+/// for a max-resolution point with no area claim use [`encode_point`].
 ///
 /// # Panics
 /// Panics if `base_cell > 11`, `order > 29`, or `tuples` has fewer than `order`
@@ -124,46 +186,66 @@ pub fn encode(base_cell: u8, tuples: &[u8], order: u8) -> u64 {
         tuples.len()
     );
 
-    let prefix = ((base_cell + 1) as u64) << PREFIX_SHIFT;
-
-    // Body: orders 1..=27 only (orders 28/29 live in the suffix). Order n sits
-    // at the tuple `BODY_TUPLES - n` counting from the body's low end.
-    let body_orders = order.min(BODY_TUPLES);
-    let mut body: u64 = 0;
-    for n in 1..=body_orders {
-        let pair = (tuples[(n - 1) as usize] & 3) as u64;
-        // Order 1 is the highest pair; shift it furthest left within the body.
-        let shift = SUFFIX_BITS + 2 * (BODY_TUPLES - n) as u32;
-        body |= pair << shift;
-    }
-
     let (t28, t29) = match order {
         28 => (tuples[27], 0),
         29 => (tuples[27], tuples[28]),
         _ => (0, 0),
     };
-    let suffix = build_suffix(order, t28, t29);
+    pack_prefix_body(base_cell, tuples, order) | build_suffix(order, t28, t29)
+}
 
-    prefix | body | suffix
+/// Encode an order-29 **point** (max resolution, no area claim).
+///
+/// Use this when casting a raw location (e.g. a lat/lon) to a Morton index: the
+/// result decodes with `kind == Kind::Point` and `order == 29`, distinct from a
+/// real order-29 area cell. `tuples` must hold all 29 stored `0..=3` tuples.
+///
+/// # Panics
+/// Panics if `base_cell > 11` or `tuples` has fewer than 29 entries.
+pub fn encode_point(base_cell: u8, tuples: &[u8]) -> u64 {
+    assert!(
+        base_cell <= 11,
+        "base_cell must be 0..=11, got {}",
+        base_cell
+    );
+    assert!(
+        tuples.len() >= MAX_ORDER as usize,
+        "need {} tuples for an order-29 point, got {}",
+        MAX_ORDER,
+        tuples.len()
+    );
+    pack_prefix_body(base_cell, tuples, MAX_ORDER) | build_point_suffix(tuples[27], tuples[28])
 }
 
 /// Read just the order encoded by a packed word's suffix (the "fast path").
 ///
-/// Returns `None` for the nonsensical variable-length counts `28..=31`.
+/// Every 6-bit suffix value is valid under the monotone encoding, so this is
+/// total: `0..=27` -> the order itself; `28..=47` -> order 28 (block parent) or
+/// 29 (block child); `48..=63` -> an order-29 point.
 #[inline]
-pub fn order_of(word: u64) -> Option<u8> {
+pub fn order_of(word: u64) -> u8 {
     let suffix = word & SUFFIX_MASK;
-    if suffix & 1 == 0 {
-        let count = (suffix >> 1) as u8; // 0..=31
-        if count <= BODY_TUPLES {
-            Some(count)
+    if suffix <= BODY_TUPLES as u64 {
+        suffix as u8 // 0..=27
+    } else if suffix < POINT_BASE {
+        // area tail: pos 0 in a 5-block is order 28, pos 1..4 is order 29.
+        if (suffix - AREA_TAIL_BASE).is_multiple_of(5) {
+            28
         } else {
-            None
+            29
         }
-    } else if suffix & 0b11 == 0b01 {
-        Some(28)
     } else {
-        Some(29)
+        29 // point region
+    }
+}
+
+/// Read whether a packed word is an area cell or a max-encoded point.
+#[inline]
+pub fn kind_of(word: u64) -> Kind {
+    if (word & SUFFIX_MASK) >= POINT_BASE {
+        Kind::Point
+    } else {
+        Kind::Area
     }
 }
 
@@ -179,6 +261,30 @@ pub fn base_cell_of(word: u64) -> Option<u8> {
     }
 }
 
+/// Decode the order-28/29 tail (`t28`, `t29`, `kind`) carried by a suffix.
+///
+/// Returns the stored `0..=3` tuples for orders 28/29 (`t29 == None` at order
+/// 28), and whether the suffix is an area cell or a max-encoded point. Suffix
+/// values `0..=27` have no tail and are handled by the caller.
+#[inline]
+fn decode_tail(suffix: u64) -> (u8, Option<u8>, Kind) {
+    if suffix >= POINT_BASE {
+        // point: r2 = (t28)*4 + t29, both stored 0..=3.
+        let r2 = suffix - POINT_BASE;
+        ((r2 / 4) as u8, Some((r2 % 4) as u8), Kind::Point)
+    } else {
+        // area tail: r = t28*5 + (pos), pos 0 => order 28, 1..=4 => order 29.
+        let r = suffix - AREA_TAIL_BASE;
+        let t28 = (r / 5) as u8;
+        let pos = r % 5;
+        if pos == 0 {
+            (t28, None, Kind::Area)
+        } else {
+            (t28, Some((pos - 1) as u8), Kind::Area)
+        }
+    }
+}
+
 /// Decode a packed 64-bit word back into its `DecimalMorton` parts.
 pub fn decode(word: u64) -> Result<DecimalMorton, DecodeError> {
     let prefix = (word >> PREFIX_SHIFT) as u8 & 0x0f;
@@ -188,25 +294,29 @@ pub fn decode(word: u64) -> Result<DecimalMorton, DecodeError> {
         other => return Err(DecodeError::InvalidPrefix(other)),
     };
 
-    let suffix = word & SUFFIX_MASK;
-    let order = order_of(word).ok_or(DecodeError::InvalidSuffixCount((suffix >> 1) as u8))?;
-
+    let order = order_of(word);
     let mut tuples = Vec::with_capacity(order as usize);
     let body_orders = order.min(BODY_TUPLES);
     for n in 1..=body_orders {
         let shift = SUFFIX_BITS + 2 * (BODY_TUPLES - n) as u32;
         tuples.push(((word >> shift) & 3) as u8);
     }
-    if order >= 28 {
-        tuples.push(((suffix >> 4) & 3) as u8); // order-28 tuple
-    }
-    if order == 29 {
-        tuples.push(((suffix >> 2) & 3) as u8); // order-29 tuple
-    }
+
+    let kind = if order >= 28 {
+        let (t28, t29, kind) = decode_tail(word & SUFFIX_MASK);
+        tuples.push(t28);
+        if let Some(t29) = t29 {
+            tuples.push(t29);
+        }
+        kind
+    } else {
+        Kind::Area
+    };
 
     Ok(DecimalMorton {
         base_cell,
         order,
+        kind,
         tuples,
     })
 }
@@ -218,8 +328,8 @@ pub fn decode(word: u64) -> Result<DecimalMorton, DecodeError> {
 /// unchanged when `k >=` the word's own order (nothing to coarsen). Returns
 /// `None` if the word does not decode.
 pub fn coarsen(word: u64, k: u8) -> Option<u64> {
-    let native = order_of(word)?;
     base_cell_of(word)?; // reject empty / invalid prefix
+    let native = order_of(word);
     if k >= native {
         return Some(word);
     }
@@ -233,18 +343,19 @@ pub fn coarsen(word: u64, k: u8) -> Option<u64> {
         // Highest `2 * kept_body_orders` bits of the body region.
         let keep_bits = 2 * kept_body_orders as u32;
         let mask = (((1u64 << keep_bits) - 1) << (54 - keep_bits)) << SUFFIX_BITS;
-        word & mask & BODY_MASK
+        word & mask
     };
 
-    // Build the target suffix. Orders 28/29 keep their tuples, which live in the
-    // *source* suffix at the same bit positions (k < native means native == 29
-    // when k == 28, so the order-28 tuple is present to preserve). Lower targets
+    // Build the target suffix. Coarsening to order 28 preserves the order-28
+    // tuple, recovered from the source tail (k < native here means native is 29,
+    // so the tail is present). The result is always an area cell. Lower targets
     // use the variable-length form.
-    let src_suffix = word & SUFFIX_MASK;
-    let suffix = match k {
-        28 => build_suffix(28, ((src_suffix >> 4) & 3) as u8, 0),
+    let suffix = if k == 28 {
+        let (t28, _, _) = decode_tail(word & SUFFIX_MASK);
+        build_suffix(28, t28, 0)
+    } else {
         // k == 29 implies k >= native, already returned above; unreachable here.
-        _ => build_suffix(k, 0, 0),
+        build_suffix(k, 0, 0)
     };
     Some(prefix | body | suffix)
 }
@@ -269,6 +380,7 @@ mod tests {
                 let dec = decode(word).expect("decode");
                 assert_eq!(dec.base_cell, base, "base mismatch order {}", order);
                 assert_eq!(dec.order, order, "order mismatch base {}", base);
+                assert_eq!(dec.kind, Kind::Area, "area-encode must decode Area");
                 assert_eq!(
                     &dec.tuples[..],
                     &tuples[..order as usize],
@@ -287,7 +399,7 @@ mod tests {
             // body and suffix are both zero for order 0
             assert_eq!(word & BODY_MASK, 0, "body not zero-filled, base {}", base);
             assert_eq!(word & SUFFIX_MASK, 0, "suffix not zero, base {}", base);
-            assert_eq!(order_of(word), Some(0));
+            assert_eq!(order_of(word), 0);
             assert_eq!(base_cell_of(word), Some(base));
             let dec = decode(word).unwrap();
             assert!(dec.tuples.is_empty());
@@ -300,9 +412,14 @@ mod tests {
         for order in 1..=BODY_TUPLES {
             let tuples = sample_tuples(order, 7);
             let word = encode(base, &tuples, order);
-            // low suffix bit must be 0 (variable length) and count == order
-            assert_eq!(word & 1, 0, "var-length flag wrong at order {}", order);
-            assert_eq!(order_of(word), Some(order));
+            // suffix is literally the order count in the variable-length region.
+            assert_eq!(
+                word & SUFFIX_MASK,
+                order as u64,
+                "suffix != order {}",
+                order
+            );
+            assert_eq!(order_of(word), order);
             assert_eq!(decode(word).unwrap().tuples, &tuples[..order as usize]);
         }
     }
@@ -314,13 +431,12 @@ mod tests {
         for t28 in 0..=3u8 {
             tuples[27] = t28;
             let word = encode(base, &tuples, 28);
-            assert_eq!(word & 0b11, 0b01, "order-28 flag wrong for tuple {}", t28);
-            // spare bits 3..2 must be zero-filled
-            assert_eq!((word >> 2) & 0b11, 0, "spare bits set for tuple {}", t28);
-            assert_eq!((word >> 4) & 0b11, t28 as u64, "order-28 tuple wrong");
-            assert_eq!(order_of(word), Some(28));
+            // order-28 node sits at the head of its t28 5-block: 28 + 5*t28.
+            assert_eq!(word & SUFFIX_MASK, 28 + 5 * t28 as u64, "suffix wrong");
+            assert_eq!(order_of(word), 28);
             let dec = decode(word).unwrap();
             assert_eq!(dec.order, 28);
+            assert_eq!(dec.kind, Kind::Area);
             assert_eq!(dec.tuples[27], t28);
         }
     }
@@ -334,16 +450,75 @@ mod tests {
                 tuples[27] = t28;
                 tuples[28] = t29;
                 let word = encode(base, &tuples, 29);
-                assert_eq!(word & 0b11, 0b11, "order-29 flag wrong");
-                assert_eq!((word >> 4) & 0b11, t28 as u64, "order-28 tuple wrong");
-                assert_eq!((word >> 2) & 0b11, t29 as u64, "order-29 tuple wrong");
-                assert_eq!(order_of(word), Some(29));
+                // child pos t29+1 within the t28 5-block.
+                assert_eq!(
+                    word & SUFFIX_MASK,
+                    28 + 5 * t28 as u64 + t29 as u64 + 1,
+                    "suffix wrong"
+                );
+                assert_eq!(order_of(word), 29);
                 let dec = decode(word).unwrap();
                 assert_eq!(dec.order, 29);
+                assert_eq!(dec.kind, Kind::Area);
                 assert_eq!(dec.tuples[27], t28);
                 assert_eq!(dec.tuples[28], t29);
             }
         }
+    }
+
+    #[test]
+    fn point_round_trip_and_flag() {
+        // A max-encoded point keeps all 29 tuples, decodes as Kind::Point at
+        // order 29, and is distinct from the area cell with the same path.
+        let base = 6u8;
+        let mut tuples = sample_tuples(29, 21);
+        for t28 in 0..=3u8 {
+            for t29 in 0..=3u8 {
+                tuples[27] = t28;
+                tuples[28] = t29;
+                let point = encode_point(base, &tuples);
+                // point region: 48 + 4*t28 + t29.
+                assert_eq!(
+                    point & SUFFIX_MASK,
+                    48 + 4 * t28 as u64 + t29 as u64,
+                    "point suffix wrong"
+                );
+                assert_eq!(order_of(point), 29);
+                assert_eq!(kind_of(point), Kind::Point);
+                let dec = decode(point).unwrap();
+                assert_eq!(dec.order, 29);
+                assert_eq!(dec.kind, Kind::Point);
+                assert_eq!(dec.tuples[27], t28);
+                assert_eq!(dec.tuples[28], t29);
+                // The order-29 *area* cell with the same path is a different word.
+                let area = encode(base, &tuples, 29);
+                assert_ne!(point, area, "point must differ from area cell");
+                assert_eq!(kind_of(area), Kind::Area);
+            }
+        }
+    }
+
+    #[test]
+    fn point_sorts_after_area_of_same_body() {
+        // A max-encoded point sorts after every area cell sharing the same body
+        // tuples 1..27 (it is the highest suffix range -- the finest, last thing
+        // at that location).
+        let base = 2u8;
+        let mut tuples = sample_tuples(29, 55);
+        // Fix body 1..27; vary only the 28/29 tail.
+        let point = encode_point(base, &tuples);
+        for t28 in 0..=3u8 {
+            for t29 in 0..=3u8 {
+                tuples[27] = t28;
+                tuples[28] = t29;
+                let area28 = encode(base, &tuples, 28);
+                let area29 = encode(base, &tuples, 29);
+                assert!(point > area28, "point !> area28 ({t28})");
+                assert!(point > area29, "point !> area29 ({t28},{t29})");
+            }
+        }
+        // ...and after the order-27 ancestor too.
+        assert!(point > encode(base, &tuples, 27));
     }
 
     #[test]
@@ -370,21 +545,22 @@ mod tests {
     }
 
     #[test]
-    fn invalid_variable_length_counts_rejected() {
-        // counts 28..=31 with low bit 0 are nonsensical
-        for bad_count in 28..=31u64 {
-            let suffix = bad_count << 1; // low bit 0 => variable length
+    fn every_suffix_value_decodes() {
+        // The monotone code uses all 64 suffix values, so any word with a valid
+        // prefix decodes (no nonsensical suffixes remain). Orders stay 0..=29 and
+        // only suffix >= 48 is a point.
+        for suffix in 0..=SUFFIX_MASK {
             let word = (1u64 << PREFIX_SHIFT) | suffix;
-            assert_eq!(
-                order_of(word),
-                None,
-                "count {} should be invalid",
-                bad_count
-            );
-            assert_eq!(
-                decode(word),
-                Err(DecodeError::InvalidSuffixCount(bad_count as u8))
-            );
+            let dec = decode(word).expect("suffix should decode");
+            assert!(dec.order <= MAX_ORDER);
+            assert_eq!(order_of(word), dec.order);
+            let expected_kind = if suffix >= 48 {
+                Kind::Point
+            } else {
+                Kind::Area
+            };
+            assert_eq!(dec.kind, expected_kind, "kind wrong for suffix {}", suffix);
+            assert_eq!(kind_of(word), expected_kind);
         }
     }
 
@@ -425,6 +601,39 @@ mod tests {
     }
 
     #[test]
+    fn zorder_across_27_28_29_seam() {
+        // Pin the paramount property across the full 0..=29 seam for AREA cells
+        // sharing a fixed body 1..27: the order-27 ancestor sorts before every
+        // order-28 node, which sorts before its order-29 children, with t28
+        // blocks ascending. The all-minimum continuation makes the suffix the
+        // sole tiebreaker.
+        let base = 4u8;
+        let body: Vec<u8> = (0..27u8).map(|i| i % 4).collect();
+        let mut full = body.clone();
+        full.push(0); // t28 placeholder
+        full.push(0); // t29 placeholder
+
+        let mut chain = vec![encode(base, &body, 27)];
+        for t28 in 0..=3u8 {
+            full[27] = t28;
+            chain.push(encode(base, &full, 28)); // [t28]
+            for t29 in 0..=3u8 {
+                full[28] = t29;
+                chain.push(encode(base, &full, 29)); // [t28, t29]
+            }
+        }
+        // 1 (order27) + 4*(1 + 4) = 21 nodes.
+        assert_eq!(chain.len(), 21);
+        for w in chain.windows(2) {
+            assert!(w[0] < w[1], "seam not monotone: {} !< {}", w[0], w[1]);
+        }
+        // Already strictly ascending => sorting is a no-op.
+        let mut sorted = chain.clone();
+        sorted.sort_unstable();
+        assert_eq!(chain, sorted, "seam chain not already Z-sorted");
+    }
+
+    #[test]
     fn coarsen_matches_reencode() {
         let base = 7u8;
         let tuples = sample_tuples(29, 99);
@@ -455,13 +664,51 @@ mod tests {
     }
 
     #[test]
+    fn coarsen_zero_fills_below_target() {
+        // Coarsening an order-29 word to k must leave every body bit below order
+        // k zero and recover exactly the order-k re-encoding.
+        let base = 10u8;
+        let tuples = sample_tuples(29, 71);
+        let fine = encode(base, &tuples, 29);
+        for k in 0..=27u8 {
+            let coarsened = coarsen(fine, k).expect("coarsen");
+            if k < BODY_TUPLES {
+                let below_bits = 2 * (BODY_TUPLES - k) as u32;
+                let below_mask = ((1u64 << below_bits) - 1) << SUFFIX_BITS;
+                assert_eq!(coarsened & below_mask, 0, "body not zero-filled at k {}", k);
+            }
+            assert_eq!(coarsened, encode(base, &tuples, k), "k {}", k);
+        }
+        // 29 -> 28 preserves the order-28 tuple and yields an area cell.
+        let to28 = coarsen(fine, 28).expect("coarsen 28");
+        let dec = decode(to28).unwrap();
+        assert_eq!(dec.order, 28);
+        assert_eq!(dec.kind, Kind::Area);
+        assert_eq!(dec.tuples[27], tuples[27]);
+    }
+
+    #[test]
+    fn coarsen_point_to_28_preserves_tuple() {
+        // A max-encoded point coarsened to order 28 becomes an area cell that
+        // keeps its order-28 tuple.
+        let base = 8u8;
+        let tuples = sample_tuples(29, 88);
+        let point = encode_point(base, &tuples);
+        let to28 = coarsen(point, 28).expect("coarsen point");
+        let dec = decode(to28).unwrap();
+        assert_eq!(dec.order, 28);
+        assert_eq!(dec.kind, Kind::Area);
+        assert_eq!(dec.tuples[27], tuples[27]);
+    }
+
+    #[test]
     fn order_of_and_base_cell_of_match_decode() {
         for base in [0u8, 5, 11] {
             for order in [0u8, 1, 13, 27, 28, 29] {
                 let tuples = sample_tuples(order, base as u64);
                 let word = encode(base, &tuples, order);
                 let dec = decode(word).unwrap();
-                assert_eq!(order_of(word), Some(dec.order));
+                assert_eq!(order_of(word), dec.order);
                 assert_eq!(base_cell_of(word), Some(dec.base_cell));
             }
         }

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -365,6 +365,100 @@ pub fn coarsen(word: u64, k: u8) -> Option<u64> {
     Some(prefix | body | suffix)
 }
 
+// ---------------------------------------------------------------------------
+// healpix-crate bridge: decimal_morton <-> (depth, nested_idx)
+// ---------------------------------------------------------------------------
+//
+// The HEALPix **NESTED** index is the lingua franca for cross-library interop
+// (the `healpix` crate hashes lat/lon to it, and UNIQ is just nested with a
+// depth offset). These two functions are the foundation every later skin needs:
+// `from_nested` lands a healpix hash straight into a packed area word in one
+// pass (no intermediate tuple `Vec`), and `to_nested` hands a word back to the
+// healpix crate for `center`/`vertices`/UNIQ.
+//
+// Nested layout at `depth`: `nested == base * 4^depth + within`, where `base`
+// is `0..=11` and `within` packs the per-order 2-bit tuples with order 1 in the
+// most significant pair (bits `2*(depth-1)..`) down to order `depth` in the
+// lowest pair. That is exactly the decimal_morton tuple order, so the bridge is
+// a pure bit reshuffle: no decimal-digit math, no allocation.
+
+/// Pack a HEALPix NESTED index at `depth` into a canonical `decimal_morton`
+/// **area** word, in a single pass (no intermediate tuple buffer).
+///
+/// This is the bridge from the `healpix` crate's representation: feed it the
+/// output of `healpix::get(depth).hash(..)`. The result is always `Kind::Area`
+/// and bit-identical to `encode(base, &tuples, depth)` for the tuples implied by
+/// `nested`. Use [`encode_point`] (or the tuple form) for a max-encoded point.
+///
+/// # Panics
+/// Panics if `depth > 29`, or if the decoded base cell exceeds `11` (i.e.
+/// `nested` is too large for `depth` -- a malformed nested index).
+pub fn from_nested(nested: u64, depth: u8) -> u64 {
+    assert!(depth <= MAX_ORDER, "depth must be 0..=29, got {}", depth);
+    let base = (nested >> (2 * depth as u32)) as u8;
+    assert!(
+        base <= 11,
+        "nested index {} too large for depth {} (base {} > 11)",
+        nested,
+        depth,
+        base
+    );
+
+    let prefix = ((base + 1) as u64) << PREFIX_SHIFT;
+
+    // Body: orders 1..=min(depth, 27). Order n's tuple is the 2-bit pair at
+    // `2*(depth-n)` of `nested`; it lands at body bit `SUFFIX_BITS + 2*(27-n)`.
+    let body_orders = depth.min(BODY_TUPLES);
+    let mut body: u64 = 0;
+    for n in 1..=body_orders {
+        let pair = (nested >> (2 * (depth - n) as u32)) & 3;
+        let shift = SUFFIX_BITS + 2 * (BODY_TUPLES - n) as u32;
+        body |= pair << shift;
+    }
+
+    // Suffix carries the order count (and, at 28/29, the tail tuples).
+    // At depth 28 the order-28 tuple is the *lowest* pair (`nested & 3`); at
+    // depth 29 order 28 is the next pair up and order 29 is the lowest.
+    let (t28, t29) = match depth {
+        28 => ((nested & 3) as u8, 0),
+        29 => (((nested >> 2) & 3) as u8, (nested & 3) as u8),
+        _ => (0, 0),
+    };
+    prefix | body | build_suffix(depth, t28, t29)
+}
+
+/// Unpack a `decimal_morton` word back into its HEALPix `(depth, nested_idx)`.
+///
+/// The inverse of [`from_nested`]: hands the cell to the `healpix` crate for
+/// `center` / `vertices` / UNIQ conversion. A max-encoded point ([`Kind::Point`])
+/// returns its order-29 nested cell just like an area cell -- the point/area
+/// distinction is a decimal_morton concept the bare nested index does not carry,
+/// so callers that need it should consult [`kind_of`]. Returns `None` for the
+/// empty sentinel or an invalid prefix.
+pub fn to_nested(word: u64) -> Option<(u8, u64)> {
+    let base = base_cell_of(word)? as u64;
+    let order = order_of(word);
+
+    let mut within: u64 = 0;
+    let body_orders = order.min(BODY_TUPLES);
+    for n in 1..=body_orders {
+        let shift = SUFFIX_BITS + 2 * (BODY_TUPLES - n) as u32;
+        let pair = (word >> shift) & 3;
+        within |= pair << (2 * (order - n) as u32);
+    }
+    if order >= 28 {
+        let (t28, t29, _) = decode_tail(word & SUFFIX_MASK);
+        // order 28 -> the tail tuple is the lowest pair; order 29 adds another.
+        within |= (t28 as u64) << (2 * (order - 28) as u32);
+        if let Some(t29) = t29 {
+            within |= t29 as u64;
+        }
+    }
+
+    let nested = base * (1u64 << (2 * order as u32)) + within;
+    Some((order, nested))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -732,6 +826,122 @@ mod tests {
                 let dec = decode(word).unwrap();
                 assert_eq!(order_of(word), dec.order);
                 assert_eq!(base_cell_of(word), Some(dec.base_cell));
+            }
+        }
+    }
+
+    // -- healpix-crate bridge (from_nested / to_nested) ----------------------
+
+    /// Reconstruct a nested index from base cell + stored `0..=3` tuples, the
+    /// reference `from_nested` must agree with.
+    fn nested_from_tuples(base: u8, tuples: &[u8], order: u8) -> u64 {
+        let mut within = 0u64;
+        for n in 1..=order {
+            within |= ((tuples[(n - 1) as usize] & 3) as u64) << (2 * (order - n) as u32);
+        }
+        (base as u64) * (1u64 << (2 * order as u32)) + within
+    }
+
+    #[test]
+    fn from_nested_matches_tuple_encode() {
+        // from_nested(nested, depth) must be bit-identical to the tuple-based
+        // encode for the same cell, across all base cells and orders.
+        for base in 0..=11u8 {
+            for order in 0..=MAX_ORDER {
+                let tuples = sample_tuples(order, base as u64 + 3);
+                let nested = nested_from_tuples(base, &tuples, order);
+                let via_nested = from_nested(nested, order);
+                let via_tuples = encode(base, &tuples, order);
+                assert_eq!(
+                    via_nested, via_tuples,
+                    "from_nested != encode at base {} order {}",
+                    base, order
+                );
+                assert_eq!(kind_of(via_nested), Kind::Area);
+            }
+        }
+    }
+
+    #[test]
+    fn nested_round_trip_all_orders() {
+        // (depth, nested) -> word -> (depth, nested) is the identity for every
+        // base cell and order 0..=29.
+        for base in 0..=11u8 {
+            for order in 0..=MAX_ORDER {
+                let tuples = sample_tuples(order, base as u64 * 7 + 1);
+                let nested = nested_from_tuples(base, &tuples, order);
+                let word = from_nested(nested, order);
+                let (depth2, nested2) = to_nested(word).expect("to_nested");
+                assert_eq!(
+                    depth2, order,
+                    "depth round-trip base {} order {}",
+                    base, order
+                );
+                assert_eq!(
+                    nested2, nested,
+                    "nested round-trip base {} order {}",
+                    base, order
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn to_nested_point_returns_order29_cell() {
+        // A max-encoded point carries an order-29 nested cell; to_nested returns
+        // it (the point/area flag lives in kind_of, not the bare nested index)
+        // and it equals the matching area cell's nested index.
+        let base = 7u8;
+        let tuples = sample_tuples(29, 42);
+        let point = encode_point(base, &tuples);
+        let area = encode(base, &tuples, 29);
+        let (pd, pn) = to_nested(point).unwrap();
+        let (ad, an) = to_nested(area).unwrap();
+        assert_eq!(pd, 29);
+        assert_eq!((pd, pn), (ad, an), "point and area share a nested cell");
+        assert_eq!(kind_of(point), Kind::Point);
+        assert_eq!(kind_of(area), Kind::Area);
+    }
+
+    #[test]
+    fn to_nested_rejects_empty_and_invalid() {
+        assert_eq!(to_nested(0), None);
+        for bad in 13..=15u64 {
+            assert_eq!(to_nested(bad << PREFIX_SHIFT), None);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "depth must be 0..=29")]
+    fn from_nested_rejects_depth_over_29() {
+        from_nested(0, 30);
+    }
+
+    #[test]
+    #[should_panic(expected = "too large for depth")]
+    fn from_nested_rejects_oversized_nested() {
+        // base would be 12 at depth 1 (nested 48 = 12 * 4): malformed.
+        from_nested(48, 1);
+    }
+
+    #[test]
+    fn from_nested_agrees_with_healpix_crate() {
+        // End-to-end against the real healpix crate: hash a spread of lat/lon to
+        // a nested index, bridge it, and confirm to_nested recovers exactly that
+        // (depth, nested). This pins the bridge to the cross-library nested
+        // representation #35 targets for interop.
+        use healpix::coords::Degrees;
+        for depth in [1u8, 6, 12, 17, 27, 28, 29] {
+            let layer = healpix::get(depth);
+            for i in 0..200u32 {
+                let f = i as f64;
+                let lat = -85.0 + (f * 1.7) % 170.0;
+                let lon = -180.0 + (f * 3.1) % 360.0;
+                let nested = layer.hash(Degrees(lon, lat));
+                let word = from_nested(nested, depth);
+                let (d2, n2) = to_nested(word).expect("to_nested");
+                assert_eq!(d2, depth, "depth {} lat {} lon {}", depth, lat, lon);
+                assert_eq!(n2, nested, "nested mismatch depth {} i {}", depth, i);
             }
         }
     }

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -32,18 +32,19 @@
 //!
 //!   * **`0..=27`** -- self-describing tuple count: order is literally the suffix
 //!     value (`0` = base-cell-only / order 0). `27` is the order-27 path tail `[]`.
-//!   * **`28..=47`** -- the 20 order-28/29 *area* nodes in preorder. With
-//!     `t28,t29 in {1..4}` stored `0..3`, `r = (t28-1)*5 + (t29_present ? t29 : 0)`
-//!     (`0..=19`) and `suffix = 28 + r`. Each `t28` owns a 5-block: `[t28]`
-//!     (order 28) followed by its four `[t28,t29]` order-29 children, so the
-//!     order-28 parent sorts before its order-29 children (parent-first preorder).
+//!   * **`28..=47`** -- the 20 order-28/29 *area* nodes in preorder. Tuples are
+//!     the **stored `0..=3`** values throughout (read as `1..=4`), matching
+//!     `build_suffix`: `r = t28*5 + (t29_present ? t29 + 1 : 0)` (`0..=19`) and
+//!     `suffix = 28 + r`. Each `t28` owns a 5-block: `[t28]` (order 28) followed
+//!     by its four `[t28,t29]` order-29 children, so the order-28 parent sorts
+//!     before its order-29 children (parent-first preorder).
 //!   * **`48..=63`** -- an order-29 *point* cast to maximum resolution: it carries
 //!     no area claim (e.g. a raw lat/lon cast to a Morton index). Keyed by the
-//!     `(t28,t29) in {1..4}^2` combination: `r2 = (t28-1)*4 + (t29-1)` (`0..=15`),
+//!     **stored** `(t28,t29)` combination: `r2 = t28*4 + t29` (`0..=15`),
 //!     `suffix = 48 + r2`. A decoded point sets `kind == Kind::Point`. Z-order
 //!     note: a point sorts **after** every area cell sharing the same body (it is
-//!     the highest suffix range), so a max-encoded point sorts after the area
-//!     cells that contain it -- intended (a point is the finest, last thing there).
+//!     the highest suffix range), so a max-encoded point sorts after every area
+//!     cell of the same body -- intended (a point is the finest, last thing there).
 //!
 //! Storage is **unsigned**; the signed "negative = southern" form is a
 //! presentation detail applied elsewhere. Encoding **zero-fills** every bit
@@ -221,7 +222,8 @@ pub fn encode_point(base_cell: u8, tuples: &[u8]) -> u64 {
 ///
 /// Every 6-bit suffix value is valid under the monotone encoding, so this is
 /// total: `0..=27` -> the order itself; `28..=47` -> order 28 (block parent) or
-/// 29 (block child); `48..=63` -> an order-29 point.
+/// 29 (block child); `48..=63` -> an order-29 point. Both order-29 area cells
+/// and points return `29` here; use [`kind_of`] to tell them apart.
 #[inline]
 pub fn order_of(word: u64) -> u8 {
     let suffix = word & SUFFIX_MASK;
@@ -229,7 +231,10 @@ pub fn order_of(word: u64) -> u8 {
         suffix as u8 // 0..=27
     } else if suffix < POINT_BASE {
         // area tail: pos 0 in a 5-block is order 28, pos 1..4 is order 29.
-        if (suffix - AREA_TAIL_BASE).is_multiple_of(5) {
+        // `% 5` (not `is_multiple_of`, stable only since 1.87) keeps the MSRV
+        // low and matches `decode_tail`'s `r % 5`; no `rust-version` is declared.
+        #[allow(clippy::manual_is_multiple_of)]
+        if (suffix - AREA_TAIL_BASE) % 5 == 0 {
             28
         } else {
             29
@@ -699,6 +704,23 @@ mod tests {
         assert_eq!(dec.order, 28);
         assert_eq!(dec.kind, Kind::Area);
         assert_eq!(dec.tuples[27], tuples[27]);
+    }
+
+    #[test]
+    fn coarsen_point_below_28_becomes_area() {
+        // Coarsening a max-encoded point below order 28 drops the point
+        // distinction into an ordinary variable-length area cell, identical to
+        // coarsening (or re-encoding) the matching area word at that order.
+        let base = 3u8;
+        let tuples = sample_tuples(29, 64);
+        let point = encode_point(base, &tuples);
+        for k in 0..=27u8 {
+            let coarsened = coarsen(point, k).expect("coarsen point");
+            assert_eq!(coarsened, encode(base, &tuples, k), "point coarsen k {}", k);
+            let dec = decode(coarsened).unwrap();
+            assert_eq!(dec.order, k);
+            assert_eq!(dec.kind, Kind::Area, "coarsened point must be Area at k {}", k);
+        }
     }
 
     #[test]

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -1,0 +1,469 @@
+//! Full-resolution `decimal_morton` 64-bit MOC datatype kernel (issue #35).
+//!
+//! This is the phase-1 encode/decode kernel for the packed 64-bit Morton MOC
+//! index that captures the HEALPix order explicitly and reaches order 29.
+//!
+//! # Bit layout (MSB -> LSB)
+//!
+//! ```text
+//! [ 4-bit prefix ][ 54-bit body (27 x 2-bit) ][ 6-bit suffix ]
+//!   63 .. 60        59 ..  6                     5 ..  0
+//! ```
+//!
+//! * **prefix** -- base cell stored as `base_id + 1`, so the 12 HEALPix base
+//!   cells occupy `1..=12`. `0` is an empty/null sentinel and `13..=15` are
+//!   invalid. The `+1` shift is monotonic, so a raw unsigned sort is preserved
+//!   as a Z-order curve (the property issue #35 calls paramount).
+//! * **body** -- 27 two-bit tuples, one per order `1..=27`. Order 1 occupies the
+//!   highest tuple (bits 59..58), order 27 the lowest (bits 7..6). The stored
+//!   value is `0..=3` but is *interpreted* as `1..=4` (a decode-time `+1`,
+//!   matching the existing decimal Morton convention).
+//! * **suffix** -- 6 bits, understood right-to-left (low bit first):
+//!     * rightmost bit `0` => variable length; the 5 bits to its left encode the
+//!       number of tuples to read, valid `0..=27` (0 = base-cell-only / order 0).
+//!     * rightmost two bits `01` => order 28; suffix bits 5..4 hold the order-28
+//!       tuple, bits 3..2 are spare (zero-filled).
+//!     * rightmost two bits `11` => order 29; suffix bits 5..4 hold the order-28
+//!       tuple and bits 3..2 the order-29 tuple.
+//!
+//! Storage is **unsigned**; the signed "negative = southern" form is a
+//! presentation detail applied elsewhere. Encoding **zero-fills** every bit
+//! below an element's order, so two encodings of the same cell are bit-equal
+//! (canonical) -- integer equality, hashing, dedup and the raw sort all work.
+
+/// Highest HEALPix order this datatype encodes.
+pub const MAX_ORDER: u8 = 29;
+/// Number of two-bit tuples held in the body (orders 1..=27).
+pub const BODY_TUPLES: u8 = 27;
+
+const PREFIX_SHIFT: u32 = 60;
+const SUFFIX_BITS: u32 = 6;
+const SUFFIX_MASK: u64 = (1 << SUFFIX_BITS) - 1; // low 6 bits
+/// Full 54-bit body mask, sitting just above the suffix.
+const BODY_MASK: u64 = ((1u64 << 54) - 1) << SUFFIX_BITS;
+
+/// A decoded `decimal_morton` index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecimalMorton {
+    /// HEALPix base cell, `0..=11`.
+    pub base_cell: u8,
+    /// HEALPix order, `0..=29`.
+    pub order: u8,
+    /// The per-order tuples, `tuples[i]` for order `i + 1`. Each value is the
+    /// stored `0..=3` (not the `1..=4` interpretation). Length == `order`.
+    pub tuples: Vec<u8>,
+}
+
+/// Errors raised while decoding an untrusted packed word.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// Prefix was `0` (the empty/null sentinel) -- there is no cell to decode.
+    Empty,
+    /// Prefix was `13..=15`; only `1..=12` map to a base cell.
+    InvalidPrefix(u8),
+    /// Variable-length suffix pointed at a tuple count of `28..=31`, which is
+    /// nonsensical (orders 28/29 use the dedicated flag forms).
+    InvalidSuffixCount(u8),
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecodeError::Empty => write!(f, "empty decimal_morton (prefix 0)"),
+            DecodeError::InvalidPrefix(p) => {
+                write!(f, "invalid base-cell prefix {} (valid 1..=12)", p)
+            }
+            DecodeError::InvalidSuffixCount(c) => {
+                write!(
+                    f,
+                    "invalid variable-length suffix count {} (valid 0..=27)",
+                    c
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+/// Build the 6-bit suffix value for a given order and its order-28/29 tuples.
+#[inline]
+fn build_suffix(order: u8, t28: u8, t29: u8) -> u64 {
+    match order {
+        // variable length: low bit 0, count in the 5 bits above it
+        0..=27 => ((order as u64) << 1) & SUFFIX_MASK,
+        // order 28: bits 5..4 = tuple-28, bits 3..2 spare (0), bits 1..0 = 01
+        28 => (((t28 & 3) as u64) << 4) | 0b01,
+        // order 29: bits 5..4 = tuple-28, bits 3..2 = tuple-29, bits 1..0 = 11
+        29 => (((t28 & 3) as u64) << 4) | (((t29 & 3) as u64) << 2) | 0b11,
+        _ => unreachable!("order > 29 is rejected before build_suffix"),
+    }
+}
+
+/// Encode a base cell, per-order tuples and order into a packed 64-bit word.
+///
+/// `tuples` supplies the stored `0..=3` value for each order `1..=order`; only
+/// the first `order` entries are read. Any bit below the element's order is
+/// zero-filled, so the result is canonical.
+///
+/// # Panics
+/// Panics if `base_cell > 11`, `order > 29`, or `tuples` has fewer than `order`
+/// entries -- these are programmer errors on the trusted encode path.
+pub fn encode(base_cell: u8, tuples: &[u8], order: u8) -> u64 {
+    assert!(
+        base_cell <= 11,
+        "base_cell must be 0..=11, got {}",
+        base_cell
+    );
+    assert!(order <= MAX_ORDER, "order must be 0..=29, got {}", order);
+    assert!(
+        tuples.len() >= order as usize,
+        "need at least {} tuples for order {}, got {}",
+        order,
+        order,
+        tuples.len()
+    );
+
+    let prefix = ((base_cell + 1) as u64) << PREFIX_SHIFT;
+
+    // Body: orders 1..=27 only (orders 28/29 live in the suffix). Order n sits
+    // at the tuple `BODY_TUPLES - n` counting from the body's low end.
+    let body_orders = order.min(BODY_TUPLES);
+    let mut body: u64 = 0;
+    for n in 1..=body_orders {
+        let pair = (tuples[(n - 1) as usize] & 3) as u64;
+        // Order 1 is the highest pair; shift it furthest left within the body.
+        let shift = SUFFIX_BITS + 2 * (BODY_TUPLES - n) as u32;
+        body |= pair << shift;
+    }
+
+    let (t28, t29) = match order {
+        28 => (tuples[27], 0),
+        29 => (tuples[27], tuples[28]),
+        _ => (0, 0),
+    };
+    let suffix = build_suffix(order, t28, t29);
+
+    prefix | body | suffix
+}
+
+/// Read just the order encoded by a packed word's suffix (the "fast path").
+///
+/// Returns `None` for the nonsensical variable-length counts `28..=31`.
+#[inline]
+pub fn order_of(word: u64) -> Option<u8> {
+    let suffix = word & SUFFIX_MASK;
+    if suffix & 1 == 0 {
+        let count = (suffix >> 1) as u8; // 0..=31
+        if count <= BODY_TUPLES {
+            Some(count)
+        } else {
+            None
+        }
+    } else if suffix & 0b11 == 0b01 {
+        Some(28)
+    } else {
+        Some(29)
+    }
+}
+
+/// Read just the base cell (`0..=11`) encoded by a packed word's prefix.
+///
+/// Returns `None` for the empty sentinel (`0`) or an invalid prefix (`13..=15`).
+#[inline]
+pub fn base_cell_of(word: u64) -> Option<u8> {
+    let prefix = (word >> PREFIX_SHIFT) as u8 & 0x0f;
+    match prefix {
+        1..=12 => Some(prefix - 1),
+        _ => None,
+    }
+}
+
+/// Decode a packed 64-bit word back into its `DecimalMorton` parts.
+pub fn decode(word: u64) -> Result<DecimalMorton, DecodeError> {
+    let prefix = (word >> PREFIX_SHIFT) as u8 & 0x0f;
+    let base_cell = match prefix {
+        0 => return Err(DecodeError::Empty),
+        1..=12 => prefix - 1,
+        other => return Err(DecodeError::InvalidPrefix(other)),
+    };
+
+    let suffix = word & SUFFIX_MASK;
+    let order = order_of(word).ok_or(DecodeError::InvalidSuffixCount((suffix >> 1) as u8))?;
+
+    let mut tuples = Vec::with_capacity(order as usize);
+    let body_orders = order.min(BODY_TUPLES);
+    for n in 1..=body_orders {
+        let shift = SUFFIX_BITS + 2 * (BODY_TUPLES - n) as u32;
+        tuples.push(((word >> shift) & 3) as u8);
+    }
+    if order >= 28 {
+        tuples.push(((suffix >> 4) & 3) as u8); // order-28 tuple
+    }
+    if order == 29 {
+        tuples.push(((suffix >> 2) & 3) as u8); // order-29 tuple
+    }
+
+    Ok(DecimalMorton {
+        base_cell,
+        order,
+        tuples,
+    })
+}
+
+/// Coarsen a packed word to order `k`, discarding finer detail.
+///
+/// The base cell and the first `k` tuples are kept; every lower bit is
+/// zero-filled and the suffix is rewritten for order `k`. Returns the input
+/// unchanged when `k >=` the word's own order (nothing to coarsen). Returns
+/// `None` if the word does not decode.
+pub fn coarsen(word: u64, k: u8) -> Option<u64> {
+    let native = order_of(word)?;
+    base_cell_of(word)?; // reject empty / invalid prefix
+    if k >= native {
+        return Some(word);
+    }
+
+    let prefix = word & (0x0fu64 << PREFIX_SHIFT);
+    // Keep the body tuples for orders 1..=min(k, 27); mask off everything below.
+    let kept_body_orders = k.min(BODY_TUPLES);
+    let body = if kept_body_orders == 0 {
+        0
+    } else {
+        // Highest `2 * kept_body_orders` bits of the body region.
+        let keep_bits = 2 * kept_body_orders as u32;
+        let mask = (((1u64 << keep_bits) - 1) << (54 - keep_bits)) << SUFFIX_BITS;
+        word & mask & BODY_MASK
+    };
+
+    // Build the target suffix. Orders 28/29 keep their tuples, which live in the
+    // *source* suffix at the same bit positions (k < native means native == 29
+    // when k == 28, so the order-28 tuple is present to preserve). Lower targets
+    // use the variable-length form.
+    let src_suffix = word & SUFFIX_MASK;
+    let suffix = match k {
+        28 => build_suffix(28, ((src_suffix >> 4) & 3) as u8, 0),
+        // k == 29 implies k >= native, already returned above; unreachable here.
+        _ => build_suffix(k, 0, 0),
+    };
+    Some(prefix | body | suffix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic tuple vector (stored 0..=3) for property coverage.
+    fn sample_tuples(order: u8, seed: u64) -> Vec<u8> {
+        (0..order.max(1))
+            .map(|i| ((seed.wrapping_mul(2654435761).wrapping_add(i as u64)) % 4) as u8)
+            .collect()
+    }
+
+    #[test]
+    fn roundtrip_all_base_cells_all_orders() {
+        for base in 0..=11u8 {
+            for order in 0..=MAX_ORDER {
+                let tuples = sample_tuples(order, base as u64 + 1);
+                let word = encode(base, &tuples, order);
+                let dec = decode(word).expect("decode");
+                assert_eq!(dec.base_cell, base, "base mismatch order {}", order);
+                assert_eq!(dec.order, order, "order mismatch base {}", base);
+                assert_eq!(
+                    &dec.tuples[..],
+                    &tuples[..order as usize],
+                    "tuple mismatch base {} order {}",
+                    base,
+                    order
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn order_zero_is_base_cell_only() {
+        for base in 0..=11u8 {
+            let word = encode(base, &[], 0);
+            // body and suffix are both zero for order 0
+            assert_eq!(word & BODY_MASK, 0, "body not zero-filled, base {}", base);
+            assert_eq!(word & SUFFIX_MASK, 0, "suffix not zero, base {}", base);
+            assert_eq!(order_of(word), Some(0));
+            assert_eq!(base_cell_of(word), Some(base));
+            let dec = decode(word).unwrap();
+            assert!(dec.tuples.is_empty());
+        }
+    }
+
+    #[test]
+    fn variable_length_orders_1_through_27() {
+        let base = 5u8;
+        for order in 1..=BODY_TUPLES {
+            let tuples = sample_tuples(order, 7);
+            let word = encode(base, &tuples, order);
+            // low suffix bit must be 0 (variable length) and count == order
+            assert_eq!(word & 1, 0, "var-length flag wrong at order {}", order);
+            assert_eq!(order_of(word), Some(order));
+            assert_eq!(decode(word).unwrap().tuples, &tuples[..order as usize]);
+        }
+    }
+
+    #[test]
+    fn order_28_suffix_form() {
+        let base = 3u8;
+        let mut tuples = sample_tuples(28, 11);
+        for t28 in 0..=3u8 {
+            tuples[27] = t28;
+            let word = encode(base, &tuples, 28);
+            assert_eq!(word & 0b11, 0b01, "order-28 flag wrong for tuple {}", t28);
+            // spare bits 3..2 must be zero-filled
+            assert_eq!((word >> 2) & 0b11, 0, "spare bits set for tuple {}", t28);
+            assert_eq!((word >> 4) & 0b11, t28 as u64, "order-28 tuple wrong");
+            assert_eq!(order_of(word), Some(28));
+            let dec = decode(word).unwrap();
+            assert_eq!(dec.order, 28);
+            assert_eq!(dec.tuples[27], t28);
+        }
+    }
+
+    #[test]
+    fn order_29_suffix_form() {
+        let base = 9u8;
+        let mut tuples = sample_tuples(29, 13);
+        for t28 in 0..=3u8 {
+            for t29 in 0..=3u8 {
+                tuples[27] = t28;
+                tuples[28] = t29;
+                let word = encode(base, &tuples, 29);
+                assert_eq!(word & 0b11, 0b11, "order-29 flag wrong");
+                assert_eq!((word >> 4) & 0b11, t28 as u64, "order-28 tuple wrong");
+                assert_eq!((word >> 2) & 0b11, t29 as u64, "order-29 tuple wrong");
+                assert_eq!(order_of(word), Some(29));
+                let dec = decode(word).unwrap();
+                assert_eq!(dec.order, 29);
+                assert_eq!(dec.tuples[27], t28);
+                assert_eq!(dec.tuples[28], t29);
+            }
+        }
+    }
+
+    #[test]
+    fn prefix_stores_base_plus_one() {
+        for base in 0..=11u8 {
+            let word = encode(base, &[], 0);
+            assert_eq!((word >> PREFIX_SHIFT) & 0x0f, (base + 1) as u64);
+        }
+    }
+
+    #[test]
+    fn empty_sentinel_decodes_to_error() {
+        assert_eq!(decode(0), Err(DecodeError::Empty));
+        assert_eq!(base_cell_of(0), None);
+    }
+
+    #[test]
+    fn invalid_prefix_rejected() {
+        for bad in 13..=15u64 {
+            let word = bad << PREFIX_SHIFT;
+            assert_eq!(decode(word), Err(DecodeError::InvalidPrefix(bad as u8)));
+            assert_eq!(base_cell_of(word), None);
+        }
+    }
+
+    #[test]
+    fn invalid_variable_length_counts_rejected() {
+        // counts 28..=31 with low bit 0 are nonsensical
+        for bad_count in 28..=31u64 {
+            let suffix = bad_count << 1; // low bit 0 => variable length
+            let word = (1u64 << PREFIX_SHIFT) | suffix;
+            assert_eq!(
+                order_of(word),
+                None,
+                "count {} should be invalid",
+                bad_count
+            );
+            assert_eq!(
+                decode(word),
+                Err(DecodeError::InvalidSuffixCount(bad_count as u8))
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_zero_fill_dedups() {
+        // Encode reads only the first `order` tuples, so trailing garbage in the
+        // input must not change the canonical word: two inputs for the same
+        // order-3 cell produce bit-identical results.
+        let base = 2u8;
+        let canonical = encode(base, &[1, 2, 3], 3);
+        let from_noisy = encode(base, &[1, 2, 3, 3, 1, 0, 2], 3);
+        assert_eq!(canonical, from_noisy);
+        // Every body bit below order 3 is zero.
+        let below_mask = ((1u64 << (2 * (BODY_TUPLES - 3) as u32)) - 1) << SUFFIX_BITS;
+        assert_eq!(canonical & below_mask, 0);
+    }
+
+    #[test]
+    fn raw_sort_is_zorder() {
+        // A parent (lower order) sorts immediately before its descendants, and
+        // siblings sort by tuple value -- the Z-order locality property.
+        let base = 4u8;
+        let parent = encode(base, &[0, 0], 2); // order-2 cell, path 0->0
+        let children: Vec<u64> = (0..4u8).map(|c| encode(base, &[0, 0, c], 3)).collect();
+        for &child in &children {
+            assert!(parent < child, "parent {parent} !< child {child}");
+        }
+        let sorted = {
+            let mut c = children.clone();
+            c.sort_unstable();
+            c
+        };
+        assert_eq!(children, sorted, "children not already Z-sorted");
+        // A higher base cell sorts after everything in base 4.
+        let other_base = encode(base + 1, &[0, 0, 0], 3);
+        assert!(other_base > parent);
+        assert!(other_base > *children.last().unwrap());
+    }
+
+    #[test]
+    fn coarsen_matches_reencode() {
+        let base = 7u8;
+        let tuples = sample_tuples(29, 99);
+        let fine = encode(base, &tuples, 29);
+        for k in 0..=29u8 {
+            let coarsened = coarsen(fine, k).expect("coarsen");
+            let expected = encode(base, &tuples, k);
+            assert_eq!(
+                coarsened, expected,
+                "coarsen to {} != re-encode at {}",
+                k, k
+            );
+        }
+    }
+
+    #[test]
+    fn coarsen_noop_when_k_ge_order() {
+        let base = 1u8;
+        let word = encode(base, &[2, 1, 3], 3);
+        assert_eq!(coarsen(word, 3), Some(word));
+        assert_eq!(coarsen(word, 5), Some(word));
+        assert_eq!(coarsen(word, 29), Some(word));
+    }
+
+    #[test]
+    fn coarsen_rejects_empty() {
+        assert_eq!(coarsen(0, 0), None);
+    }
+
+    #[test]
+    fn order_of_and_base_cell_of_match_decode() {
+        for base in [0u8, 5, 11] {
+            for order in [0u8, 1, 13, 27, 28, 29] {
+                let tuples = sample_tuples(order, base as u64);
+                let word = encode(base, &tuples, order);
+                let dec = decode(word).unwrap();
+                assert_eq!(order_of(word), Some(dec.order));
+                assert_eq!(base_cell_of(word), Some(dec.base_cell));
+            }
+        }
+    }
+}

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -395,14 +395,18 @@ pub fn coarsen(word: u64, k: u8) -> Option<u64> {
 /// `nested` is too large for `depth` -- a malformed nested index).
 pub fn from_nested(nested: u64, depth: u8) -> u64 {
     assert!(depth <= MAX_ORDER, "depth must be 0..=29, got {}", depth);
-    let base = (nested >> (2 * depth as u32)) as u8;
+    // Check the base on the full u64 *before* the `as u8` cast -- a grossly
+    // oversized nested index would otherwise wrap past this guard and silently
+    // produce a wrong word.
+    let base_u64 = nested >> (2 * depth as u32);
     assert!(
-        base <= 11,
+        base_u64 <= 11,
         "nested index {} too large for depth {} (base {} > 11)",
         nested,
         depth,
-        base
+        base_u64
     );
+    let base = base_u64 as u8;
 
     let prefix = ((base + 1) as u64) << PREFIX_SHIFT;
 
@@ -922,6 +926,14 @@ mod tests {
     fn from_nested_rejects_oversized_nested() {
         // base would be 12 at depth 1 (nested 48 = 12 * 4): malformed.
         from_nested(48, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "too large for depth")]
+    fn from_nested_rejects_truncation_wrap() {
+        // A base that wraps to 0..=11 under a bare `as u8` (256 -> 0) must still
+        // be caught: the guard checks the full u64 before the cast.
+        from_nested(256, 0);
     }
 
     #[test]

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -229,7 +229,11 @@ fn rust_nested2mort(
 
 /// Build compacted prefix trie over morton indices (Python binding)
 ///
-/// Returns a list of tuples: (characteristic, count, original_indices, child_node_ids, depth)
+/// Returns `(nodes, permutation)` where `nodes` is a list of tuples
+/// `(characteristic, count, idx_start, idx_len, child_node_ids, depth)` and
+/// `permutation` is one flat int64 numpy array of original positions. Each
+/// node's membership is the slice `permutation[idx_start : idx_start+idx_len]`
+/// — no per-node index list is materialised under the GIL (issue #34 item 8).
 #[pyfunction]
 #[pyo3(signature = (morton_array, max_depth=None))]
 fn split_children_rust(
@@ -238,23 +242,32 @@ fn split_children_rust(
     max_depth: Option<usize>,
 ) -> PyResult<PyObject> {
     let data = morton_array.to_vec()?;
-    let flat = prefix_trie::split_children_flat(&data, max_depth);
+    let (flat, perm) = py.allow_threads(|| prefix_trie::split_children_flat(&data, max_depth));
 
-    // Convert Vec<FlatNode> to a Python list of tuples
+    // Node metadata: (characteristic, count, idx_start, idx_len, child_ids, depth)
     let py_list = pyo3::types::PyList::empty_bound(py);
-    for (characteristic, count, indices, child_ids, depth) in flat {
-        let py_indices = pyo3::types::PyList::new_bound(py, &indices);
+    for (characteristic, count, idx_start, idx_len, child_ids, depth) in flat {
         let py_child_ids = pyo3::types::PyList::new_bound(py, &child_ids);
-        let tuple = pyo3::types::PyTuple::new_bound(py, &[
-            characteristic.to_object(py),
-            count.to_object(py),
-            py_indices.to_object(py),
-            py_child_ids.to_object(py),
-            depth.to_object(py),
-        ]);
+        let tuple = pyo3::types::PyTuple::new_bound(
+            py,
+            &[
+                characteristic.to_object(py),
+                count.to_object(py),
+                idx_start.to_object(py),
+                idx_len.to_object(py),
+                py_child_ids.to_object(py),
+                depth.to_object(py),
+            ],
+        );
         py_list.append(tuple)?;
     }
-    Ok(py_list.to_object(py))
+
+    // Single flat permutation buffer as a numpy int64 array.
+    let perm_i64: Vec<i64> = perm.into_iter().map(|i| i as i64).collect();
+    let py_perm = perm_i64.into_pyarray_bound(py);
+
+    let out = pyo3::types::PyTuple::new_bound(py, &[py_list.to_object(py), py_perm.to_object(py)]);
+    Ok(out.to_object(py))
 }
 
 /// Convert geographic coordinates to morton indices entirely in Rust

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -137,8 +137,12 @@ fn fast_norm2mort<'py>(
 ///
 /// # Returns
 /// Tuple of two NumPy arrays: (nested cell ids as u64, depths as u8).
-/// Each digit of every morton index must be in 1-4 and the parent in 0-11;
-/// malformed indices raise a `ValueError`.
+///
+/// Callers must pre-validate inputs: each digit of every morton index is
+/// expected to be in 1-4 and the parent in 0-11. A zero morton raises a
+/// `ValueError`; other malformed indices are not checked in release builds
+/// (the digit check is a debug assertion) and will silently mis-decode, so
+/// validate upstream (as ``mort2norm`` does via ``validate_morton``).
 #[pyfunction]
 fn rust_mort2nested(
     py: Python<'_>,

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod buffer;
 pub mod cell_geom;
 pub mod coverage;
+pub mod decimal_morton;
 pub mod geo2mort;
 pub mod linestring;
 pub mod moc;

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -130,6 +130,99 @@ fn fast_norm2mort<'py>(
     Ok(results.into_pyarray_bound(py).into_any().unbind())
 }
 
+/// Decode morton indices to HEALPix NESTED cell ids and depths (vectorized).
+///
+/// # Arguments
+/// * `morton_array` - Morton indices (i64 NumPy array)
+///
+/// # Returns
+/// Tuple of two NumPy arrays: (nested cell ids as u64, depths as u8).
+/// Each digit of every morton index must be in 1-4 and the parent in 0-11;
+/// malformed indices raise a `ValueError`.
+#[pyfunction]
+fn rust_mort2nested(
+    py: Python<'_>,
+    morton_array: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let data = morton_array.to_vec()?;
+
+    let result = std::panic::catch_unwind(|| {
+        let mut nested = Vec::with_capacity(data.len());
+        let mut depths = Vec::with_capacity(data.len());
+        for &m in &data {
+            let (cell, depth) = morton::mort2nested(m);
+            nested.push(cell);
+            depths.push(depth);
+        }
+        (nested, depths)
+    });
+
+    match result {
+        Ok((nested, depths)) => {
+            let py_nested = nested.into_pyarray_bound(py).into_any().unbind();
+            let py_depths = depths.into_pyarray_bound(py).into_any().unbind();
+            let tuple = pyo3::types::PyTuple::new_bound(py, &[py_nested, py_depths]);
+            Ok(tuple.to_object(py))
+        }
+        Err(e) => {
+            let msg = if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = e.downcast_ref::<&str>() {
+                s.to_string()
+            } else {
+                "mort2nested panicked".to_string()
+            };
+            Err(PyValueError::new_err(msg))
+        }
+    }
+}
+
+/// Encode HEALPix NESTED cell ids and depths to morton indices (vectorized).
+///
+/// # Arguments
+/// * `nested_array` - HEALPix NESTED cell ids (u64 NumPy array)
+/// * `depth_array` - HEALPix depths/orders (u8 NumPy array), same length
+///
+/// # Returns
+/// Morton indices as an i64 NumPy array.
+#[pyfunction]
+fn rust_nested2mort(
+    py: Python<'_>,
+    nested_array: PyReadonlyArray1<u64>,
+    depth_array: PyReadonlyArray1<u8>,
+) -> PyResult<PyObject> {
+    let nested = nested_array.to_vec()?;
+    let depths = depth_array.to_vec()?;
+
+    if nested.len() != depths.len() {
+        return Err(PyValueError::new_err(
+            "nested and depth arrays must have the same length",
+        ));
+    }
+
+    let result = std::panic::catch_unwind(|| {
+        nested
+            .iter()
+            .zip(depths.iter())
+            .map(|(&n, &d)| morton::nested2mort(n, d))
+            .collect::<Vec<i64>>()
+    });
+
+    match result {
+        Ok(morton) => Ok(morton.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => {
+            let msg = if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = e.downcast_ref::<&str>() {
+                s.to_string()
+            } else {
+                "nested2mort panicked".to_string()
+            };
+            Err(PyValueError::new_err(msg))
+        }
+    }
+}
+
 /// Build compacted prefix trie over morton indices (Python binding)
 ///
 /// Returns a list of tuples: (characteristic, count, original_indices, child_node_ids, depth)
@@ -727,6 +820,8 @@ fn rust_linestring_coverage(
 #[pymodule]
 fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fast_norm2mort, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mort2nested, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_nested2mort, m)?)?;
     m.add_function(wrap_pyfunction!(split_children_rust, m)?)?;
     m.add_function(wrap_pyfunction!(rust_geo2mort, m)?)?;
     m.add_function(wrap_pyfunction!(rust_ang2pix, m)?)?;

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -11,12 +11,17 @@
 //! - [`to_order`] densifies every cell to a single target order → the flat,
 //!   back-compatible form.
 //!
-//! `HashSet`/`HashMap` are used only for membership; every result is sorted, so
-//! output is independent of hash iteration order (unlike the issue #28 bug).
-
-use std::collections::{HashMap, HashSet};
+//! [`normalize`] runs as a single sorted-stream pass (no hash-set fixpoint), so
+//! output is deterministic and independent of any iteration order (unlike the
+//! issue #28 bug).
 
 use crate::morton::{mort2nested, nested2mort};
+
+/// Maximum HEALPix depth mortie supports (order 18 → 64-bit morton limit).
+/// Cells are mapped to half-open ranges over the uniform grid at this depth so a
+/// single sort linearizes ancestry: a coarser cell's range strictly contains its
+/// descendants'.
+const MAX_DEPTH: u8 = 18;
 
 /// Densify a (possibly mixed-order) morton set to a flat list at `order`.
 ///
@@ -46,55 +51,77 @@ pub fn to_order(morton: &[i64], order: u8) -> Vec<i64> {
     out
 }
 
+/// Half-open range `[start, end)` a cell covers on the uniform `MAX_DEPTH` grid.
+#[inline]
+fn cell_range(nested: u64, depth: u8) -> (u64, u64) {
+    let shift = 2 * (MAX_DEPTH - depth) as u32;
+    let start = nested << shift;
+    (start, start + (1u64 << shift))
+}
+
 /// Collapse a morton set into its canonical compact MOC.
 ///
-/// First drops any cell that already has an ancestor in the set, then
-/// repeatedly merges any 4 complete sibling cells into their parent.  Returns
-/// sorted unique morton indices at mixed orders.
+/// Runs in a single sorted-stream pass: cells are linearized by their range on
+/// the uniform `MAX_DEPTH` grid, contained (descendant) cells are pruned in one
+/// sweep, then a stack merge collapses every complete sibling quartet into its
+/// parent, cascading without a fixpoint loop.  Returns sorted unique morton
+/// indices at mixed orders.
 pub fn normalize(morton: &[i64]) -> Vec<i64> {
-    let mut set: HashSet<(u64, u8)> = morton.iter().map(|&m| mort2nested(m)).collect();
-
-    // (1) Ancestor-prune: a cell contained in a coarser cell is redundant.
-    let snapshot: Vec<(u64, u8)> = set.iter().copied().collect();
-    for &(n, d) in &snapshot {
-        let (mut nn, mut dd) = (n, d);
-        while dd > 0 {
-            nn >>= 2;
-            dd -= 1;
-            if set.contains(&(nn, dd)) {
-                set.remove(&(n, d));
-                break;
-            }
-        }
+    if morton.is_empty() {
+        return Vec::new();
     }
 
-    // (2) Sibling-merge: collapse 4 complete children into their parent, until
-    // no further merges are possible (handles multi-level collapse over passes).
-    loop {
-        let mut by_parent: HashMap<(u64, u8), Vec<u64>> = HashMap::new();
-        for &(n, d) in &set {
-            if d > 0 {
-                by_parent.entry((n >> 2, d - 1)).or_default().push(n & 3);
-            }
-        }
-        let mut changed = false;
-        for (parent, child_slots) in by_parent {
-            let distinct: HashSet<u64> = child_slots.iter().copied().collect();
-            if distinct.len() == 4 {
-                let (pn, pd) = parent;
-                for slot in 0..4u64 {
-                    set.remove(&((pn << 2) | slot, pd + 1));
+    // Linearize: sort by range start ascending, then by range end descending so
+    // a coarser cell sorts ahead of any descendant sharing its start.
+    let mut cells: Vec<(u64, u64, u64, u8)> = morton
+        .iter()
+        .map(|&m| {
+            let (n, d) = mort2nested(m);
+            let (start, end) = cell_range(n, d);
+            (start, end, n, d)
+        })
+        .collect();
+    cells.sort_unstable_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+
+    // (1) Ancestor-prune + dedup in one sweep: keep a cell only if it starts at
+    // or beyond the end of the last kept cell (anything else is contained in it).
+    let mut stack: Vec<(u64, u8)> = Vec::with_capacity(cells.len());
+    let mut last_end: u64 = 0;
+    let mut first = true;
+    for (start, end, n, d) in cells {
+        if first || start >= last_end {
+            // (2) Stack merge: push, then collapse complete sibling quartets.
+            stack.push((n, d));
+            while stack.len() >= 4 {
+                let len = stack.len();
+                let (n0, d0) = stack[len - 4];
+                let (n1, d1) = stack[len - 3];
+                let (n2, d2) = stack[len - 2];
+                let (n3, d3) = stack[len - 1];
+                let parent = n0 >> 2;
+                let complete = d0 > 0
+                    && d1 == d0
+                    && d2 == d0
+                    && d3 == d0
+                    && n1 >> 2 == parent
+                    && n2 >> 2 == parent
+                    && n3 >> 2 == parent
+                    && n0 & 3 == 0
+                    && n1 & 3 == 1
+                    && n2 & 3 == 2
+                    && n3 & 3 == 3;
+                if !complete {
+                    break;
                 }
-                set.insert((pn, pd));
-                changed = true;
+                stack.truncate(len - 4);
+                stack.push((parent, d0 - 1));
             }
-        }
-        if !changed {
-            break;
+            last_end = end;
+            first = false;
         }
     }
 
-    let mut out: Vec<i64> = set.iter().map(|&(n, d)| nested2mort(n, d)).collect();
+    let mut out: Vec<i64> = stack.iter().map(|&(n, d)| nested2mort(n, d)).collect();
     out.sort_unstable();
     out
 }
@@ -162,5 +189,113 @@ mod tests {
         let direct = to_order(&children, 5);
         let viamoc = to_order(&normalize(&children), 5);
         assert_eq!(direct, viamoc);
+    }
+
+    #[test]
+    fn test_normalize_empty() {
+        assert_eq!(normalize(&[]), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn test_normalize_multilevel_cascade() {
+        // 16 leaves at depth 5 under cell 2@3 → cascade two levels to 2@3.
+        let mut leaves = Vec::new();
+        for c in 0..4u64 {
+            for s in 0..4u64 {
+                leaves.push(nested2mort(((2 << 2 | c) << 2) | s, 5));
+            }
+        }
+        assert_eq!(normalize(&leaves), vec![nested2mort(2, 3)]);
+    }
+
+    #[test]
+    fn test_normalize_dedup() {
+        // Duplicate inputs collapse to one cell.
+        let c = nested2mort(42, 6);
+        assert_eq!(normalize(&[c, c, c]), vec![c]);
+    }
+
+    #[test]
+    fn test_normalize_distinct_parents_unchanged() {
+        // Complete quartets under two different parents stay as two parents.
+        let mut cells: Vec<i64> = (0..4).map(|s| nested2mort((1 << 2) | s, 4)).collect();
+        cells.extend((0..4).map(|s| nested2mort((7 << 2) | s, 4)));
+        let mut expected = vec![nested2mort(1, 3), nested2mort(7, 3)];
+        expected.sort_unstable();
+        assert_eq!(normalize(&cells), expected);
+    }
+
+    /// Brute-force reference: prune descendants, then fixpoint sibling-merge via
+    /// sorted vectors (no hashing), used to differentially test the fast path.
+    fn normalize_reference(morton: &[i64]) -> Vec<i64> {
+        use std::collections::BTreeSet;
+        let mut set: BTreeSet<(u8, u64)> = morton
+            .iter()
+            .map(|&m| {
+                let (n, d) = mort2nested(m);
+                (d, n)
+            })
+            .collect();
+        // ancestor-prune
+        let snap: Vec<(u8, u64)> = set.iter().copied().collect();
+        for &(d, n) in &snap {
+            let (mut dd, mut nn) = (d, n);
+            while dd > 0 {
+                dd -= 1;
+                nn >>= 2;
+                if set.contains(&(dd, nn)) {
+                    set.remove(&(d, n));
+                    break;
+                }
+            }
+        }
+        // fixpoint sibling-merge
+        loop {
+            let mut merged = false;
+            let snap: Vec<(u8, u64)> = set.iter().copied().collect();
+            for &(d, n) in &snap {
+                if d == 0 || n & 3 != 0 {
+                    continue;
+                }
+                if (1..4).all(|s| set.contains(&(d, n | s))) {
+                    for s in 0..4 {
+                        set.remove(&(d, n | s));
+                    }
+                    set.insert((d - 1, n >> 2));
+                    merged = true;
+                }
+            }
+            if !merged {
+                break;
+            }
+        }
+        let mut out: Vec<i64> = set.iter().map(|&(d, n)| nested2mort(n, d)).collect();
+        out.sort_unstable();
+        out
+    }
+
+    #[test]
+    fn test_normalize_matches_reference() {
+        // Random mixed-order covers: fast path must equal the brute-force ref.
+        let mut state = 0x9e3779b97f4a7c15u64;
+        let mut rng = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for _ in 0..200 {
+            let k = (rng() % 60) as usize + 1;
+            let cells: Vec<i64> = (0..k)
+                .map(|_| {
+                    let depth = (rng() % 6) as u8 + 1;
+                    let nside_sq = 1u64 << (2 * depth as u32);
+                    let base = rng() % 12;
+                    let n = base * nside_sq + rng() % nside_sq;
+                    nested2mort(n, depth)
+                })
+                .collect();
+            assert_eq!(normalize(&cells), normalize_reference(&cells));
+        }
     }
 }

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -297,5 +297,30 @@ mod tests {
                 .collect();
             assert_eq!(normalize(&cells), normalize_reference(&cells));
         }
+
+        // Dense subtrees: emit many leaves under one shallow root so complete,
+        // cascading sibling quartets are exercised (with random gaps so partial
+        // quartets and ancestor cells also occur).
+        for _ in 0..200 {
+            let root_depth = (rng() % 3) as u8 + 1;
+            let leaf_depth = root_depth + 2 + (rng() % 2) as u8;
+            let base = rng() % 12;
+            let root = base * (1u64 << (2 * root_depth as u32)) + rng() % 4;
+            let span = 1u64 << (2 * (leaf_depth - root_depth) as u32);
+            let base_leaf = root << (2 * (leaf_depth - root_depth) as u32);
+            let mut cells: Vec<i64> = Vec::new();
+            for off in 0..span {
+                if rng() % 8 != 0 {
+                    cells.push(nested2mort(base_leaf + off, leaf_depth));
+                }
+            }
+            if rng() % 4 == 0 {
+                cells.push(nested2mort(root, root_depth)); // ancestor present
+            }
+            if cells.is_empty() {
+                continue;
+            }
+            assert_eq!(normalize(&cells), normalize_reference(&cells));
+        }
     }
 }

--- a/src_rust/src/prefix_trie.rs
+++ b/src_rust/src/prefix_trie.rs
@@ -1,173 +1,255 @@
-//! Morton bounding box: build a compacted prefix trie over morton index
-//! strings and return a flat list of nodes.
+//! Morton bounding box: build a compacted prefix trie over morton indices
+//! and return a flat list of nodes plus one shared permutation buffer.
 //!
-//! The Python side reconstructs `MortonChild` objects from this flat output.
+//! A morton index is a decimal self-describing address: the first digit is
+//! the base cell and every later digit is in `1..=4` (a base-4 path step).
+//! The trie therefore branches on decimal-digit columns of the (left-padded)
+//! decimal rendering, but we never materialise strings — each value is read
+//! as a fixed-width array of integer *slots* via integer arithmetic:
+//!
+//! * `SLOT_SPACE` (`-2`) — left-pad position (a shorter value's high columns)
+//! * `SLOT_MINUS` (`-1`) — the sign column of a negative value
+//! * `0..=9`            — a decimal digit
+//!
+//! Column 0 is always the sign/pad column and column 1 the first digit/pad,
+//! mirroring the historical `rjust`-padded char grid exactly so the
+//! `split_children` Rust-vs-Python parity contract holds bit-for-bit.
+//!
+//! Membership is stored once as a single `permutation` buffer; each node
+//! carries an `(idx_start, idx_len)` slice into it instead of cloning its
+//! index list. The Python side reconstructs `MortonChild` objects from this
+//! flat output and slices the shared buffer with numpy.
 
 use rayon::prelude::*;
-use std::collections::BTreeMap;
+
+/// Slot sentinel for a left-pad (space) column.
+const SLOT_SPACE: i8 = -2;
+/// Slot sentinel for the `'-'` sign column.
+const SLOT_MINUS: i8 = -1;
 
 /// A flat trie node returned to Python.
 ///
-/// Fields: (characteristic, count, original_indices, child_node_ids, depth)
-pub type FlatNode = (String, usize, Vec<usize>, Vec<usize>, usize);
+/// Fields: `(characteristic, count, idx_start, idx_len, child_node_ids, depth)`
+/// where `(idx_start, idx_len)` is a slice into the shared permutation buffer.
+pub type FlatNode = (String, usize, usize, usize, Vec<usize>, usize);
 
-/// Build a compacted prefix trie and return all nodes as a flat `Vec`.
+/// Render a slot value back to its decimal-string character.
+#[inline]
+fn slot_char(slot: i8) -> char {
+    match slot {
+        SLOT_SPACE => ' ',
+        SLOT_MINUS => '-',
+        d => (b'0' + d as u8) as char,
+    }
+}
+
+/// Build the fixed-width slot grid (row-major) matching `str(v).rjust(width)`.
+///
+/// Returns `(grid, ncols)`. Row `i` holds the right-justified slots for
+/// `morton_array[i]`; high columns beyond the value's length are `SLOT_SPACE`.
+fn build_slot_grid(morton_array: &[i64]) -> (Vec<i8>, usize) {
+    let n = morton_array.len();
+
+    // String length of each value: decimal digits (+1 for a leading '-').
+    let str_lens: Vec<usize> = morton_array
+        .par_iter()
+        .map(|&v| {
+            let digits = decimal_digits(v.unsigned_abs());
+            digits + if v < 0 { 1 } else { 0 }
+        })
+        .collect();
+
+    let max_len = str_lens.iter().copied().max().unwrap();
+    let has_negatives = morton_array.iter().any(|&v| v < 0);
+    // Ensure column 0 is always a sign/pad column even when all positive.
+    let ncols = if has_negatives { max_len } else { max_len + 1 };
+
+    let mut grid = vec![SLOT_SPACE; n * ncols];
+    grid.par_chunks_mut(ncols)
+        .zip(morton_array.par_iter())
+        .for_each(|(row, &v)| {
+            let abs = v.unsigned_abs();
+            let ndig = decimal_digits(abs);
+            let slen = ndig + if v < 0 { 1 } else { 0 };
+            let start = ncols - slen;
+            let mut col = start;
+            if v < 0 {
+                row[col] = SLOT_MINUS;
+                col += 1;
+            }
+            // Write decimal digits most-significant first.
+            let mut divisor = 10u64.pow((ndig - 1) as u32);
+            let mut rem = abs;
+            for _ in 0..ndig {
+                row[col] = (rem / divisor) as i8;
+                rem %= divisor;
+                divisor /= 10;
+                col += 1;
+            }
+        });
+
+    (grid, ncols)
+}
+
+/// Count decimal digits in `val` (a `0` value has one digit).
+#[inline]
+fn decimal_digits(val: u64) -> usize {
+    if val == 0 {
+        return 1;
+    }
+    (val.ilog10() + 1) as usize
+}
+
+/// Build a compacted prefix trie and return all nodes plus the permutation.
 ///
 /// # Arguments
 /// * `morton_array` – signed 64-bit morton indices
 /// * `max_depth`    – optional branching depth limit (None = unlimited)
 ///
 /// # Returns
-/// `Vec<FlatNode>` where each tuple is
-/// `(characteristic, count, original_indices, child_node_ids, depth)`.
-///
-/// Nodes are emitted depth-first; roots come first.
+/// `(Vec<FlatNode>, Vec<usize>)`. Each node references its membership as an
+/// `(idx_start, idx_len)` slice of the returned permutation buffer (the
+/// original positions in `morton_array`). Nodes are emitted depth-first;
+/// roots come first.
 pub fn split_children_flat(
     morton_array: &[i64],
     max_depth: Option<usize>,
-) -> Vec<FlatNode> {
+) -> (Vec<FlatNode>, Vec<usize>) {
     let n = morton_array.len();
     if n == 0 {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     }
 
-    // 1. Convert i64 → padded strings (parallel with rayon)
-    let strings: Vec<String> = morton_array
-        .par_iter()
-        .map(|v| v.to_string())
-        .collect();
+    let (grid, ncols) = build_slot_grid(morton_array);
+    let slot = |i: usize, col: usize| grid[i * ncols + col];
 
-    // Determine max string length; ensure column 0 is sign/pad
-    let max_len = strings.iter().map(|s| s.len()).max().unwrap();
-    let has_negatives = strings.iter().any(|s| s.starts_with('-'));
-    let padded_len = if has_negatives { max_len } else { max_len + 1 };
-
-    // Right-pad each string with spaces, then build a flat byte grid
-    let padded: Vec<Vec<u8>> = strings
-        .par_iter()
-        .map(|s| {
-            let mut v = Vec::with_capacity(padded_len);
-            let bytes = s.as_bytes();
-            // left-pad with spaces
-            for _ in 0..(padded_len - bytes.len()) {
-                v.push(b' ');
-            }
-            v.extend_from_slice(bytes);
-            v
-        })
-        .collect();
-
-    // 2. Group by (sign_col, first_digit) → root groups
-    //    sign_col = padded[i][0], digit_col = padded[i][1]
-    let mut root_groups: BTreeMap<(u8, u8), Vec<usize>> = BTreeMap::new();
-    for i in 0..n {
-        let sign = padded[i][0];
-        let digit = padded[i][1];
-        root_groups.entry((sign, digit)).or_default().push(i);
-    }
-
-    // 3. Build trie iteratively, collecting nodes into flat vec
+    // Single permutation buffer; nodes own contiguous slices of it. We sort a
+    // working copy column-by-column so each group is contiguous, mirroring the
+    // recursive partition order of the historical algorithm.
+    let mut perm: Vec<usize> = (0..n).collect();
     let mut nodes: Vec<FlatNode> = Vec::new();
 
-    for ((sign, digit), indices) in &root_groups {
-        let characteristic = if *sign == b'-' {
-            format!("-{}", *digit as char)
-        } else {
-            format!("{}", *digit as char)
-        };
+    // Root grouping: by (sign column, first-digit column), in slot order.
+    // Sort by (col0, col1) so each root group is a contiguous run.
+    perm.sort_by(|&a, &b| (slot(a, 0), slot(a, 1)).cmp(&(slot(b, 0), slot(b, 1))));
 
-        // Recursively compact this group starting at column 2
+    let mut i = 0usize;
+    while i < n {
+        let s0 = slot(perm[i], 0);
+        let s1 = slot(perm[i], 1);
+        let mut j = i + 1;
+        while j < n && slot(perm[j], 0) == s0 && slot(perm[j], 1) == s1 {
+            j += 1;
+        }
+
+        // Root characteristic: '-' + digit for negatives, else just the digit.
+        let mut characteristic = String::new();
+        if s0 == SLOT_MINUS {
+            characteristic.push('-');
+        }
+        characteristic.push(slot_char(s1));
+
         compact_group(
-            &padded,
-            indices,
+            &grid,
+            ncols,
+            &mut perm,
+            i,
+            j,
             2, // start scanning at column 2
-            padded_len,
             characteristic,
             0, // depth
             max_depth,
             &mut nodes,
         );
+
+        i = j;
     }
 
-    nodes
+    (nodes, perm)
 }
 
-/// Recursively compact a group of indices and append nodes to `out`.
+/// Recursively compact the permutation slice `perm[lo..hi]` and append nodes.
 ///
 /// Returns the node id (index into `out`) of the node created for this group.
+#[allow(clippy::too_many_arguments)]
 fn compact_group(
-    grid: &[Vec<u8>],
-    indices: &[usize],
-    start_col: usize,
+    grid: &[i8],
     ncols: usize,
+    perm: &mut [usize],
+    lo: usize,
+    hi: usize,
+    start_col: usize,
     mut characteristic: String,
     depth: usize,
     max_depth: Option<usize>,
     out: &mut Vec<FlatNode>,
 ) -> usize {
+    let slot = |i: usize, col: usize| grid[i * ncols + col];
     let mut col = start_col;
 
-    // Extend characteristic while the column is uniform
     while col < ncols {
-        let first_byte = grid[indices[0]][col];
-        let all_same = indices.iter().all(|&i| grid[i][col] == first_byte);
+        let first = slot(perm[lo], col);
+        let all_same = perm[lo..hi].iter().all(|&i| slot(i, col) == first);
 
         if all_same {
-            characteristic.push(first_byte as char);
+            characteristic.push(slot_char(first));
             col += 1;
         } else {
-            // Divergence — branch if depth allows
+            // Divergence — branch if depth allows.
             if max_depth.is_some() && depth >= max_depth.unwrap() {
                 break;
             }
 
-            // Reserve a slot for this node, fill children later
+            // Reserve this node's slot; children fill its child_ids later.
             let node_id = out.len();
             out.push((
                 characteristic.clone(),
-                indices.len(),
-                indices.to_vec(),
-                Vec::new(), // child_node_ids placeholder
+                hi - lo,
+                lo,
+                hi - lo,
+                Vec::new(),
                 depth,
             ));
 
-            // Group by the diverging byte
-            let mut child_groups: BTreeMap<u8, Vec<usize>> = BTreeMap::new();
-            for &i in indices {
-                child_groups.entry(grid[i][col]).or_default().push(i);
-            }
+            // Sort the slice by this column so each child group is contiguous,
+            // preserving relative order within a child (stable) so deeper
+            // columns stay grouped.
+            perm[lo..hi].sort_by_key(|&i| slot(i, col));
 
-            let mut child_ids = Vec::with_capacity(child_groups.len());
-            for (byte_val, child_indices) in &child_groups {
-                let child_char = format!("{}{}", characteristic, *byte_val as char);
+            let mut child_ids = Vec::new();
+            let mut g = lo;
+            while g < hi {
+                let cv = slot(perm[g], col);
+                let mut k = g + 1;
+                while k < hi && slot(perm[k], col) == cv {
+                    k += 1;
+                }
+                let mut child_char = characteristic.clone();
+                child_char.push(slot_char(cv));
                 let cid = compact_group(
                     grid,
-                    child_indices,
-                    col + 1,
                     ncols,
+                    perm,
+                    g,
+                    k,
+                    col + 1,
                     child_char,
                     depth + 1,
                     max_depth,
                     out,
                 );
                 child_ids.push(cid);
+                g = k;
             }
 
-            // Patch in the child_node_ids
-            out[node_id].3 = child_ids;
+            out[node_id].4 = child_ids;
             return node_id;
         }
     }
 
-    // Leaf node (no divergence within columns, or hit max_depth)
+    // Leaf node (uniform through all columns, or hit max_depth).
     let node_id = out.len();
-    out.push((
-        characteristic,
-        indices.len(),
-        indices.to_vec(),
-        Vec::new(),
-        depth,
-    ));
+    out.push((characteristic, hi - lo, lo, hi - lo, Vec::new(), depth));
     node_id
 }
 
@@ -175,60 +257,60 @@ fn compact_group(
 mod tests {
     use super::*;
 
+    /// Collect (characteristic, count) for nodes at a given depth.
+    fn at_depth(nodes: &[FlatNode], depth: usize) -> Vec<(String, usize)> {
+        nodes
+            .iter()
+            .filter(|n| n.5 == depth)
+            .map(|n| (n.0.clone(), n.1))
+            .collect()
+    }
+
     #[test]
     fn test_identical_indices() {
         let arr = vec![1234i64, 1234, 1234];
-        let nodes = split_children_flat(&arr, None);
+        let (nodes, perm) = split_children_flat(&arr, None);
         assert_eq!(nodes.len(), 1);
         assert_eq!(nodes[0].0, "1234"); // characteristic
-        assert_eq!(nodes[0].1, 3);       // count
-        assert!(nodes[0].3.is_empty());  // no children
+        assert_eq!(nodes[0].1, 3); // count
+        assert!(nodes[0].4.is_empty()); // no children
+        assert_eq!(nodes[0].3, 3); // idx_len
+        assert_eq!(perm.len(), 3);
     }
 
     #[test]
     fn test_divergence() {
         let arr = vec![1231i64, 1232, 1233];
-        let nodes = split_children_flat(&arr, None);
-        // Root "123" with 3 children
+        let (nodes, _) = split_children_flat(&arr, None);
         assert_eq!(nodes[0].0, "123");
-        assert_eq!(nodes[0].3.len(), 3);
+        assert_eq!(nodes[0].4.len(), 3);
     }
 
     #[test]
     fn test_negative_indices() {
         let arr = vec![-123i64, -124, -234];
-        let nodes = split_children_flat(&arr, None);
-        // Should have roots for -1 and -2 groups
-        let root_chars: Vec<&str> = nodes
-            .iter()
-            .filter(|n| n.4 == 0) // depth == 0
-            .map(|n| n.0.as_str())
-            .collect();
-        assert!(root_chars.iter().any(|c| c.starts_with("-1")));
-        assert!(root_chars.iter().any(|c| c.starts_with("-2")));
+        let (nodes, _) = split_children_flat(&arr, None);
+        let roots = at_depth(&nodes, 0);
+        assert!(roots.iter().any(|(c, _)| c.starts_with("-1")));
+        assert!(roots.iter().any(|(c, _)| c.starts_with("-2")));
     }
 
     #[test]
     fn test_mixed_sign() {
         let arr = vec![-111i64, -112, 111, 112];
-        let nodes = split_children_flat(&arr, None);
-        let root_chars: Vec<&str> = nodes
-            .iter()
-            .filter(|n| n.4 == 0)
-            .map(|n| n.0.as_str())
-            .collect();
-        assert!(root_chars.iter().any(|c| c.starts_with("-")));
-        assert!(root_chars.iter().any(|c| !c.starts_with("-")));
+        let (nodes, _) = split_children_flat(&arr, None);
+        let roots = at_depth(&nodes, 0);
+        assert!(roots.iter().any(|(c, _)| c.starts_with('-')));
+        assert!(roots.iter().any(|(c, _)| !c.starts_with('-')));
     }
 
     #[test]
     fn test_max_depth_zero() {
         let arr = vec![1111i64, 1122, 1211, 1222];
-        let nodes = split_children_flat(&arr, Some(0));
-        // All root nodes should have no children
+        let (nodes, _) = split_children_flat(&arr, Some(0));
         for n in &nodes {
-            if n.4 == 0 {
-                assert!(n.3.is_empty());
+            if n.5 == 0 {
+                assert!(n.4.is_empty());
             }
         }
     }
@@ -236,20 +318,57 @@ mod tests {
     #[test]
     fn test_coverage() {
         let arr = vec![-5112i64, -5121, -6131, -6132, -6133];
-        let nodes = split_children_flat(&arr, None);
-        // Total count across root nodes should equal input length
-        let root_count: usize = nodes
-            .iter()
-            .filter(|n| n.4 == 0)
-            .map(|n| n.1)
-            .sum();
+        let (nodes, perm) = split_children_flat(&arr, None);
+        let root_count: usize = at_depth(&nodes, 0).iter().map(|(_, c)| c).sum();
         assert_eq!(root_count, arr.len());
+        assert_eq!(perm.len(), arr.len());
     }
 
     #[test]
     fn test_empty() {
         let arr: Vec<i64> = vec![];
-        let nodes = split_children_flat(&arr, None);
+        let (nodes, perm) = split_children_flat(&arr, None);
         assert!(nodes.is_empty());
+        assert!(perm.is_empty());
+    }
+
+    #[test]
+    fn test_mixed_order() {
+        // Shorter and longer values left-pad differently (space-aligned).
+        let arr = vec![123i64, 1231, 1232];
+        let (nodes, _) = split_children_flat(&arr, None);
+        // The order-2 value 123 splits off from the order-3 values via the
+        // pad/digit column, so there must be more than one root-or-leaf node.
+        assert!(nodes.len() >= 2);
+        // Coverage is preserved.
+        let total: usize = at_depth(&nodes, 0).iter().map(|(_, c)| c).sum();
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn test_slices_partition_permutation() {
+        // Every leaf's (start,len) slice maps to its original morton values,
+        // and the leaf slices tile the whole permutation buffer.
+        let arr = vec![1211i64, 1211, 1222, 1233, 1233, 1233];
+        let (nodes, perm) = split_children_flat(&arr, None);
+        let mut covered = vec![false; arr.len()];
+        for n in &nodes {
+            if n.4.is_empty() {
+                // leaf
+                for &p in &perm[n.2..n.2 + n.3] {
+                    covered[p] = true;
+                }
+            }
+        }
+        assert!(covered.iter().all(|&c| c));
+    }
+
+    #[test]
+    fn test_decimal_digits() {
+        assert_eq!(decimal_digits(0), 1);
+        assert_eq!(decimal_digits(9), 1);
+        assert_eq!(decimal_digits(10), 2);
+        assert_eq!(decimal_digits(999), 3);
+        assert_eq!(decimal_digits(1000), 4);
     }
 }


### PR DESCRIPTION
Refs #35

## What this lands

The `decimal_morton` datatype: the **packed-i64 encode/decode kernel** in Rust (the shared foundation every later skin sits on), the monotonic-suffix + point/area work, a **criterion benchmark** vs the existing order-≤18 path, and the **healpix-crate bridge** (`from_nested`/`to_nested`). Encoding-coupled #34 items (#4/#7/#8/#9) have landed; the Python surface for the `decimal_morton` skin itself is deferred to the skin phases (see "Follow-up").

Module `src_rust/src/decimal_morton.rs` (wired into the crate via a one-line `pub mod` in `lib.rs`); bench `src_rust/benches/decimal_morton_bench.rs` (wired in `Cargo.toml`).

## Bit-layout approach (as settled on #35)

64-bit word, MSB → LSB:

```
[ 4-bit prefix ][ 54-bit body (27 x 2-bit) ][ 6-bit suffix ]
  63 .. 60        59 ..  6                     5 ..  0
```

- **prefix** — base cell stored as `base_id + 1` → `1..=12`; `0` empty/null sentinel; `13..=15` invalid. Monotonic, so raw unsigned sort stays Z-order.
- **body** — 27 two-bit tuples, order 1 in the highest pair, order 27 in the lowest. Stored `0..=3`, interpreted `1..=4`.
- **suffix** — one monotone preorder code `0..=63`: `0..=27` variable-length area (order == suffix); `28..=47` order 28/29 area (preorder, div/mod 5); `48..=63` order-29 max-encoded **point** (`Kind::Point`, no area claim). Raw unsigned sort == Z-order across the full `0..=29` seam.

Storage is **unsigned**; signed "negative = southern" is a later-skin presentation detail. Encode **zero-fills** below the element's order (canonical — bit-equal dups, working equality/hash/dedup/sort).

### API
- `encode` / `encode_point` / `decode` — canonical pack / max-encoded point / full unpack.
- `order_of` / `base_cell_of` / `kind_of` — fast-path reads.
- `coarsen(word, k)` — body-mask + suffix rewrite for order `k`.
- **`from_nested(nested, depth)` / `to_nested(word)` — the healpix-crate bridge** (NESTED ↔ packed word; the cross-library interop foundation for UNIQ/`center`/`vertices`).

## Phases checklist (this PR — complete)

- [x] **Phase 1 — int64 encode/decode kernel**: layout, `encode`/`decode`, `order_of`/`base_cell_of`, `coarsen`, guards, exhaustive tests.
- [x] **Monotonic suffix + point/area distinction**: single-integer suffix; real-vs-max-encoded order-29 point/area split; Z-order across the 27/28/29 seam.
- [x] **Phase A — benchmarks**: criterion bench of new vs old encode/decode; encode side re-pointed at the single-pass `from_nested` encoder; added `coarsen` + standalone `from_nested`/`to_nested` cases so CodSpeed measures the new primitives. Results tables in the PR comments.
- [x] **Phase B — healpix-crate bridge** (`from_nested`/`to_nested`): single-pass nested↔word, round-trip + property tests, validated end-to-end against the real `healpix` crate.
- [x] **Phase 2 — encoding-coupled #34 items**: #4 (batch `rust_mort2nested`/`rust_nested2mort` PyO3 fns + `mort2norm` rewire), #7/#8 (integer prefix trie + flat buffer), #9 (single-pass `moc::normalize`). `mort2norm` empty-input guard added.
- [x] **Merged `main`** (commit `de09ee6`): resolved the `lib.rs` conflict (this branch's `(flat, perm)` flat-buffer return vs `main`'s GIL-release `allow_threads` rewrite of `split_children_rust`); rebuilt + full suite green.

## Follow-up (separate PRs — not in this diff)

These are the later `decimal_morton` *skin* phases; each is its own PR and **does not block this merge**:

- Phase 3 — RangeMOC / `moc`-crate adoption decision (the #34 Part 2 gate; a call for @espg).
- Phase 4 — Arrow ExtensionType skin.
- Phase 5 — numpy/pandas ExtensionArray skin.
- `MORTIE_FORCE_PYTHON` fallback removal (#37, currently `blocked` on this PR).

## How it was tested (this run, after merging `main`, built with maturin)

`cargo test --lib` → **123 passed**; `flake8 mortie --select=E9,F63,F7,F82` clean; `pytest` → **243 passed / 8 skipped / 0 failed** (up from 235 — `main` brought `test_threading.py`), including `test_rust_vs_python.py` and the `rust_mort2nested`/`rust_nested2mort` round-trips. The new bench builds (`cargo bench --no-run`). `cargo clippy`/`rustfmt --check` clean on every line this PR's phases touched (pre-existing tree-wide fmt/clippy drift left untouched — a dedicated sweep PR follows after this merges, per the thread).

## Questions for review

1. **Scope choice — `decimal_morton` skin stays Rust-internal (no PyO3 binding for it yet).** Confirmed yes in review — the useful Python surface is the Phase 5 ExtensionArray work.
2. **`coarsen` 29→28** preserves the order-28 tuple (genuine order-28 parent). **Confirmed** by @espg.
3. **fmt/clippy-clean sweep** offered as a separate `small-fix` PR — **approved**; sequenced to land *after* this PR (and #44) to avoid re-conflicting `lib.rs`/`coverage_bench.rs`.