### PR TITLE
morton_index datatype skin: pandas + Arrow (phases 4 & 5 of #35)

### DIFF
--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -90,18 +90,16 @@ __all__ = [
     'morton_polygon_from_array',
 ]
 
-# morton_index datatype (issue #35, phase 5). The pandas ExtensionArray surface
-# is an optional extra: importing mortie must succeed with only numpy installed,
-# so the dtype/array are exposed lazily and only built when pandas is present.
-# The module itself imports fine numpy-only; touching the classes without pandas
-# raises a clear ImportError.
-from . import morton_index  # noqa: F401
-
-# Arrow interop (issue #35, phase 4). pyarrow is an optional extra exactly like
-# pandas: the module imports numpy-only, and the extension type is built lazily
-# only when pyarrow is present (touching it without pyarrow raises a clear
-# ImportError). See mortie/arrow.py.
-from . import arrow  # noqa: F401
+# morton_index datatype (phase 5) + Arrow interop (phase 4) for issue #35. The
+# pandas ExtensionArray and the pyarrow ExtensionType are optional extras:
+# importing mortie must succeed with only numpy installed, so the names are
+# exposed lazily and built only when pandas / pyarrow are present (touching them
+# without the extra raises a clear ImportError). See mortie/morton_index.py and
+# mortie/arrow.py.
+from . import (
+    arrow,  # noqa: F401
+    morton_index,  # noqa: F401
+)
 
 _ARROW_NAMES = (
     "MortonIndexType",

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -90,5 +90,21 @@ __all__ = [
     'morton_polygon_from_array',
 ]
 
+# morton_index datatype (issue #35, phase 5). The pandas ExtensionArray surface
+# is an optional extra: importing mortie must succeed with only numpy installed,
+# so the dtype/array are exposed lazily and only built when pandas is present.
+# The module itself imports fine numpy-only; touching the classes without pandas
+# raises a clear ImportError.
+from . import morton_index  # noqa: F401
+
+
+def __getattr__(name):
+    if name in ("MortonIndexDtype", "MortonIndexArray"):
+        return getattr(morton_index, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ += ['MortonIndexDtype', 'MortonIndexArray', 'morton_index']
+
 # The Rust extension is imported and used internally by fastNorm2Mort in tools.py
 # No need to do anything here - tools.py handles the Rust integration

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -97,14 +97,31 @@ __all__ = [
 # raises a clear ImportError.
 from . import morton_index  # noqa: F401
 
+# Arrow interop (issue #35, phase 4). pyarrow is an optional extra exactly like
+# pandas: the module imports numpy-only, and the extension type is built lazily
+# only when pyarrow is present (touching it without pyarrow raises a clear
+# ImportError). See mortie/arrow.py.
+from . import arrow  # noqa: F401
+
+_ARROW_NAMES = (
+    "MortonIndexType",
+    "MortonIndexExtArray",
+    "morton_index_type",
+    "from_morton_index",
+    "to_morton_index",
+)
+
 
 def __getattr__(name):
     if name in ("MortonIndexDtype", "MortonIndexArray"):
         return getattr(morton_index, name)
+    if name in _ARROW_NAMES:
+        return getattr(arrow, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ += ['MortonIndexDtype', 'MortonIndexArray', 'morton_index']
+__all__ += list(_ARROW_NAMES) + ['arrow']
 
 # The Rust extension is imported and used internally by fastNorm2Mort in tools.py
 # No need to do anything here - tools.py handles the Rust integration

--- a/mortie/arrow.py
+++ b/mortie/arrow.py
@@ -1,0 +1,171 @@
+"""
+The ``morton_index`` Arrow skin: a pyarrow :class:`pyarrow.ExtensionType` over
+``int64`` storage carrying the ``morton_index`` tag (issue #35, phase 4).
+
+This is the Arrow-interop sibling of the pandas ExtensionArray in
+:mod:`mortie.morton_index`. The packed 64-bit decimal-Morton words live in Rust
+(``src_rust/src/decimal_morton.rs``); this module only wraps them so the same
+words can travel through an Arrow array and survive a parquet round-trip with
+their ``morton_index`` identity attached as extension metadata. Storage is the
+raw ``int64`` words verbatim (zero-copy over the kernel's bit layout), the same
+unsigned-Z-order convention as the pandas skin.
+
+pyarrow is an **optional** dependency exactly like pandas: importing ``mortie``
+succeeds with neither installed. The extension type is built lazily on first
+use and a clear ``ImportError`` is raised if it is touched without pyarrow.
+"""
+
+import numpy as np
+
+# The extension-type / array helpers are provided via module-level
+# ``__getattr__`` (built lazily so a numpy-only install can import this module),
+# so they are intentionally not named in ``__all__`` here.
+__all__ = []
+
+# The extension name registered with pyarrow (the metadata tag that travels
+# through IPC / parquet and identifies the type on the way back).
+EXTENSION_NAME = "mortie.morton_index"
+
+
+def _require_pyarrow():
+    """Import pyarrow lazily, raising a clear error if it is absent.
+
+    pyarrow is an optional extra (the only hard runtime dep is numpy), so the
+    extension type is built on top of whatever pyarrow provides at call time
+    rather than at module import.
+    """
+    try:
+        import pyarrow as pa
+    except ImportError as exc:  # pragma: no cover - exercised via message only
+        raise ImportError(
+            "the morton_index Arrow extension type requires pyarrow; install it "
+            "with `pip install mortie[pyarrow]` (or `pip install pyarrow`)"
+        ) from exc
+    return pa
+
+
+# The extension type is created and registered once, on first access, so that a
+# numpy-only install can import this module without pyarrow present.
+_EXT_TYPE = None
+_REGISTERED = False
+
+
+def _build_type():
+    """Define, instantiate, and register the pyarrow extension type.
+
+    Returns the singleton ``MortonIndexType`` instance, building it once and
+    caching it on the module. Splitting this out of import time is what keeps
+    pyarrow an optional dependency.
+    """
+    global _EXT_TYPE, _REGISTERED
+    if _EXT_TYPE is not None:
+        return _EXT_TYPE
+
+    pa = _require_pyarrow()
+
+    class MortonIndexExtArray(pa.ExtensionArray):
+        """Extension array whose ``.to_numpy()`` yields the packed words."""
+
+        def to_numpy(self, **kwargs):
+            kwargs.setdefault("zero_copy_only", False)
+            return self.storage.to_numpy(**kwargs)
+
+    class MortonIndexType(pa.ExtensionType):
+        """pyarrow extension type for ``morton_index`` packed words.
+
+        Storage is ``int64`` (the raw packed Morton words, verbatim); the
+        ``morton_index`` identity rides along as the extension name so it
+        survives IPC / parquet serialization. Carries no parameters, so its
+        serialized form is empty.
+        """
+
+        def __init__(self):
+            super().__init__(pa.int64(), EXTENSION_NAME)
+
+        def __arrow_ext_serialize__(self):
+            # No parameters to carry; the extension name is the whole identity.
+            return b""
+
+        @classmethod
+        def __arrow_ext_deserialize__(cls, storage_type, serialized):
+            return cls()
+
+        def __arrow_ext_class__(self):
+            return MortonIndexExtArray
+
+        def to_pandas_dtype(self):
+            """The matching pandas ExtensionDtype (``morton_index``)."""
+            from .morton_index import MortonIndexDtype
+
+            return MortonIndexDtype()
+
+    inst = MortonIndexType()
+    if not _REGISTERED:
+        try:
+            pa.register_extension_type(inst)
+        except pa.ArrowKeyError:
+            # Already registered (e.g. a prior build in the same interpreter).
+            pass
+        _REGISTERED = True
+    _EXT_TYPE = inst
+    return _EXT_TYPE
+
+
+def morton_index_type():
+    """Return the (registered) ``morton_index`` pyarrow extension type."""
+    return _build_type()
+
+
+def from_morton_index(array):
+    """Wrap a :class:`~mortie.morton_index.MortonIndexArray` as an Arrow array.
+
+    Builds a pyarrow ``ExtensionArray`` of the ``morton_index`` type over the
+    same ``int64`` words (zero-copy from the backing numpy storage where
+    pyarrow allows). ``array`` may also be a raw ``int64`` array-like of words.
+    """
+    pa = _require_pyarrow()
+    ext_type = _build_type()
+    data = getattr(array, "_data", array)
+    storage = pa.array(np.asarray(data, dtype=np.int64), type=pa.int64())
+    return pa.ExtensionArray.from_storage(ext_type, storage)
+
+
+def to_morton_index(array):
+    """Convert an Arrow ``morton_index`` array back to a ``MortonIndexArray``.
+
+    Accepts the extension array (or its plain ``int64`` storage) and returns the
+    pandas-side :class:`~mortie.morton_index.MortonIndexArray` over the same
+    words.
+    """
+    _require_pyarrow()
+    from .morton_index import MortonIndexArray
+
+    storage = getattr(array, "storage", array)
+    words = storage.to_numpy(zero_copy_only=False).astype(np.int64, copy=False)
+    return MortonIndexArray(words)
+
+
+def __getattr__(name):
+    """Lazily expose the extension type / array classes.
+
+    Building the type touches pyarrow, so it is deferred until the names are
+    actually requested (module import stays numpy-only).
+    """
+    if name in ("MortonIndexType", "MortonIndexExtArray"):
+        inst = _build_type()
+        if name == "MortonIndexType":
+            return type(inst)
+        return inst.__arrow_ext_class__()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# Register the extension type eagerly *iff* pyarrow is already importable, so a
+# parquet read of a previously-written file resolves the ``morton_index``
+# extension name without the user first touching the type. A numpy-only
+# environment skips this silently (the type still builds on demand).
+try:
+    import pyarrow as _pa  # noqa: F401
+
+    _build_type()
+except ImportError:
+    pass

--- a/mortie/arrow.py
+++ b/mortie/arrow.py
@@ -7,7 +7,7 @@ This is the Arrow-interop sibling of the pandas ExtensionArray in
 (``src_rust/src/decimal_morton.rs``); this module only wraps them so the same
 words can travel through an Arrow array and survive a parquet round-trip with
 their ``morton_index`` identity attached as extension metadata. Storage is the
-raw ``int64`` words verbatim (zero-copy over the kernel's bit layout), the same
+raw ``int64`` words verbatim (over the kernel's bit layout), the same
 unsigned-Z-order convention as the pandas skin.
 
 pyarrow is an **optional** dependency exactly like pandas: importing ``mortie``
@@ -120,8 +120,8 @@ def from_morton_index(array):
     """Wrap a :class:`~mortie.morton_index.MortonIndexArray` as an Arrow array.
 
     Builds a pyarrow ``ExtensionArray`` of the ``morton_index`` type over the
-    same ``int64`` words (zero-copy from the backing numpy storage where
-    pyarrow allows). ``array`` may also be a raw ``int64`` array-like of words.
+    same ``int64`` words. ``array`` may also be a raw ``int64`` array-like of
+    words.
     """
     pa = _require_pyarrow()
     ext_type = _build_type()

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -4,9 +4,10 @@ The ``morton_index`` datatype: a pandas ExtensionArray skin over the packed
 
 The kernel lives in Rust (``src_rust/src/decimal_morton.rs``); this module is the
 user-facing surface. Storage is raw ``int64`` packed words (zero-copy over the
-kernel's bit layout ``[4-bit prefix | 54-bit body | 6-bit suffix]``), so a raw
-``int64`` sort is the Z-order curve and comparisons/sort fall straight out of the
-underlying integers. Domain operations (``coarsen``/``order``/``base_cell``) and
+kernel's bit layout ``[4-bit prefix | 54-bit body | 6-bit suffix]``). The Z-order
+is the *unsigned* word order -- base cells 8..=11 (prefix 9..=12) set the i64
+sign bit, so comparisons and sort operate on the ``uint64`` view of the words to
+preserve spatial locality. Domain operations (``coarsen``/``order``/``base_cell``) and
 the ``(nested, depth)`` <-> word bridge delegate to the vectorized Rust
 bindings; **no arithmetic operators** are defined (raw arithmetic on packed
 words is meaningless).
@@ -143,8 +144,26 @@ def _build_classes():
             return cls(words.astype(np.int64, copy=False))
 
         @classmethod
+        def _coerce_words(cls, scalars):
+            """Map a sequence of words / NA markers to an int64 array.
+
+            Missing markers (``pd.NA``/``None``/``NaN``) become the all-zero
+            empty sentinel so pandas' NA-bearing construction/assignment paths
+            round-trip through :meth:`isna`.
+            """
+            sentinel = int(cls._SENTINEL)
+            out = [
+                sentinel if (v is None or v is pd.NA or v != v) else int(v)
+                for v in scalars
+            ]
+            return np.asarray(out, dtype=np.int64)
+
+        @classmethod
         def _from_sequence(cls, scalars, *, dtype=None, copy=False):
-            return cls(np.asarray(scalars, dtype=np.int64), copy=copy)
+            arr = np.asarray(scalars)
+            if arr.dtype == object or arr.dtype.kind == "f":
+                return cls(cls._coerce_words(scalars))
+            return cls(arr.astype(np.int64, copy=False), copy=copy)
 
         @classmethod
         def _from_factorized(cls, values, original):
@@ -168,6 +187,17 @@ def _build_classes():
         def __setitem__(self, key, value):
             if isinstance(value, type(self)):
                 value = value._data
+            elif np.isscalar(value) or value is None or value is pd.NA:
+                # accept the dtype's NA value (-> empty sentinel)
+                value = (
+                    int(self._SENTINEL)
+                    if (value is None or value is pd.NA or value != value)
+                    else int(value)
+                )
+                self._data[key] = value
+                return
+            else:
+                value = self._coerce_words(value)
             self._data[key] = np.asarray(value, dtype=np.int64)
 
         @property
@@ -196,20 +226,28 @@ def _build_classes():
             return cls(np.concatenate([a._data for a in to_concat]))
 
         def _values_for_argsort(self):
-            # Raw int64 *is* the Z-order, so sorting on it sorts spatially.
-            return self._data
+            # The Z-order is the *unsigned* word order: base cells 8..=11 set the
+            # i64 sign bit (prefix 9..=12), so we sort on the uint64 view to keep
+            # the spatial locality the kernel guarantees.
+            return self._data.view(np.uint64)
 
         def _values_for_factorize(self):
             return self._data, int(self._SENTINEL)
 
-        # -- comparisons (raw int64 == Z-order) -----------------------------
+        # -- comparisons -----------------------------------------------------
+        # Ordering uses the *unsigned* word so it matches the raw-sort Z-order
+        # across the sign-bit boundary (prefix >= 8 sets i64's sign bit);
+        # equality is bit-identity either way.
 
         def _cmp(self, other, op):
             if isinstance(other, type(self)):
                 other = other._data
             elif isinstance(other, (list, np.ndarray)):
                 other = np.asarray(other, dtype=np.int64)
-            return op(self._data, other)
+            else:
+                # scalar
+                other = np.int64(other)
+            return op(self._data.view(np.uint64), np.asarray(other).view(np.uint64))
 
         def __eq__(self, other):
             import operator

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -1,0 +1,349 @@
+"""
+The ``morton_index`` datatype: a pandas ExtensionArray skin over the packed
+64-bit decimal-Morton MOC kernel (issue #35, phase 5).
+
+The kernel lives in Rust (``src_rust/src/decimal_morton.rs``); this module is the
+user-facing surface. Storage is raw ``int64`` packed words (zero-copy over the
+kernel's bit layout ``[4-bit prefix | 54-bit body | 6-bit suffix]``), so a raw
+``int64`` sort is the Z-order curve and comparisons/sort fall straight out of the
+underlying integers. Domain operations (``coarsen``/``order``/``base_cell``) and
+the ``(nested, depth)`` <-> word bridge delegate to the vectorized Rust
+bindings; **no arithmetic operators** are defined (raw arithmetic on packed
+words is meaningless).
+
+pandas is an **optional** dependency: importing ``mortie`` succeeds with only
+numpy installed. The pandas machinery here is built lazily on first use, and a
+clear ``ImportError`` is raised if the ExtensionArray is touched without pandas.
+"""
+
+import numpy as np
+
+from . import _rustie
+
+# ``MortonIndexDtype`` / ``MortonIndexArray`` are provided via module-level
+# ``__getattr__`` (built lazily so a numpy-only install can import this module),
+# so they are intentionally not named in ``__all__`` here.
+__all__ = []
+
+# HEALPix orders this datatype reaches (0 = base cell, 29 = max resolution).
+MAX_ORDER = 29
+
+
+def _require_pandas():
+    """Import pandas lazily, raising a clear error if it is absent.
+
+    pandas is an optional extra (the only hard runtime dep is numpy), so the
+    ExtensionArray classes are built on top of whatever pandas provides at
+    call time rather than at module import.
+    """
+    try:
+        import pandas as pd
+    except ImportError as exc:  # pragma: no cover - exercised via message only
+        raise ImportError(
+            "the morton_index ExtensionArray requires pandas; install it with "
+            "`pip install mortie[pandas]` (or `pip install pandas`)"
+        ) from exc
+    return pd
+
+
+# The dtype / array classes are created once, on first access, so that a
+# numpy-only install can import this module without pandas present.
+_DTYPE = None
+_ARRAY = None
+
+
+def _build_classes():
+    """Define and register the pandas ExtensionDtype / ExtensionArray.
+
+    Returns the ``(dtype_cls, array_cls)`` pair, building them once and caching
+    on the module. Splitting this out of import time is what keeps pandas an
+    optional dependency.
+    """
+    global _DTYPE, _ARRAY
+    if _DTYPE is not None:
+        return _DTYPE, _ARRAY
+
+    pd = _require_pandas()
+    from pandas.api.extensions import (
+        ExtensionArray,
+        ExtensionDtype,
+        register_extension_dtype,
+    )
+
+    @register_extension_dtype
+    class MortonIndexDtype(ExtensionDtype):
+        """pandas dtype registered as ``"morton_index"``.
+
+        Backed by ``int64`` storage (the raw packed Morton words). The missing
+        value is ``pd.NA``, stored as the kernel's all-zero empty sentinel.
+        """
+
+        name = "morton_index"
+        type = np.int64
+        kind = "i"
+        na_value = pd.NA
+        _is_numeric = False
+
+        @classmethod
+        def construct_array_type(cls):
+            return MortonIndexArray
+
+    class MortonIndexArray(ExtensionArray):
+        """An array of packed 64-bit ``morton_index`` MOC words.
+
+        Construct from raw words with the constructor, or from a HEALPix NESTED
+        index via :meth:`from_nested` / a lat/lon via :meth:`from_latlon`.
+        Comparisons and sorting use the raw ``int64`` (the Z-order); the domain
+        methods :meth:`coarsen`, :meth:`orders`/:meth:`order`,
+        :meth:`base_cells`/:meth:`base_cell` and :meth:`is_fixed_order` delegate
+        to the vectorized Rust bindings. No arithmetic operators are defined.
+        """
+
+        # The all-zero word is the kernel's empty/null sentinel (prefix 0).
+        _SENTINEL = np.int64(0)
+
+        def __init__(self, values, copy=False):
+            arr = np.asarray(values, dtype=np.int64)
+            if arr.ndim != 1:
+                raise ValueError("morton_index values must be 1-dimensional")
+            self._data = arr.copy() if copy else arr
+
+        # -- construction ----------------------------------------------------
+
+        @classmethod
+        def from_nested(cls, nested, depth):
+            """Pack HEALPix NESTED ids at ``depth`` into ``morton_index`` words.
+
+            ``nested`` is an array-like of NESTED cell ids; ``depth`` is the
+            scalar HEALPix order they were hashed at.
+            """
+            nested = np.ascontiguousarray(np.asarray(nested), dtype=np.uint64)
+            words = _rustie.rust_mi_from_nested(nested, int(depth))
+            return cls(words.astype(np.int64, copy=False))
+
+        @classmethod
+        def from_words(cls, words, copy=False):
+            """Wrap an array of already-packed ``int64`` words."""
+            return cls(words, copy=copy)
+
+        @classmethod
+        def from_latlon(cls, lat, lon, order=MAX_ORDER):
+            """Hash lat/lon (degrees) to ``morton_index`` words at ``order``.
+
+            Routes through the Rust ``healpix`` bridge: lat/lon -> NESTED ids ->
+            packed words, so it matches the cross-library nested representation.
+            """
+            lat = np.ascontiguousarray(np.asarray(lat), dtype=np.float64)
+            lon = np.ascontiguousarray(np.asarray(lon), dtype=np.float64)
+            if lat.shape != lon.shape:
+                raise ValueError("lat and lon must have the same shape")
+            nested = _rustie.rust_ang2pix(int(order), lon, lat)
+            nested = np.ascontiguousarray(nested, dtype=np.uint64)
+            words = _rustie.rust_mi_from_nested(nested, int(order))
+            return cls(words.astype(np.int64, copy=False))
+
+        @classmethod
+        def _from_sequence(cls, scalars, *, dtype=None, copy=False):
+            return cls(np.asarray(scalars, dtype=np.int64), copy=copy)
+
+        @classmethod
+        def _from_factorized(cls, values, original):
+            return cls(values)
+
+        # -- required ExtensionArray surface --------------------------------
+
+        @property
+        def dtype(self):
+            return MortonIndexDtype()
+
+        def __len__(self):
+            return len(self._data)
+
+        def __getitem__(self, item):
+            result = self._data[item]
+            if np.isscalar(result) or isinstance(result, np.integer):
+                return np.int64(result)
+            return type(self)(result)
+
+        def __setitem__(self, key, value):
+            if isinstance(value, type(self)):
+                value = value._data
+            self._data[key] = np.asarray(value, dtype=np.int64)
+
+        @property
+        def nbytes(self):
+            return self._data.nbytes
+
+        def isna(self):
+            # The empty sentinel (all-zero word, prefix 0) is the missing value.
+            return self._data == self._SENTINEL
+
+        def copy(self):
+            return type(self)(self._data, copy=True)
+
+        def take(self, indices, *, allow_fill=False, fill_value=None):
+            from pandas.api.extensions import take
+
+            if allow_fill and (fill_value is None or fill_value is pd.NA):
+                fill_value = int(self._SENTINEL)
+            result = take(
+                self._data, indices, allow_fill=allow_fill, fill_value=fill_value
+            )
+            return type(self)(result)
+
+        @classmethod
+        def _concat_same_type(cls, to_concat):
+            return cls(np.concatenate([a._data for a in to_concat]))
+
+        def _values_for_argsort(self):
+            # Raw int64 *is* the Z-order, so sorting on it sorts spatially.
+            return self._data
+
+        def _values_for_factorize(self):
+            return self._data, int(self._SENTINEL)
+
+        # -- comparisons (raw int64 == Z-order) -----------------------------
+
+        def _cmp(self, other, op):
+            if isinstance(other, type(self)):
+                other = other._data
+            elif isinstance(other, (list, np.ndarray)):
+                other = np.asarray(other, dtype=np.int64)
+            return op(self._data, other)
+
+        def __eq__(self, other):
+            import operator
+
+            return self._cmp(other, operator.eq)
+
+        def __ne__(self, other):
+            import operator
+
+            return self._cmp(other, operator.ne)
+
+        def __lt__(self, other):
+            import operator
+
+            return self._cmp(other, operator.lt)
+
+        def __le__(self, other):
+            import operator
+
+            return self._cmp(other, operator.le)
+
+        def __gt__(self, other):
+            import operator
+
+            return self._cmp(other, operator.gt)
+
+        def __ge__(self, other):
+            import operator
+
+            return self._cmp(other, operator.ge)
+
+        # -- domain operations (delegate to the Rust kernel) ----------------
+
+        def orders(self):
+            """Per-element HEALPix order as a numpy ``uint8`` array."""
+            return _rustie.rust_mi_order_of(self._data)
+
+        def order(self):
+            """The single shared order, or raise if the array is mixed-order."""
+            if not self.is_fixed_order():
+                raise ValueError(
+                    "array holds mixed orders; use .orders() for the per-element "
+                    "orders or .coarsen(k) to cast to a fixed order"
+                )
+            return int(self.orders()[0]) if len(self) else None
+
+        def base_cells(self):
+            """Per-element HEALPix base cell (``0..=11``) as a numpy array.
+
+            Empty / invalid words map to ``255``.
+            """
+            return _rustie.rust_mi_base_cell_of(self._data)
+
+        def base_cell(self):
+            """The single shared base cell, or raise if the array is mixed."""
+            bases = self.base_cells()
+            if len(bases) == 0:
+                return None
+            if not np.all(bases == bases[0]):
+                raise ValueError(
+                    "array spans multiple base cells; use .base_cells() instead"
+                )
+            return int(bases[0])
+
+        def is_fixed_order(self):
+            """True if every element shares one HEALPix order (else mixed)."""
+            if len(self) == 0:
+                return True
+            ords = self.orders()
+            return bool(np.all(ords == ords[0]))
+
+        def coarsen(self, k):
+            """Coarsen every word to order ``k`` (a new array; suffix rewrite).
+
+            Elements already at or below order ``k`` are returned unchanged.
+            """
+            words = _rustie.rust_mi_coarsen(self._data, int(k))
+            return type(self)(words)
+
+        def to_nested(self):
+            """Return ``(nested ids, depths)`` numpy arrays via the kernel."""
+            return _rustie.rust_mi_to_nested(self._data)
+
+        # -- repr ------------------------------------------------------------
+
+        def _word_repr(self, word):
+            """Compact ``base/order`` label for one packed word."""
+            w = np.asarray([word], dtype=np.int64)
+            if word == int(self._SENTINEL):
+                return "<NA>"
+            base = int(_rustie.rust_mi_base_cell_of(w)[0])
+            order = int(_rustie.rust_mi_order_of(w)[0])
+            return f"base={base} order={order}"
+
+        def __repr__(self):
+            n = len(self)
+            if self.is_fixed_order():
+                order = "empty" if n == 0 else f"order={int(self.orders()[0])}"
+            else:
+                order = "order=mixed"
+            head = ", ".join(self._word_repr(w) for w in self._data[:3])
+            if n > 6:
+                tail = ", ".join(self._word_repr(w) for w in self._data[-3:])
+                body = f"{head}, ..., {tail}"
+            else:
+                body = ", ".join(self._word_repr(w) for w in self._data)
+            return f"MortonIndexArray([{body}], len={n}, {order})"
+
+        def _formatter(self, boxed=False):
+            return lambda w: self._word_repr(w)
+
+    _DTYPE, _ARRAY = MortonIndexDtype, MortonIndexArray
+    return _DTYPE, _ARRAY
+
+
+def __getattr__(name):
+    """Lazily expose ``MortonIndexDtype`` / ``MortonIndexArray``.
+
+    Building the classes touches pandas, so it is deferred until the names are
+    actually requested (module import stays numpy-only).
+    """
+    if name in ("MortonIndexDtype", "MortonIndexArray"):
+        dtype_cls, array_cls = _build_classes()
+        return dtype_cls if name == "MortonIndexDtype" else array_cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# Register the dtype eagerly *iff* pandas is already importable, so that
+# ``pd.Series(dtype="morton_index")`` resolves the registered name without the
+# user first touching the classes. A numpy-only environment skips this silently
+# (the classes still build on demand via __getattr__, raising a clear error).
+try:
+    import pandas as _pd  # noqa: F401
+
+    _build_classes()
+except ImportError:
+    pass

--- a/mortie/tests/test_arrow.py
+++ b/mortie/tests/test_arrow.py
@@ -129,8 +129,9 @@ class TestOptionalExtra:
         assert hasattr(marrow, "morton_index_type")
 
     def test_clear_error_without_pyarrow(self, monkeypatch):
-        # Simulate pyarrow being absent: reload mortie.arrow with the real import
-        # machinery blocking pyarrow, then assert the helper raises a clear error.
+        # Simulate pyarrow being absent: re-import mortie.arrow with the real
+        # import machinery blocking pyarrow, then assert the helper raises a
+        # clear error.
         import builtins
 
         real_import = builtins.__import__
@@ -150,6 +151,11 @@ class TestOptionalExtra:
         with pytest.raises(ImportError, match="requires pyarrow"):
             fresh.morton_index_type()
 
-        # Restore a clean module for subsequent tests.
+        # ``monkeypatch.undo()`` restores both the real ``__import__`` and the
+        # ORIGINAL ``mortie.arrow`` module object that ``delitem`` saved above
+        # (the one already consistent with pyarrow's process-global extension
+        # registry). We deliberately do NOT reload the module: a reload would
+        # build a fresh ``MortonIndexType`` class that can't re-register (the
+        # name is already taken), desyncing the module from the registry. The
+        # transient pyarrow-less ``fresh`` copy is simply discarded by undo.
         monkeypatch.undo()
-        importlib.reload(importlib.import_module("mortie.arrow"))

--- a/mortie/tests/test_arrow.py
+++ b/mortie/tests/test_arrow.py
@@ -1,0 +1,155 @@
+"""
+Tests for the ``morton_index`` pyarrow ExtensionType (issue #35, phase 4).
+
+These pin the Arrow-interop skin in ``mortie/arrow.py``: round-tripping the
+pandas ``MortonIndexArray`` <-> the pyarrow ExtensionType <-> parquet, with the
+``morton_index`` extension identity surviving serialization, plus the optional-
+extra contract (numpy-only / pandas-only import still works; a clear error is
+raised when pyarrow is genuinely absent).
+"""
+
+import importlib
+import sys
+
+import numpy as np
+import pytest
+
+import mortie  # noqa: F401  (registers the morton_index pyarrow extension type)
+from mortie import _rustie
+
+pa = pytest.importorskip("pyarrow")
+import pyarrow.parquet as pq  # noqa: E402
+
+from mortie import arrow as marrow  # noqa: E402
+
+EXT_NAME = "mortie.morton_index"
+
+
+def _sample_words(n=8, order=12):
+    """A spread of packed words across base cells / both hemispheres."""
+    bases = np.arange(n, dtype=np.uint64) % 12
+    nested = bases * (1 << (2 * order)) + np.arange(n, dtype=np.uint64)
+    return _rustie.rust_mi_from_nested(
+        np.ascontiguousarray(nested), order
+    ).astype(np.int64)
+
+
+# ---------------------------------------------------------------------------
+# Extension-type surface
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionType:
+    def test_type_is_int64_extension(self):
+        t = marrow.morton_index_type()
+        assert isinstance(t, pa.ExtensionType)
+        assert t.storage_type == pa.int64()
+        assert t.extension_name == EXT_NAME
+
+    def test_serialize_is_empty(self):
+        t = marrow.morton_index_type()
+        assert t.__arrow_ext_serialize__() == b""
+
+    def test_registered_name_resolves(self):
+        # Building the type registers it; an array of that type reports it back.
+        words = _sample_words()
+        arr = marrow.from_morton_index(words)
+        assert arr.type.extension_name == EXT_NAME
+
+
+# ---------------------------------------------------------------------------
+# Conversion round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestConversion:
+    def test_from_raw_words_preserves_bits(self):
+        words = _sample_words()
+        arr = marrow.from_morton_index(words)
+        np.testing.assert_array_equal(arr.to_numpy(), words)
+
+    def test_extension_array_to_pandas(self):
+        words = _sample_words()
+        mia = marrow.to_morton_index(marrow.from_morton_index(words))
+        np.testing.assert_array_equal(np.asarray(mia._data), words)
+        assert mia.dtype.name == "morton_index"
+
+    def test_pandas_extension_array_round_trip(self):
+        pd = pytest.importorskip("pandas")  # noqa: F841
+        mia = mortie.MortonIndexArray(_sample_words())
+        arr = marrow.from_morton_index(mia)
+        back = marrow.to_morton_index(arr)
+        np.testing.assert_array_equal(back._data, mia._data)
+
+    def test_to_pandas_dtype_matches(self):
+        t = marrow.morton_index_type()
+        assert t.to_pandas_dtype().name == "morton_index"
+
+
+# ---------------------------------------------------------------------------
+# Parquet serialization (metadata survives the round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestParquet:
+    def test_parquet_preserves_extension_type(self, tmp_path):
+        words = _sample_words()
+        table = pa.table({"mi": marrow.from_morton_index(words)})
+        assert table.schema.field("mi").type.extension_name == EXT_NAME
+
+        path = tmp_path / "mi.parquet"
+        pq.write_table(table, path)
+        read = pq.read_table(path)
+
+        col_type = read.schema.field("mi").type
+        assert isinstance(col_type, pa.ExtensionType)
+        assert col_type.extension_name == EXT_NAME
+        np.testing.assert_array_equal(read.column("mi").chunk(0).to_numpy(), words)
+
+    def test_parquet_words_round_trip_to_pandas(self, tmp_path):
+        words = _sample_words()
+        path = tmp_path / "mi.parquet"
+        pq.write_table(pa.table({"mi": marrow.from_morton_index(words)}), path)
+        col = pq.read_table(path).column("mi").chunk(0)
+        mia = marrow.to_morton_index(col)
+        np.testing.assert_array_equal(mia._data, words)
+
+
+# ---------------------------------------------------------------------------
+# Optional-extra contract
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalExtra:
+    def test_arrow_module_imports_numpy_only(self):
+        # mortie.arrow must import even with neither pandas nor pyarrow; here we
+        # only assert the module object and its public helpers exist.
+        assert hasattr(marrow, "from_morton_index")
+        assert hasattr(marrow, "to_morton_index")
+        assert hasattr(marrow, "morton_index_type")
+
+    def test_clear_error_without_pyarrow(self, monkeypatch):
+        # Simulate pyarrow being absent: reload mortie.arrow with the real import
+        # machinery blocking pyarrow, then assert the helper raises a clear error.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked(name, *args, **kwargs):
+            if name == "pyarrow" or name.startswith("pyarrow."):
+                raise ImportError("blocked for test")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.delitem(sys.modules, "mortie.arrow", raising=False)
+        for mod in list(sys.modules):
+            if mod == "pyarrow" or mod.startswith("pyarrow."):
+                monkeypatch.delitem(sys.modules, mod, raising=False)
+        monkeypatch.setattr(builtins, "__import__", _blocked)
+
+        fresh = importlib.import_module("mortie.arrow")
+        with pytest.raises(ImportError, match="requires pyarrow"):
+            fresh.morton_index_type()
+
+        # Restore a clean module for subsequent tests.
+        monkeypatch.undo()
+        importlib.reload(importlib.import_module("mortie.arrow"))

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -1,0 +1,304 @@
+"""
+Tests for the ``morton_index`` pandas ExtensionArray (issue #35, phase 5).
+
+The packed-word kernel is exercised in Rust (``decimal_morton.rs`` unit tests);
+here we pin the Python skin: the vectorized Rust bindings, the ExtensionArray
+surface (construction, repr, comparisons/sort, domain ops), round-trips against
+the ``healpix`` crate (via the bindings) and an independent ``cdshealpix``
+oracle, and usability as a ``pd.Series(dtype="morton_index")``.
+"""
+
+import numpy as np
+import pytest
+
+import mortie
+from mortie import _rustie
+
+pd = pytest.importorskip("pandas")
+from mortie import MortonIndexArray as MIA  # noqa: E402
+
+MAX_ORDER = 29
+
+
+def _nested_from_tuples(base, tuples, order):
+    """Reference nested index from base cell + stored 0..=3 tuples."""
+    within = 0
+    for n in range(1, order + 1):
+        within |= (int(tuples[n - 1]) & 3) << (2 * (order - n))
+    return base * (1 << (2 * order)) + within
+
+
+def _sample_tuples(order, seed):
+    """Deterministic stored 0..=3 tuples (mirrors the Rust test helper)."""
+    return np.array(
+        [((seed * 2654435761 + i) % 4) for i in range(max(order, 1))],
+        dtype=np.uint8,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rust binding round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestNestedRoundTrip:
+    """from_nested / to_nested round-trips for all base cells / orders."""
+
+    def test_all_base_cells_all_orders(self):
+        for base in range(12):
+            for order in range(MAX_ORDER + 1):
+                tuples = _sample_tuples(order, base + 1)
+                nested = _nested_from_tuples(base, tuples, order)
+                arr = np.array([nested], dtype=np.uint64)
+                words = _rustie.rust_mi_from_nested(arr, order)
+                back, depth = _rustie.rust_mi_to_nested(words.astype(np.int64))
+                assert int(depth[0]) == order, (base, order)
+                assert int(back[0]) == nested, (base, order)
+
+    def test_both_hemispheres(self):
+        # base 0-3 northern, 4-7 equatorial, 8-11 southern; cover all bands.
+        bases = np.array([0, 3, 4, 7, 8, 11], dtype=np.uint64)
+        order = 12
+        nested = (bases << np.uint64(2 * order)) + np.uint64(123)
+        words = _rustie.rust_mi_from_nested(nested, order)
+        back, depth = _rustie.rust_mi_to_nested(words.astype(np.int64))
+        np.testing.assert_array_equal(back, nested)
+        np.testing.assert_array_equal(depth, np.full(len(bases), order))
+
+
+class TestVsCdshealpix:
+    """End-to-end against an independent HEALPix oracle (cdshealpix)."""
+
+    def test_latlon_matches_cdshealpix_nested(self):
+        cds = pytest.importorskip("cdshealpix")
+        import astropy.units as u
+        from cdshealpix.nested import lonlat_to_healpix
+
+        order = 14
+        lats = np.array([0.0, 41.8, -41.8, 80.0, -80.0, 12.3, -67.9])
+        lons = np.array([0.0, 45.0, 135.0, 200.0, 305.0, 91.5, 270.2])
+        a = MIA.from_latlon(lats, lons, order=order)
+        ours, depth = a.to_nested()
+        oracle = np.asarray(
+            lonlat_to_healpix(lons * u.deg, lats * u.deg, depth=order),
+            dtype=np.uint64,
+        )
+        np.testing.assert_array_equal(ours, oracle)
+        np.testing.assert_array_equal(depth, np.full(len(lats), order))
+
+
+# ---------------------------------------------------------------------------
+# coarsen / order / base_cell domain ops
+# ---------------------------------------------------------------------------
+
+
+class TestDomainOps:
+
+    def test_coarsen_vectorized_matches_kernel(self):
+        # Build an order-29 array, coarsen to each k, and compare to a
+        # re-encode at k built straight from the kernel binding.
+        base = 7
+        tuples = _sample_tuples(29, 99)
+        nested29 = _nested_from_tuples(base, tuples, 29)
+        a = MIA.from_nested(np.array([nested29], dtype=np.uint64), 29)
+        for k in range(MAX_ORDER + 1):
+            coarsened = a.coarsen(k)
+            expected = MIA.from_nested(
+                np.array([_nested_from_tuples(base, tuples, k)], dtype=np.uint64), k
+            )
+            np.testing.assert_array_equal(
+                coarsened._data, expected._data, err_msg=f"coarsen k={k}"
+            )
+
+    def test_coarsen_noop_when_k_ge_order(self):
+        a = MIA.from_nested(np.array([5, 6, 7], dtype=np.uint64), 3)
+        for k in (3, 5, 29):
+            np.testing.assert_array_equal(a.coarsen(k)._data, a._data)
+
+    def test_orders_and_base_cells(self):
+        nested = np.array(
+            [3 * (1 << (2 * 10)) + 5, 8 * (1 << (2 * 10)) + 9], dtype=np.uint64
+        )
+        a = MIA.from_nested(nested, 10)
+        np.testing.assert_array_equal(a.orders(), np.array([10, 10], dtype=np.uint8))
+        np.testing.assert_array_equal(
+            a.base_cells(), np.array([3, 8], dtype=np.uint8)
+        )
+
+    def test_is_fixed_order(self):
+        fixed = MIA.from_nested(np.array([5, 6, 7], dtype=np.uint64), 5)
+        assert fixed.is_fixed_order()
+        assert fixed.order() == 5
+        mixed = MIA.from_words(
+            np.concatenate(
+                [
+                    fixed._data,
+                    MIA.from_nested(np.array([3], dtype=np.uint64), 2)._data,
+                ]
+            )
+        )
+        assert not mixed.is_fixed_order()
+        with pytest.raises(ValueError):
+            mixed.order()
+
+    def test_base_cell_scalar_and_mixed(self):
+        same = MIA.from_nested(
+            np.array([5 + (4 << 20), 6 + (4 << 20)], dtype=np.uint64), 10
+        )
+        assert same.base_cell() == 4
+        multi = MIA.from_nested(
+            np.array([0 + (0 << 20), 0 + (5 << 20)], dtype=np.uint64), 10
+        )
+        with pytest.raises(ValueError):
+            multi.base_cell()
+
+    def test_empty_array_fixed_order(self):
+        empty = MIA(np.array([], dtype=np.int64))
+        assert empty.is_fixed_order()
+        assert empty.order() is None
+        assert empty.base_cell() is None
+
+
+# ---------------------------------------------------------------------------
+# raw int64 sort == Z-order, canonicalization
+# ---------------------------------------------------------------------------
+
+
+class TestSortAndCanonical:
+
+    def test_raw_sort_is_zorder(self):
+        # Parent sorts before its children, children already ascending.
+        base = 4
+        parent = MIA.from_nested(
+            np.array([_nested_from_tuples(base, [0, 0], 2)], dtype=np.uint64), 2
+        )._data[0]
+        children = MIA.from_nested(
+            np.array(
+                [_nested_from_tuples(base, [0, 0, c], 3) for c in range(4)],
+                dtype=np.uint64,
+            ),
+            3,
+        )._data
+        assert np.all(parent < children)
+        np.testing.assert_array_equal(children, np.sort(children))
+
+    def test_series_sort_matches_raw(self):
+        rng = np.random.default_rng(42)
+        nested = rng.integers(0, 12 * (1 << (2 * 8)), size=200, dtype=np.uint64)
+        a = MIA.from_nested(nested, 8)
+        s = pd.Series(a)
+        sorted_series = s.sort_values()
+        np.testing.assert_array_equal(
+            sorted_series.values._data, np.sort(a._data)
+        )
+
+    def test_canonical_zero_fill_dedups(self):
+        # Two nested indices that agree on the first 3 orders but differ in the
+        # discarded tail must coarsen to the same canonical word.
+        base = 2
+        t = [1, 2, 3]
+        n1 = _nested_from_tuples(base, t + [0, 0], 5)
+        n2 = _nested_from_tuples(base, t + [3, 1], 5)
+        a = MIA.from_nested(np.array([n1, n2], dtype=np.uint64), 5).coarsen(3)
+        assert a._data[0] == a._data[1]
+
+
+# ---------------------------------------------------------------------------
+# repr, comparisons, pandas integration
+# ---------------------------------------------------------------------------
+
+
+class TestReprAndPandas:
+
+    def test_repr_truncates(self):
+        a = MIA.from_nested(np.arange(20, dtype=np.uint64), 5)
+        r = repr(a)
+        assert "..." in r
+        assert "order=5" in r
+        assert "len=20" in r
+
+    def test_repr_mixed_order_label(self):
+        a = MIA.from_words(
+            np.concatenate(
+                [
+                    MIA.from_nested(np.array([5], dtype=np.uint64), 5)._data,
+                    MIA.from_nested(np.array([3], dtype=np.uint64), 2)._data,
+                ]
+            )
+        )
+        assert "order=mixed" in repr(a)
+
+    def test_comparisons(self):
+        a = MIA.from_nested(np.array([5, 6, 7], dtype=np.uint64), 5)
+        np.testing.assert_array_equal(a == a, np.array([True, True, True]))
+        np.testing.assert_array_equal(a < a._data + 1, np.array([True] * 3))
+        b = MIA.from_nested(np.array([5, 99, 7], dtype=np.uint64), 5)
+        assert list(a == b) == [True, False, True]
+
+    def test_no_arithmetic_operators(self):
+        a = MIA.from_nested(np.array([5, 6], dtype=np.uint64), 5)
+        # Arithmetic on packed words is meaningless and is not implemented.
+        with pytest.raises(TypeError):
+            a + a
+
+    def test_series_construction_by_name(self):
+        words = MIA.from_nested(np.array([5, 6, 7, 8], dtype=np.uint64), 3)._data
+        s = pd.Series(words.tolist(), dtype="morton_index")
+        assert str(s.dtype) == "morton_index"
+        assert len(s) == 4
+        # round-trips through the ExtensionArray
+        assert isinstance(s.values, MIA)
+        np.testing.assert_array_equal(s.values._data, words)
+
+    def test_na_sentinel(self):
+        a = MIA(np.array([0, 5], dtype=np.int64))
+        np.testing.assert_array_equal(a.isna(), np.array([True, False]))
+        assert a._word_repr(0) == "<NA>"
+
+    def test_take_with_fill(self):
+        a = MIA.from_nested(np.array([5, 6, 7], dtype=np.uint64), 5)
+        taken = a.take([0, -1], allow_fill=True)
+        assert taken.isna()[1]
+        assert taken._data[0] == a._data[0]
+
+    def test_concat_and_getitem(self):
+        a = MIA.from_nested(np.array([5, 6], dtype=np.uint64), 5)
+        b = MIA.from_nested(np.array([7], dtype=np.uint64), 5)
+        c = MIA._concat_same_type([a, b])
+        assert len(c) == 3
+        assert isinstance(c[0], np.int64)
+        assert isinstance(c[:2], MIA)
+
+
+# ---------------------------------------------------------------------------
+# encode / decode bindings
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeDecode:
+
+    def test_encode_decode_round_trip(self):
+        base_cells = np.array([0, 5, 11], dtype=np.uint8)
+        orders = np.array([3, 10, 29], dtype=np.uint8)
+        tuples = np.zeros((3, 29), dtype=np.uint8)
+        for i in range(3):
+            tuples[i, : orders[i]] = _sample_tuples(int(orders[i]), i + 1)[
+                : orders[i]
+            ]
+        words = _rustie.rust_mi_encode(base_cells, tuples, orders)
+        b2, o2, kinds, t2 = _rustie.rust_mi_decode(words.astype(np.int64))
+        np.testing.assert_array_equal(b2, base_cells)
+        np.testing.assert_array_equal(o2, orders)
+        np.testing.assert_array_equal(kinds, np.zeros(3, dtype=np.uint8))
+        for i in range(3):
+            np.testing.assert_array_equal(
+                t2[i, : orders[i]], tuples[i, : orders[i]]
+            )
+
+    def test_to_nested_rejects_empty(self):
+        with pytest.raises(ValueError):
+            _rustie.rust_mi_to_nested(np.array([0], dtype=np.int64))
+
+    def test_coarsen_rejects_empty(self):
+        with pytest.raises(ValueError):
+            _rustie.rust_mi_coarsen(np.array([0], dtype=np.int64), 3)

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -11,7 +11,7 @@ oracle, and usability as a ``pd.Series(dtype="morton_index")``.
 import numpy as np
 import pytest
 
-import mortie
+import mortie  # noqa: F401  (registers the "morton_index" pandas dtype on import)
 from mortie import _rustie
 
 pd = pytest.importorskip("pandas")
@@ -70,7 +70,7 @@ class TestVsCdshealpix:
     """End-to-end against an independent HEALPix oracle (cdshealpix)."""
 
     def test_latlon_matches_cdshealpix_nested(self):
-        cds = pytest.importorskip("cdshealpix")
+        pytest.importorskip("cdshealpix")
         import astropy.units as u
         from cdshealpix.nested import lonlat_to_healpix
 
@@ -182,15 +182,37 @@ class TestSortAndCanonical:
         assert np.all(parent < children)
         np.testing.assert_array_equal(children, np.sort(children))
 
-    def test_series_sort_matches_raw(self):
+    def test_series_sort_matches_unsigned_zorder(self):
         rng = np.random.default_rng(42)
         nested = rng.integers(0, 12 * (1 << (2 * 8)), size=200, dtype=np.uint64)
         a = MIA.from_nested(nested, 8)
         s = pd.Series(a)
         sorted_series = s.sort_values()
-        np.testing.assert_array_equal(
-            sorted_series.values._data, np.sort(a._data)
+        # Z-order is the *unsigned* word order (the kernel's u64 sort).
+        expected = np.sort(a._data.view(np.uint64)).view(np.int64)
+        np.testing.assert_array_equal(sorted_series.values._data, expected)
+
+    def test_sort_orders_southern_base_cells(self):
+        # Base cells 8-11 set the i64 sign bit (prefix 9-12), so a *signed* sort
+        # would invert them. The array must sort by ascending base cell because
+        # the unsigned word is the Z-order. (regression for the i64 sign-bit bug)
+        order = 5
+        nested = np.array(
+            [b * (1 << (2 * order)) + 1 for b in range(12)], dtype=np.uint64
         )
+        a = MIA.from_nested(nested, order)
+        s = pd.Series(a).sort_values()
+        np.testing.assert_array_equal(
+            s.values.base_cells(), np.arange(12, dtype=np.uint8)
+        )
+        # base 6 sorts before base 7 (both straddle the sign boundary region).
+        b6 = MIA.from_nested(np.array([6 << (2 * order)], dtype=np.uint64), order)
+        b7 = MIA.from_nested(np.array([7 << (2 * order)], dtype=np.uint64), order)
+        assert bool(b6 < b7._data[0])
+        # and a southern cell (base 11) sorts after a northern one (base 0).
+        b0 = MIA.from_nested(np.array([0 << (2 * order)], dtype=np.uint64), order)
+        b11 = MIA.from_nested(np.array([11 << (2 * order)], dtype=np.uint64), order)
+        assert bool(b0 < b11._data[0])
 
     def test_canonical_zero_fill_dedups(self):
         # Two nested indices that agree on the first 3 orders but differ in the
@@ -254,6 +276,24 @@ class TestReprAndPandas:
         a = MIA(np.array([0, 5], dtype=np.int64))
         np.testing.assert_array_equal(a.isna(), np.array([True, False]))
         assert a._word_repr(0) == "<NA>"
+
+    def test_setitem_accepts_na(self):
+        a = MIA.from_nested(np.array([5, 6, 7], dtype=np.uint64), 5)
+        a[1] = pd.NA
+        assert a.isna()[1]
+        a[2] = None
+        assert a.isna()[2]
+        # a real word still assigns
+        a[0] = int(a._data[0])
+        assert not a.isna()[0]
+
+    def test_from_sequence_accepts_na(self):
+        w = int(MIA.from_nested(np.array([5], dtype=np.uint64), 3)._data[0])
+        a = MIA._from_sequence([w, pd.NA, None])
+        np.testing.assert_array_equal(a.isna(), np.array([False, True, True]))
+        # Series with missing entries routes through _from_sequence
+        s = pd.Series([w, None], dtype="morton_index")
+        assert bool(s.isna().iloc[1])
 
     def test_take_with_fill(self):
         a = MIA.from_nested(np.array([5, 6, 7], dtype=np.uint64), 5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,17 @@ dependencies = [
 "Bug Tracker" = "https://github.com/espg/mortie/issues"
 
 [project.optional-dependencies]
+# pandas (and pyarrow, for the upcoming phase-4 Arrow skin) power the optional
+# morton_index ExtensionArray; they are NOT runtime deps (numpy stays the only
+# hard dependency) — see mortie/morton_index.py.
+pandas = [
+  "pandas>=2.0",
+]
 test = [
   "pytest>=8.0",
   "pytest-cov>=4.0",
   "cdshealpix>=0.7",  # independent HEALPix oracle for the hemisphere/#11 tests
+  "pandas>=2.0",      # exercise the morton_index ExtensionArray in CI
 ]
 bench = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,17 +27,21 @@ dependencies = [
 "Bug Tracker" = "https://github.com/espg/mortie/issues"
 
 [project.optional-dependencies]
-# pandas (and pyarrow, for the upcoming phase-4 Arrow skin) power the optional
-# morton_index ExtensionArray; they are NOT runtime deps (numpy stays the only
-# hard dependency) — see mortie/morton_index.py.
+# pandas and pyarrow power the optional morton_index ExtensionArray / Arrow
+# ExtensionType; they are NOT runtime deps (numpy stays the only hard
+# dependency) — see mortie/morton_index.py and mortie/arrow.py.
 pandas = [
   "pandas>=2.0",
+]
+pyarrow = [
+  "pyarrow>=14.0",
 ]
 test = [
   "pytest>=8.0",
   "pytest-cov>=4.0",
   "cdshealpix>=0.7",  # independent HEALPix oracle for the hemisphere/#11 tests
   "pandas>=2.0",      # exercise the morton_index ExtensionArray in CI
+  "pyarrow>=14.0",    # exercise the morton_index Arrow ExtensionType in CI
 ]
 bench = [
   "pytest",

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -864,6 +864,216 @@ fn rust_linestring_coverage(
     }
 }
 
+// ---------------------------------------------------------------------------
+// morton_index datatype bindings (issue #35, phase 5)
+//
+// Vectorized batch wrappers over the `decimal_morton` kernel. Storage is i64
+// (the signed presentation form); the raw bit pattern is the kernel's u64 word,
+// so every binding reinterprets `i64 <-> u64` with a bitwise `as` cast and the
+// raw-i64 sort still equals the raw-u64 Z-order (no valid base cell 0..=11 /
+// prefix 1..=12 sets the sign bit). These work with numpy only.
+// ---------------------------------------------------------------------------
+
+/// Vectorized `from_nested`: pack HEALPix NESTED ids at `depth` into
+/// `morton_index` words (i64 numpy array out).
+#[pyfunction]
+fn rust_mi_from_nested(
+    py: Python<'_>,
+    nested_array: PyReadonlyArray1<u64>,
+    depth: u8,
+) -> PyResult<PyObject> {
+    let nested = nested_array.to_vec()?;
+    let result = py.allow_threads(|| {
+        std::panic::catch_unwind(|| {
+            nested
+                .par_iter()
+                .map(|&n| decimal_morton::from_nested(n, depth) as i64)
+                .collect::<Vec<i64>>()
+        })
+    });
+    match result {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => Err(PyValueError::new_err(panic_msg(e))),
+    }
+}
+
+/// Vectorized `to_nested`: unpack `morton_index` words (i64) back into
+/// `(nested ids u64, depths u8)`. Raises `ValueError` if any word is the empty
+/// sentinel or carries an invalid prefix.
+#[pyfunction]
+fn rust_mi_to_nested(py: Python<'_>, morton_array: PyReadonlyArray1<i64>) -> PyResult<PyObject> {
+    let data = morton_array.to_vec()?;
+    let result: Result<(Vec<u64>, Vec<u8>), ()> = py.allow_threads(|| {
+        let mut nested = Vec::with_capacity(data.len());
+        let mut depths = Vec::with_capacity(data.len());
+        for &w in &data {
+            match decimal_morton::to_nested(w as u64) {
+                Some((depth, n)) => {
+                    nested.push(n);
+                    depths.push(depth);
+                }
+                None => return Err(()),
+            }
+        }
+        Ok((nested, depths))
+    });
+    match result {
+        Ok((nested, depths)) => {
+            let py_nested = nested.into_pyarray_bound(py).into_any().unbind();
+            let py_depths = depths.into_pyarray_bound(py).into_any().unbind();
+            let tuple = pyo3::types::PyTuple::new_bound(py, &[py_nested, py_depths]);
+            Ok(tuple.to_object(py))
+        }
+        Err(()) => Err(PyValueError::new_err(
+            "morton_index array contains an empty or invalid word",
+        )),
+    }
+}
+
+/// Vectorized `coarsen`: coarsen every `morton_index` word (i64) to order `k`.
+/// Raises `ValueError` if any word is empty or has an invalid prefix.
+#[pyfunction]
+fn rust_mi_coarsen(
+    py: Python<'_>,
+    morton_array: PyReadonlyArray1<i64>,
+    k: u8,
+) -> PyResult<PyObject> {
+    let data = morton_array.to_vec()?;
+    let result: Result<Vec<i64>, ()> = py.allow_threads(|| {
+        data.par_iter()
+            .map(|&w| {
+                decimal_morton::coarsen(w as u64, k)
+                    .map(|c| c as i64)
+                    .ok_or(())
+            })
+            .collect()
+    });
+    match result {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(()) => Err(PyValueError::new_err(
+            "morton_index array contains an empty or invalid word",
+        )),
+    }
+}
+
+/// Vectorized `order_of`: read the HEALPix order of every word (u8 array out).
+#[pyfunction]
+fn rust_mi_order_of(py: Python<'_>, morton_array: PyReadonlyArray1<i64>) -> PyResult<PyObject> {
+    let data = morton_array.to_vec()?;
+    let orders: Vec<u8> = py.allow_threads(|| {
+        data.par_iter()
+            .map(|&w| decimal_morton::order_of(w as u64))
+            .collect()
+    });
+    Ok(orders.into_pyarray_bound(py).into_any().unbind())
+}
+
+/// Vectorized `base_cell_of`: read the base cell `0..=11` of every word.
+/// The empty sentinel / invalid prefix maps to `255` (no valid base cell).
+#[pyfunction]
+fn rust_mi_base_cell_of(py: Python<'_>, morton_array: PyReadonlyArray1<i64>) -> PyResult<PyObject> {
+    let data = morton_array.to_vec()?;
+    let bases: Vec<u8> = py.allow_threads(|| {
+        data.par_iter()
+            .map(|&w| decimal_morton::base_cell_of(w as u64).unwrap_or(255))
+            .collect()
+    });
+    Ok(bases.into_pyarray_bound(py).into_any().unbind())
+}
+
+/// Vectorized `encode` from base cells, packed tuples and orders.
+///
+/// `tuples` is a flat `(n, 29)` row-major u8 array; row `i` holds the stored
+/// `0..=3` tuples for element `i` (only the first `orders[i]` entries are read).
+/// Returns the i64 `morton_index` words.
+#[pyfunction]
+fn rust_mi_encode(
+    py: Python<'_>,
+    base_cells: PyReadonlyArray1<u8>,
+    tuples: PyReadonlyArray2<u8>,
+    orders: PyReadonlyArray1<u8>,
+) -> PyResult<PyObject> {
+    let bases = base_cells.to_vec()?;
+    let orders = orders.to_vec()?;
+    let shape = tuples.shape();
+    let (n, ncols) = (shape[0], shape[1]);
+    if bases.len() != n || orders.len() != n {
+        return Err(PyValueError::new_err(
+            "base_cells, tuples and orders must share the same length",
+        ));
+    }
+    if ncols < decimal_morton::MAX_ORDER as usize {
+        return Err(PyValueError::new_err(
+            "tuples must have at least 29 columns",
+        ));
+    }
+    let flat = tuples.to_vec()?;
+    let result = py.allow_threads(|| {
+        std::panic::catch_unwind(|| {
+            (0..n)
+                .map(|i| {
+                    let row = &flat[i * ncols..i * ncols + ncols];
+                    decimal_morton::encode(bases[i], row, orders[i]) as i64
+                })
+                .collect::<Vec<i64>>()
+        })
+    });
+    match result {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => Err(PyValueError::new_err(panic_msg(e))),
+    }
+}
+
+/// Vectorized `decode`: unpack each word into its base cell, order, kind flag
+/// (0 = area, 1 = point) and its full tuple row.
+///
+/// Returns `(base_cells u8, orders u8, kinds u8, tuples (n,29) u8)`; tuple
+/// columns past an element's order are zero. Raises `ValueError` on any empty /
+/// invalid word.
+#[pyfunction]
+fn rust_mi_decode(py: Python<'_>, morton_array: PyReadonlyArray1<i64>) -> PyResult<PyObject> {
+    let data = morton_array.to_vec()?;
+    let n = data.len();
+    let ncols = decimal_morton::MAX_ORDER as usize;
+    type Decoded = (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>);
+    let result: Result<Decoded, String> = py.allow_threads(|| {
+        let mut bases = Vec::with_capacity(n);
+        let mut orders = Vec::with_capacity(n);
+        let mut kinds = Vec::with_capacity(n);
+        let mut flat = vec![0u8; n * ncols];
+        for (i, &w) in data.iter().enumerate() {
+            let dec = decimal_morton::decode(w as u64).map_err(|e| e.to_string())?;
+            bases.push(dec.base_cell);
+            orders.push(dec.order);
+            kinds.push(matches!(dec.kind, decimal_morton::Kind::Point) as u8);
+            for (j, &t) in dec.tuples.iter().enumerate() {
+                flat[i * ncols + j] = t;
+            }
+        }
+        Ok((bases, orders, kinds, flat))
+    });
+    match result {
+        Ok((bases, orders, kinds, flat)) => {
+            let arr = numpy::ndarray::Array2::from_shape_vec((n, ncols), flat)
+                .map_err(|e| PyValueError::new_err(format!("shape error: {}", e)))?;
+            let py_tuples = PyArray2::from_owned_array_bound(py, arr)
+                .into_any()
+                .unbind();
+            let out = pyo3::types::PyTuple::new_bound(
+                py,
+                &[
+                    bases.into_pyarray_bound(py).into_any().unbind(),
+                    orders.into_pyarray_bound(py).into_any().unbind(),
+                    kinds.into_pyarray_bound(py).into_any().unbind(),
+                    py_tuples,
+                ],
+            );
+            Ok(out.to_object(py))
+        }
+        Err(msg) => Err(PyValueError::new_err(msg)),
+    }
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -884,5 +1094,12 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_moc_normalize, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_to_order, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_from_nested, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_to_nested, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_coarsen, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_order_of, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_base_cell_of, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_encode, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_decode, m)?)?;
     Ok(())
 }

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -869,9 +869,11 @@ fn rust_linestring_coverage(
 //
 // Vectorized batch wrappers over the `decimal_morton` kernel. Storage is i64
 // (the signed presentation form); the raw bit pattern is the kernel's u64 word,
-// so every binding reinterprets `i64 <-> u64` with a bitwise `as` cast and the
-// raw-i64 sort still equals the raw-u64 Z-order (no valid base cell 0..=11 /
-// prefix 1..=12 sets the sign bit). These work with numpy only.
+// so every binding reinterprets `i64 <-> u64` with a bitwise `as` cast (the
+// bits are preserved exactly). The Z-order is the *unsigned* word order: base
+// cells 8..=11 (prefix 9..=12) set bit 63, so a signed sort would invert them
+// -- the Python skin sorts on the uint64 view to recover spatial locality.
+// These work with numpy only.
 // ---------------------------------------------------------------------------
 
 /// Vectorized `from_nested`: pack HEALPix NESTED ids at `depth` into


### PR DESCRIPTION
`Refs #35`

## What this does

The user-facing `morton_index` datatype skin over the existing Rust kernel (`src_rust/src/decimal_morton.rs`, landed in #43). The kernel was Rust-internal with no PyO3 binding; this PR adds the vectorized bindings, a pandas ExtensionArray, and a pyarrow ExtensionType on top, delivering the headline ask of the issue — a registered datatype you can hold in a `Series` and round-trip through parquet.

Honors the settled decisions on the issue thread: dtype registered as **`morton_index`** (the more-accurate name chosen on the thread); **operator scope = comparisons + sort + `coarsen`/`order`/`base_cell` domain ops only**, no arithmetic; **pandas ExtensionArray** + **pyarrow ExtensionType** now, NEP-42 numpy dtype deferred; pandas and pyarrow are **optional extras**, not runtime deps.

### Approach

1. **PyO3 batch bindings** (`src_rust/src/lib.rs`): seven vectorized `rust_mi_*` pyfunctions over numpy `int64`/`uint64` arrays wrapping the kernel — `rust_mi_from_nested`, `rust_mi_to_nested`, `rust_mi_coarsen`, `rust_mi_order_of`, `rust_mi_base_cell_of`, `rust_mi_encode`, `rust_mi_decode`. Each compute region is wrapped in `py.allow_threads`, mirroring the ~16 existing `rust_*` sites; they work with **numpy only**. Storage is `i64` and the kernel takes `u64`, so each reinterprets the bit pattern with an `as` cast (bits preserved exactly).

2. **pandas ExtensionArray** (`mortie/morton_index.py`): an `ExtensionDtype` + `ExtensionArray` registered as `&#34;morton_index&#34;`, backed by `int64` numpy storage (zero-copy over the raw words). Surface:
   - construction from raw words (`from_words` / constructor), from `(nested, depth)` (`from_nested`), and from lat/lon (`from_latlon`, via the Rust `ang2pix` → `from_nested` bridge).
   - comparisons and sort **on the unsigned (`uint64`) view** of the words (see Z-order note below).
   - domain methods `coarsen(k)`, `orders()`/`order()`, `base_cells()`/`base_cell()`, and the mixed-vs-fixed check `is_fixed_order()`.
   - truncated `__repr__` (`base= order=` per element, head/tail with `...` past 6, array-level `order=` / `order=mixed`).
   - the all-zero empty sentinel is the missing value (`isna`); NA-bearing construction/assignment (`_from_sequence`, `__setitem__`, `take`) map `pd.NA`/`None`/`NaN` to it.
   - **no arithmetic operators** (a `+` raises `TypeError`).

3. **pyarrow ExtensionType** (`mortie/arrow.py`, phase 4): a `pa.ExtensionType` over `int64` storage carrying the `morton_index` tag (extension name `mortie.morton_index`) so the identity rides through IPC / parquet and is reconstructed on read. Carries no parameters (empty `__arrow_ext_serialize__`). Helpers `morton_index_type()`, `from_morton_index(...)` (wraps a `MortonIndexArray` or raw `int64` words as a pyarrow `ExtensionArray`, zero-copy over the backing words where pyarrow allows) and `to_morton_index(...)` (back to the pandas `MortonIndexArray`); the type also exposes `to_pandas_dtype()` → `MortonIndexDtype`. Built and registered **lazily** on first use, same pattern as pandas.

4. **pandas and pyarrow are optional extras, NOT runtime deps** (CLAUDE.md §7: numpy is the only hard dep). `mortie/morton_index.py` and `mortie/arrow.py` both import fine numpy-only; pandas/pyarrow are imported lazily, the classes/type are built on first use, and a clear `ImportError` is raised if touched without them. dtype/extension-type are registered eagerly *iff* the optional lib is already importable (so `pd.Series(dtype=&#34;morton_index&#34;)` and a parquet read resolve the name), else skipped silently. Added `pandas` and `pyarrow` optional extras to `pyproject.toml` and folded both into the `test` extra so CI exercises the new tests. **See Questions for review (1).**

5. **Tests**:
   - `mortie/tests/test_morton_index.py` (26 tests): nested round-trips through the bindings for all 12 base cells / both hemispheres / orders 0–29; lat/lon end-to-end vs an independent `cdshealpix` oracle; `coarsen` vectorized == kernel re-encode; **unsigned** raw sort == Z-order incl. the southern base cells, and `Series.sort_values` == `np.sort(view(uint64))`; canonical zero-fill dedup; `__repr__` truncation + mixed-order label; `is_fixed_order`/`orders`/`base_cell`; `pd.Series(dtype=&#34;morton_index&#34;)` usability; NA `__setitem__`/`_from_sequence`; encode/decode round-trip; empty/invalid-word rejection.
   - `mortie/tests/test_arrow.py` (11 tests): extension-type surface (storage `int64`, name, empty serialize); raw-words/`MortonIndexArray` ↔ Arrow ↔ pandas conversion; **parquet** write/read with the `morton_index` extension type surviving serialization (schema + words); the optional-extra contract (`mortie.arrow` imports numpy-only; a clear `ImportError` is raised when pyarrow is genuinely absent).

### Z-order / sign-bit note (caught in self-review, fixed before review)

The base-cell prefix sits in bits 60–63, so prefix `&gt;= 8` (base cells **8–11**) sets bit 63 — i.e. those words are **negative** as `int64`. A *signed* sort therefore inverts the southern base cells, breaking the &#34;raw sort = Z-order&#34; property the issue calls paramount. The fix: all ordering (`_values_for_argsort`, `__lt__`/`__le__`/`__gt__`/`__ge__`) operates on the **`uint64` view** of the storage; equality is bit-identity either way. The data/bits are unchanged; only the comparison/sort key is unsigned. Regression test `test_sort_orders_southern_base_cells` pins it.

## Phases checklist

- [x] **Phase 5 — `morton_index` numpy/pandas ExtensionArray + PyO3 surface**
- [x] **Phase 4 — Arrow ExtensionType** (pure-Python pyarrow `ExtensionType` over `int64` storage carrying the `morton_index` tag; ↔ pandas ExtensionArray; parquet round-trip with metadata; pyarrow optional extra — no new Rust crate)
- [x] ~~Phase 3 — RangeMOC / `moc`-crate decision~~ — **resolved / split to #50**. Decision: **Option D** — in-house / `healpix`-crate BMOC, **no `moc` crate, no FITS**. The skin therefore needs **no RangeMOC bridge**; nothing to do here.

With phases 4 and 5 landed and phase 3 split out, the skin work in this PR is **complete**.

## How it was tested

Built and run in the worktree venv (`maturin develop --release`; pandas/pyarrow/cdshealpix present so the new tests run). Exact counts:

```
cargo test --lib            ->  144 passed; 0 failed
cargo bench --no-run        ->  compiles clean (all bench executables build)
cargo fmt --check           ->  clean on my added region; pre-existing tree-wide
                                drift left untouched (benches, sphere.rs,
                                coverage/tests.rs, existing lib.rs lines) — flagged below
cargo clippy --lib          ->  warnings only; my Rust bindings (phase 5) share the
                                same useless_conversion pattern as every existing
                                rust_* binding. Phase 4 adds NO Rust.
flake8 mortie --select=E9,F63,F7,F82  ->  clean (exit 0)
pytest -q                   ->  287 passed, 8 skipped, 2 warnings
  (test_morton_index.py: 26 passed; test_arrow.py: 11 passed)
```

The 8 skips are pre-existing/environmental (unchanged by this PR). Phase 4 is **pure Python** (no `.rs` files touched), so the cargo numbers are unchanged from phase 5.

## Questions for review

1. **pandas + pyarrow as optional extras vs runtime deps — confirmed by @espg.** Both are **optional** extras (`pandas` and `pyarrow` in `pyproject.toml`, both folded into `test` so CI runs the new tests); `mortie/morton_index.py` and `mortie/arrow.py` import them lazily and raise a clear `ImportError` if used without them; module + package import stay numpy-only. This keeps CLAUDE.md §7's &#34;numpy is the only runtime dependency&#34; intact. The pandas-optional pattern was confirmed on the thread; **pyarrow follows the same confirmed pattern**.

2. **`i64`/`u64` reinterpret + signed presentation.** Storage is the unsigned word verbatim (pandas and Arrow alike); signedness is repr-only as settled. If a future &#34;negative = southern&#34; *signed storage* form is adopted (not just repr), the casts and the unsigned sort/`isna` logic would need revisiting. Correct today.

3. **Pre-existing Rust drift left untouched.** `cargo fmt --check` / `cargo clippy` report findings across the tree (benches, `sphere.rs`, `coverage/tests.rs`, existing `lib.rs` lines) predating this PR. My phase-5 Rust is fmt-clean and follows the existing `rust_*` binding style; phase 4 adds no Rust. Left the pre-existing drift alone per the green-gate convention — flag if you'd like a separate cleanup pass.

4. **`from_latlon` order default + no point-encode.** Defaults to `order=29` and produces an *area* cell (not a `Kind::Point`); the kernel's point-encode path isn't surfaced in this skin yet. Say if you want a `points=True` path.

5. **Arrow ↔ pandas auto-conversion scope.** The Arrow skin provides explicit `from_morton_index` / `to_morton_index` helpers and `to_pandas_dtype()`; I did **not** wire pandas' `__from_arrow__` hook on the dtype (so `table.to_pandas()` yields plain int64, not a `morton_index` Series automatically). Explicit conversion keeps the two skins loosely coupled and the parquet metadata round-trip is fully covered. Say if you'd like the automatic `to_pandas()` path added.
