### PR TITLE
MOC set-algebra (union/intersection/difference) via sorted-range merge (phase 1 of #50)

### DIFF
--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -42,6 +42,9 @@ from .coverage import (
     morton_coverage_moc,
     compress_moc,
     moc_to_order,
+    moc_union,
+    moc_intersection,
+    moc_difference,
 )
 from .linestring import linestring_coverage
 
@@ -81,6 +84,9 @@ __all__ = [
     'morton_coverage_moc',
     'compress_moc',
     'moc_to_order',
+    'moc_union',
+    'moc_intersection',
+    'moc_difference',
     'linestring_coverage',
     'MortonChild',
     'split_children',

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -42,9 +42,9 @@ from .coverage import (
     morton_coverage_moc,
     compress_moc,
     moc_to_order,
-    moc_union,
-    moc_intersection,
-    moc_difference,
+    moc_or,
+    moc_and,
+    moc_minus,
 )
 from .linestring import linestring_coverage
 
@@ -84,9 +84,9 @@ __all__ = [
     'morton_coverage_moc',
     'compress_moc',
     'moc_to_order',
-    'moc_union',
-    'moc_intersection',
-    'moc_difference',
+    'moc_or',
+    'moc_and',
+    'moc_minus',
     'linestring_coverage',
     'MortonChild',
     'split_children',

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -256,14 +256,16 @@ def moc_to_order(morton, order):
     return np.asarray(_rustie.rust_moc_to_order(morton, order))
 
 
-def moc_union(a, b):
-    """Union of two morton sets as a canonical compact MOC.
+def moc_or(a, b):
+    """Set union (``or``) of two morton sets as a canonical compact MOC.
 
     Both inputs may be mixed-order morton sets.  Returns the set of cells
     covering either input, collapsed to the canonical compact form (complete
     sibling quartets merged into their parent, ancestor-covered descendants
     dropped) — equivalent to ``compress_moc(concatenate([a, b]))`` but computed
     as a single linear merge over the two sorted covers (issue #50).
+
+    Originally named ``moc_union``; this is the set *union* of the two covers.
 
     Parameters
     ----------
@@ -277,7 +279,7 @@ def moc_union(a, b):
 
     See Also
     --------
-    moc_intersection, moc_difference, compress_moc
+    moc_and, moc_minus, compress_moc
     """
     from . import _rustie
 
@@ -286,12 +288,15 @@ def moc_union(a, b):
     return np.asarray(_rustie.rust_moc_union(a, b))
 
 
-def moc_intersection(a, b):
-    """Intersection of two morton sets as a canonical compact MOC.
+def moc_and(a, b):
+    """Set intersection (``and``) of two morton sets as a canonical compact MOC.
 
     Returns the cells covered by *both* inputs (empty when disjoint).  Coarse /
     fine overlaps resolve to the finer cell; the result is compacted to the
     canonical form (issue #50).
+
+    Originally named ``moc_intersection``; this is the set *intersection* of the
+    two covers.
 
     Parameters
     ----------
@@ -305,7 +310,7 @@ def moc_intersection(a, b):
 
     See Also
     --------
-    moc_union, moc_difference
+    moc_or, moc_minus
     """
     from . import _rustie
 
@@ -314,12 +319,15 @@ def moc_intersection(a, b):
     return np.asarray(_rustie.rust_moc_intersection(a, b))
 
 
-def moc_difference(a, b):
-    """Difference ``a \\ b`` of two morton sets as a canonical compact MOC.
+def moc_minus(a, b):
+    """Set difference (``a`` minus ``b``) as a canonical compact MOC.
 
     Returns the cells of *a* not covered by *b*.  Where a coarse *a* cell is
     only partly covered by *b*, the uncovered part is emitted as finer cells;
     the result is compacted to the canonical form (issue #50).
+
+    Originally named ``moc_difference``; this is the set *difference* ``a \\ b``
+    (the part of *a* not covered by *b*).
 
     Parameters
     ----------
@@ -333,7 +341,7 @@ def moc_difference(a, b):
 
     See Also
     --------
-    moc_union, moc_intersection
+    moc_or, moc_and
     """
     from . import _rustie
 

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -254,3 +254,89 @@ def moc_to_order(morton, order):
 
     morton = np.asarray(morton, dtype=np.int64).ravel()
     return np.asarray(_rustie.rust_moc_to_order(morton, order))
+
+
+def moc_union(a, b):
+    """Union of two morton sets as a canonical compact MOC.
+
+    Both inputs may be mixed-order morton sets.  Returns the set of cells
+    covering either input, collapsed to the canonical compact form (complete
+    sibling quartets merged into their parent, ancestor-covered descendants
+    dropped) — equivalent to ``compress_moc(concatenate([a, b]))`` but computed
+    as a single linear merge over the two sorted covers (issue #50).
+
+    Parameters
+    ----------
+    a, b : array_like
+        Morton indices (mixed order allowed).
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted, compacted morton indices (``int64``).
+
+    See Also
+    --------
+    moc_intersection, moc_difference, compress_moc
+    """
+    from . import _rustie
+
+    a = np.asarray(a, dtype=np.int64).ravel()
+    b = np.asarray(b, dtype=np.int64).ravel()
+    return np.asarray(_rustie.rust_moc_union(a, b))
+
+
+def moc_intersection(a, b):
+    """Intersection of two morton sets as a canonical compact MOC.
+
+    Returns the cells covered by *both* inputs (empty when disjoint).  Coarse /
+    fine overlaps resolve to the finer cell; the result is compacted to the
+    canonical form (issue #50).
+
+    Parameters
+    ----------
+    a, b : array_like
+        Morton indices (mixed order allowed).
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted, compacted morton indices (``int64``).
+
+    See Also
+    --------
+    moc_union, moc_difference
+    """
+    from . import _rustie
+
+    a = np.asarray(a, dtype=np.int64).ravel()
+    b = np.asarray(b, dtype=np.int64).ravel()
+    return np.asarray(_rustie.rust_moc_intersection(a, b))
+
+
+def moc_difference(a, b):
+    """Difference ``a \\ b`` of two morton sets as a canonical compact MOC.
+
+    Returns the cells of *a* not covered by *b*.  Where a coarse *a* cell is
+    only partly covered by *b*, the uncovered part is emitted as finer cells;
+    the result is compacted to the canonical form (issue #50).
+
+    Parameters
+    ----------
+    a, b : array_like
+        Morton indices (mixed order allowed).
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted, compacted morton indices (``int64``).
+
+    See Also
+    --------
+    moc_union, moc_intersection
+    """
+    from . import _rustie
+
+    a = np.asarray(a, dtype=np.int64).ravel()
+    b = np.asarray(b, dtype=np.int64).ravel()
+    return np.asarray(_rustie.rust_moc_difference(a, b))

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -557,6 +557,113 @@ class TestCoverageMOCApi:
         flat = mortie.morton_coverage(self.SQ_LATS, self.SQ_LONS, order=8)
         assert len(mortie.moc_to_order(moc, 8)) == len(flat)
 
+
+class TestMOCSetOps:
+    """Boolean set-algebra over morton covers (issue #50, BMOC-backed)."""
+
+    # Two overlapping squares on the west coast and a disjoint one elsewhere.
+    A_LATS = [40.0, 40.0, 50.0, 50.0]
+    A_LONS = [-125.0, -115.0, -115.0, -125.0]
+    B_LATS = [45.0, 45.0, 55.0, 55.0]   # overlaps A in lat 45-50
+    B_LONS = [-120.0, -110.0, -110.0, -120.0]
+    C_LATS = [10.0, 10.0, 20.0, 20.0]   # disjoint (southern, other lon)
+    C_LONS = [30.0, 40.0, 40.0, 30.0]
+
+    ORDER = 8
+
+    def _flatset(self, moc):
+        return set(int(x) for x in mortie.moc_to_order(moc, self.ORDER))
+
+    def _cover(self, lats, lons):
+        return mortie.morton_coverage_moc(lats, lons, order=self.ORDER)
+
+    def test_union_equals_compress_concat(self):
+        # Bit-for-bit: moc_union(a, b) == compress_moc(concatenate(a, b)).
+        a = self._cover(self.A_LATS, self.A_LONS)
+        b = self._cover(self.B_LATS, self.B_LONS)
+        expect = mortie.compress_moc(np.concatenate([a, b]))
+        np.testing.assert_array_equal(mortie.moc_union(a, b), expect)
+
+    def test_union_covers_both(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        b = self._cover(self.B_LATS, self.B_LONS)
+        u = self._flatset(mortie.moc_union(a, b))
+        assert u == self._flatset(a) | self._flatset(b)
+
+    def test_intersection_brute_force(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        b = self._cover(self.B_LATS, self.B_LONS)
+        inter = self._flatset(mortie.moc_intersection(a, b))
+        assert inter == self._flatset(a) & self._flatset(b)
+        assert len(inter) > 0, "the two squares should overlap"
+
+    def test_difference_brute_force(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        b = self._cover(self.B_LATS, self.B_LONS)
+        diff = self._flatset(mortie.moc_difference(a, b))
+        assert diff == self._flatset(a) - self._flatset(b)
+
+    def test_disjoint_intersection_empty(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        c = self._cover(self.C_LATS, self.C_LONS)
+        assert len(mortie.moc_intersection(a, c)) == 0
+        # union of disjoint covers == compress of the concatenation
+        u = self._flatset(mortie.moc_union(a, c))
+        assert u == self._flatset(a) | self._flatset(c)
+
+    def test_difference_with_self_empty(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        assert len(mortie.moc_difference(a, a)) == 0
+
+    def test_mixed_order_inputs(self):
+        # a = a single coarse parent; b = two of its order-(p+1) children.
+        # Build via nested ids so the orders are explicit.
+        from mortie import _rustie
+        parent_nested, parent_depth = 3, 3
+        a = _rustie.rust_nested2mort(
+            np.array([parent_nested], dtype=np.uint64),
+            np.array([parent_depth], dtype=np.uint8),
+        )
+        child_ids = np.array([(parent_nested << 2) | 1, (parent_nested << 2) | 2],
+                             dtype=np.uint64)
+        b = _rustie.rust_nested2mort(child_ids,
+                                     np.array([4, 4], dtype=np.uint8))
+        order = 4
+        sa = set(int(x) for x in mortie.moc_to_order(a, order))
+        sb = set(int(x) for x in mortie.moc_to_order(b, order))
+        inter = set(int(x) for x in mortie.moc_to_order(
+            mortie.moc_intersection(a, b), order))
+        diff = set(int(x) for x in mortie.moc_to_order(
+            mortie.moc_difference(a, b), order))
+        assert inter == sa & sb
+        assert diff == sa - sb
+
+    def test_empty_inputs(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        empty = np.array([], dtype=np.int64)
+        np.testing.assert_array_equal(mortie.moc_union(a, empty),
+                                      mortie.compress_moc(a))
+        np.testing.assert_array_equal(mortie.moc_union(empty, a),
+                                      mortie.compress_moc(a))
+        assert len(mortie.moc_intersection(a, empty)) == 0
+        np.testing.assert_array_equal(mortie.moc_difference(a, empty),
+                                      mortie.compress_moc(a))
+        assert len(mortie.moc_difference(empty, a)) == 0
+        assert len(mortie.moc_union(empty, empty)) == 0
+
+    def test_southern_hemisphere(self):
+        slats = [-40.0, -40.0, -50.0, -50.0]
+        slons = [10.0, 20.0, 20.0, 10.0]
+        slats2 = [-45.0, -45.0, -55.0, -55.0]
+        slons2 = [15.0, 25.0, 25.0, 15.0]
+        a = self._cover(slats, slons)
+        b = self._cover(slats2, slons2)
+        assert all(int(x) < 0 for x in a), "southern cells are negative morton"
+        inter = self._flatset(mortie.moc_intersection(a, b))
+        assert inter == self._flatset(a) & self._flatset(b)
+        diff = self._flatset(mortie.moc_difference(a, b))
+        assert diff == self._flatset(a) - self._flatset(b)
+
     def test_multipart_mismatched_ring_count(self):
         with pytest.raises(ValueError):
             mortie.morton_coverage_moc([[0, 1, 2], [3, 4, 5]], [[0, 1, 2]], order=6)

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -578,42 +578,42 @@ class TestMOCSetOps:
         return mortie.morton_coverage_moc(lats, lons, order=self.ORDER)
 
     def test_union_equals_compress_concat(self):
-        # Bit-for-bit: moc_union(a, b) == compress_moc(concatenate(a, b)).
+        # Bit-for-bit: moc_or(a, b) == compress_moc(concatenate(a, b)).
         a = self._cover(self.A_LATS, self.A_LONS)
         b = self._cover(self.B_LATS, self.B_LONS)
         expect = mortie.compress_moc(np.concatenate([a, b]))
-        np.testing.assert_array_equal(mortie.moc_union(a, b), expect)
+        np.testing.assert_array_equal(mortie.moc_or(a, b), expect)
 
     def test_union_covers_both(self):
         a = self._cover(self.A_LATS, self.A_LONS)
         b = self._cover(self.B_LATS, self.B_LONS)
-        u = self._flatset(mortie.moc_union(a, b))
+        u = self._flatset(mortie.moc_or(a, b))
         assert u == self._flatset(a) | self._flatset(b)
 
     def test_intersection_brute_force(self):
         a = self._cover(self.A_LATS, self.A_LONS)
         b = self._cover(self.B_LATS, self.B_LONS)
-        inter = self._flatset(mortie.moc_intersection(a, b))
+        inter = self._flatset(mortie.moc_and(a, b))
         assert inter == self._flatset(a) & self._flatset(b)
         assert len(inter) > 0, "the two squares should overlap"
 
     def test_difference_brute_force(self):
         a = self._cover(self.A_LATS, self.A_LONS)
         b = self._cover(self.B_LATS, self.B_LONS)
-        diff = self._flatset(mortie.moc_difference(a, b))
+        diff = self._flatset(mortie.moc_minus(a, b))
         assert diff == self._flatset(a) - self._flatset(b)
 
     def test_disjoint_intersection_empty(self):
         a = self._cover(self.A_LATS, self.A_LONS)
         c = self._cover(self.C_LATS, self.C_LONS)
-        assert len(mortie.moc_intersection(a, c)) == 0
+        assert len(mortie.moc_and(a, c)) == 0
         # union of disjoint covers == compress of the concatenation
-        u = self._flatset(mortie.moc_union(a, c))
+        u = self._flatset(mortie.moc_or(a, c))
         assert u == self._flatset(a) | self._flatset(c)
 
     def test_difference_with_self_empty(self):
         a = self._cover(self.A_LATS, self.A_LONS)
-        assert len(mortie.moc_difference(a, a)) == 0
+        assert len(mortie.moc_minus(a, a)) == 0
 
     def test_mixed_order_inputs(self):
         # a = a single coarse parent; b = two of its order-(p+1) children.
@@ -632,24 +632,24 @@ class TestMOCSetOps:
         sa = set(int(x) for x in mortie.moc_to_order(a, order))
         sb = set(int(x) for x in mortie.moc_to_order(b, order))
         inter = set(int(x) for x in mortie.moc_to_order(
-            mortie.moc_intersection(a, b), order))
+            mortie.moc_and(a, b), order))
         diff = set(int(x) for x in mortie.moc_to_order(
-            mortie.moc_difference(a, b), order))
+            mortie.moc_minus(a, b), order))
         assert inter == sa & sb
         assert diff == sa - sb
 
     def test_empty_inputs(self):
         a = self._cover(self.A_LATS, self.A_LONS)
         empty = np.array([], dtype=np.int64)
-        np.testing.assert_array_equal(mortie.moc_union(a, empty),
+        np.testing.assert_array_equal(mortie.moc_or(a, empty),
                                       mortie.compress_moc(a))
-        np.testing.assert_array_equal(mortie.moc_union(empty, a),
+        np.testing.assert_array_equal(mortie.moc_or(empty, a),
                                       mortie.compress_moc(a))
-        assert len(mortie.moc_intersection(a, empty)) == 0
-        np.testing.assert_array_equal(mortie.moc_difference(a, empty),
+        assert len(mortie.moc_and(a, empty)) == 0
+        np.testing.assert_array_equal(mortie.moc_minus(a, empty),
                                       mortie.compress_moc(a))
-        assert len(mortie.moc_difference(empty, a)) == 0
-        assert len(mortie.moc_union(empty, empty)) == 0
+        assert len(mortie.moc_minus(empty, a)) == 0
+        assert len(mortie.moc_or(empty, empty)) == 0
 
     def test_southern_hemisphere(self):
         slats = [-40.0, -40.0, -50.0, -50.0]
@@ -659,9 +659,9 @@ class TestMOCSetOps:
         a = self._cover(slats, slons)
         b = self._cover(slats2, slons2)
         assert all(int(x) < 0 for x in a), "southern cells are negative morton"
-        inter = self._flatset(mortie.moc_intersection(a, b))
+        inter = self._flatset(mortie.moc_and(a, b))
         assert inter == self._flatset(a) & self._flatset(b)
-        diff = self._flatset(mortie.moc_difference(a, b))
+        diff = self._flatset(mortie.moc_minus(a, b))
         assert diff == self._flatset(a) - self._flatset(b)
 
     def test_multipart_mismatched_ring_count(self):

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -822,6 +822,51 @@ fn rust_moc_to_order(py: Python<'_>, morton: PyReadonlyArray1<i64>, order: u8) -
     Ok(densified.into_pyarray_bound(py).into_any().unbind())
 }
 
+/// Union of two (mixed-order) morton sets → canonical compact MOC.
+#[pyfunction]
+fn rust_moc_union(
+    py: Python<'_>,
+    a: PyReadonlyArray1<i64>,
+    b: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let (av, bv) = (a.to_vec()?, b.to_vec()?);
+    let result = py.allow_threads(|| std::panic::catch_unwind(|| moc::union(&av, &bv)));
+    match result {
+        Ok(cells) => Ok(cells.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => Err(PyValueError::new_err(panic_msg(e))),
+    }
+}
+
+/// Intersection of two (mixed-order) morton sets → canonical compact MOC.
+#[pyfunction]
+fn rust_moc_intersection(
+    py: Python<'_>,
+    a: PyReadonlyArray1<i64>,
+    b: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let (av, bv) = (a.to_vec()?, b.to_vec()?);
+    let result = py.allow_threads(|| std::panic::catch_unwind(|| moc::intersection(&av, &bv)));
+    match result {
+        Ok(cells) => Ok(cells.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => Err(PyValueError::new_err(panic_msg(e))),
+    }
+}
+
+/// Difference `a \ b` of two (mixed-order) morton sets → canonical compact MOC.
+#[pyfunction]
+fn rust_moc_difference(
+    py: Python<'_>,
+    a: PyReadonlyArray1<i64>,
+    b: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let (av, bv) = (a.to_vec()?, b.to_vec()?);
+    let result = py.allow_threads(|| std::panic::catch_unwind(|| moc::difference(&av, &bv)));
+    match result {
+        Ok(cells) => Ok(cells.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => Err(PyValueError::new_err(panic_msg(e))),
+    }
+}
+
 /// Compute morton indices tracing a linestring (open polyline).
 ///
 /// # Arguments
@@ -883,6 +928,9 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_multipolygon_coverage_moc, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_normalize, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_to_order, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_union, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_intersection, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_difference, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
     Ok(())
 }

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -629,7 +629,7 @@ mod tests {
             state ^= state << 17;
             state
         };
-        let mut gen_cover = |rng: &mut dyn FnMut() -> u64| -> Vec<i64> {
+        let gen_cover = |rng: &mut dyn FnMut() -> u64| -> Vec<i64> {
             let k = (rng() % 40) as usize + 1;
             (0..k)
                 .map(|_| {

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -126,6 +126,164 @@ pub fn normalize(morton: &[i64]) -> Vec<i64> {
     out
 }
 
+// ── boolean set-algebra (issue #50, Option D: no new dependency) ───────────
+//
+// Decision #50 is Option D: fast set-algebra with no new crate. We first tried
+// routing through the `healpix 0.3.2` BMOC (`or`/`and`/`minus`) we already
+// depend on — `or`/`and` work, but its `minus` hangs on mixed-order MOC inputs
+// (an upstream loop bug). Rather than ship a mix where two ops use BMOC and one
+// is in-house, all three are implemented in-house as the same single-pass
+// sorted-range linear merge that [`normalize`] already uses: map each cover to
+// disjoint half-open ranges on the uniform `MAX_DEPTH` grid, merge the two
+// sorted range streams, then decompose the result back into HEALPix-aligned
+// cells. O(n+m), deterministic, no second HEALPix crate.
+
+/// Map a morton set to its sorted, coalesced disjoint `[start, end)` ranges on
+/// the uniform `MAX_DEPTH` grid.
+///
+/// Runs through [`normalize`] first so the cells are a proper MOC (no overlap),
+/// then merges touching ranges into maximal runs — the canonical interval form
+/// the merges operate on.
+fn morton_to_ranges(morton: &[i64]) -> Vec<(u64, u64)> {
+    let cells = normalize(morton);
+    // normalize() returns cells sorted by signed-morton value, which is NOT the
+    // grid-range order (mixed depths and the southern-hemisphere sign flip break
+    // it), so sort the ranges explicitly before coalescing touching runs.
+    let mut ranges: Vec<(u64, u64)> = cells
+        .iter()
+        .map(|&m| {
+            let (n, d) = mort2nested(m);
+            cell_range(n, d)
+        })
+        .collect();
+    ranges.sort_unstable();
+    let mut merged: Vec<(u64, u64)> = Vec::with_capacity(ranges.len());
+    for (start, end) in ranges {
+        match merged.last_mut() {
+            Some(last) if last.1 == start => last.1 = end,
+            _ => merged.push((start, end)),
+        }
+    }
+    merged
+}
+
+/// Decompose disjoint sorted `[start, end)` ranges back into a canonical compact
+/// MOC (mixed-order morton, sorted).
+///
+/// Each range is greedily split into the largest HEALPix-aligned cells that fit
+/// (the standard range→MOC decomposition), then [`normalize`] collapses any
+/// complete sibling quartets that span adjacent ranges.
+fn ranges_to_morton(ranges: &[(u64, u64)]) -> Vec<i64> {
+    let mut cells: Vec<i64> = Vec::new();
+    for &(mut start, end) in ranges {
+        while start < end {
+            // Largest aligned cell at `start`: limited by start's alignment
+            // (trailing-zero pairs) and by the remaining span.
+            let align = if start == 0 {
+                MAX_DEPTH
+            } else {
+                (start.trailing_zeros() / 2).min(MAX_DEPTH as u32) as u8
+            };
+            let span = end - start;
+            // Largest power-of-four <= span caps the cell size too.
+            let span_levels = (63 - span.leading_zeros()) / 2;
+            let levels = (align as u32).min(span_levels) as u8;
+            let depth = MAX_DEPTH - levels;
+            let nested = start >> (2 * levels as u32);
+            cells.push(nested2mort(nested, depth));
+            start += 1u64 << (2 * levels as u32);
+        }
+    }
+    normalize(&cells)
+}
+
+/// Union of two morton sets → canonical compact MOC (range OR).
+///
+/// Equivalent to `normalize(concat(a, b))` but as a linear merge over the two
+/// sorted range streams.
+pub fn union(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let (ra, rb) = (morton_to_ranges(a), morton_to_ranges(b));
+    let mut out: Vec<(u64, u64)> = Vec::with_capacity(ra.len() + rb.len());
+    let push = |out: &mut Vec<(u64, u64)>, s: u64, e: u64| match out.last_mut() {
+        Some(last) if last.1 >= s => last.1 = last.1.max(e),
+        _ => out.push((s, e)),
+    };
+    let (mut i, mut j) = (0, 0);
+    while i < ra.len() && j < rb.len() {
+        if ra[i].0 <= rb[j].0 {
+            push(&mut out, ra[i].0, ra[i].1);
+            i += 1;
+        } else {
+            push(&mut out, rb[j].0, rb[j].1);
+            j += 1;
+        }
+    }
+    while i < ra.len() {
+        push(&mut out, ra[i].0, ra[i].1);
+        i += 1;
+    }
+    while j < rb.len() {
+        push(&mut out, rb[j].0, rb[j].1);
+        j += 1;
+    }
+    ranges_to_morton(&out)
+}
+
+/// Intersection of two morton sets → canonical compact MOC (range AND).
+///
+/// Returns the cells covered by both inputs (empty when disjoint).
+pub fn intersection(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let (ra, rb) = (morton_to_ranges(a), morton_to_ranges(b));
+    let mut out: Vec<(u64, u64)> = Vec::new();
+    let (mut i, mut j) = (0, 0);
+    while i < ra.len() && j < rb.len() {
+        let lo = ra[i].0.max(rb[j].0);
+        let hi = ra[i].1.min(rb[j].1);
+        if lo < hi {
+            out.push((lo, hi));
+        }
+        // Advance whichever range ends first.
+        if ra[i].1 < rb[j].1 {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    ranges_to_morton(&out)
+}
+
+/// Difference `a \ b` → canonical compact MOC (range subtraction).
+///
+/// Returns the part of `a` not covered by `b`.
+pub fn difference(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let (ra, rb) = (morton_to_ranges(a), morton_to_ranges(b));
+    let mut out: Vec<(u64, u64)> = Vec::new();
+    let mut j = 0;
+    for &(start, end) in &ra {
+        let mut cur = start;
+        // Carve out every `b` range overlapping [start, end).
+        while j < rb.len() && rb[j].1 <= cur {
+            j += 1;
+        }
+        let mut k = j;
+        while k < rb.len() && rb[k].0 < end {
+            let (bs, be) = rb[k];
+            if bs > cur {
+                out.push((cur, bs.min(end)));
+            }
+            cur = cur.max(be);
+            if cur >= end {
+                break;
+            }
+            k += 1;
+        }
+        if cur < end {
+            out.push((cur, end));
+        }
+    }
+    ranges_to_morton(&out)
+}
+
 // ── tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -321,6 +479,184 @@ mod tests {
                 continue;
             }
             assert_eq!(normalize(&cells), normalize_reference(&cells));
+        }
+    }
+
+    // ── set-op tests (issue #50) ────────────────────────────────────────────
+
+    /// Expand a morton set to the *set* of its descendant leaf cells at `order`
+    /// (every cell densified to `order`), as a `BTreeSet` of nested ids — the
+    /// independent ground truth for the set-ops. Every cell in the test inputs
+    /// is at depth <= `order`.
+    fn leaf_set(morton: &[i64], order: u8) -> std::collections::BTreeSet<u64> {
+        let mut s = std::collections::BTreeSet::new();
+        for &m in morton {
+            let (n, d) = mort2nested(m);
+            let shift = 2 * (order - d) as u32;
+            let base = n << shift;
+            for k in 0..(1u64 << shift) {
+                s.insert(base + k);
+            }
+        }
+        s
+    }
+
+    /// Densify a morton set and return its leaf-cell set at `order` (so a
+    /// mixed-order result is compared by the flat region it covers, independent
+    /// of how it is tiled).
+    fn covered_set(result: &[i64], order: u8) -> std::collections::BTreeSet<u64> {
+        leaf_set(result, order)
+    }
+
+    #[test]
+    fn test_union_equals_normalize_concat() {
+        // Bit-for-bit: union(a,b) must equal normalize(concat(a,b)).
+        let a: Vec<i64> = (0..6).map(|n| nested2mort(n, 4)).collect();
+        let b: Vec<i64> = (4..10).map(|n| nested2mort(n, 4)).collect();
+        let mut concat = a.clone();
+        concat.extend_from_slice(&b);
+        assert_eq!(union(&a, &b), normalize(&concat));
+    }
+
+    #[test]
+    fn test_intersection_brute_force() {
+        // Overlapping equatorial cells; intersection covers exactly the overlap.
+        let order = 6u8;
+        let a: Vec<i64> = (0..20).map(|n| nested2mort(n, order)).collect();
+        let b: Vec<i64> = (10..30).map(|n| nested2mort(n, order)).collect();
+        let got = intersection(&a, &b);
+        let expect: std::collections::BTreeSet<u64> = leaf_set(&a, order)
+            .intersection(&leaf_set(&b, order))
+            .copied()
+            .collect();
+        assert_eq!(covered_set(&got, order), expect);
+    }
+
+    #[test]
+    fn test_difference_brute_force() {
+        let order = 6u8;
+        let a: Vec<i64> = (0..20).map(|n| nested2mort(n, order)).collect();
+        let b: Vec<i64> = (10..30).map(|n| nested2mort(n, order)).collect();
+        let got = difference(&a, &b);
+        let expect: std::collections::BTreeSet<u64> = leaf_set(&a, order)
+            .difference(&leaf_set(&b, order))
+            .copied()
+            .collect();
+        assert_eq!(covered_set(&got, order), expect);
+    }
+
+    #[test]
+    fn test_mixed_order_inputs() {
+        // a holds a coarse parent (3@3); b holds two of its order-4 children.
+        // intersection = those two children; difference = the other two.
+        let order = 4u8;
+        let a = vec![nested2mort(3, 3)];
+        let b = vec![nested2mort((3 << 2) | 1, 4), nested2mort((3 << 2) | 2, 4)];
+        let inter = intersection(&a, &b);
+        assert_eq!(
+            covered_set(&inter, order),
+            leaf_set(&a, order)
+                .intersection(&leaf_set(&b, order))
+                .copied()
+                .collect()
+        );
+        let diff = difference(&a, &b);
+        assert_eq!(
+            covered_set(&diff, order),
+            leaf_set(&a, order)
+                .difference(&leaf_set(&b, order))
+                .copied()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn test_setops_empty_inputs() {
+        let a: Vec<i64> = (0..4).map(|n| nested2mort(n, 4)).collect();
+        // union with empty == normalize(a)
+        assert_eq!(union(&a, &[]), normalize(&a));
+        assert_eq!(union(&[], &a), normalize(&a));
+        // intersection with empty == empty
+        assert_eq!(intersection(&a, &[]), Vec::<i64>::new());
+        assert_eq!(intersection(&[], &a), Vec::<i64>::new());
+        // difference: a\∅ == normalize(a); ∅\a == ∅
+        assert_eq!(difference(&a, &[]), normalize(&a));
+        assert_eq!(difference(&[], &a), Vec::<i64>::new());
+        // both empty
+        assert_eq!(union(&[], &[]), Vec::<i64>::new());
+        assert_eq!(intersection(&[], &[]), Vec::<i64>::new());
+        assert_eq!(difference(&[], &[]), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn test_setops_both_hemispheres() {
+        // Northern (base 2) and southern (base 8) cells in the same covers.
+        let order = 5u8;
+        let nside_sq = 1u64 << (2 * order as u32);
+        let a: Vec<i64> = (0..8)
+            .map(|k| nested2mort(2 * nside_sq + k, order))
+            .chain((0..8).map(|k| nested2mort(8 * nside_sq + k, order)))
+            .collect();
+        let b: Vec<i64> = (4..12)
+            .map(|k| nested2mort(2 * nside_sq + k, order))
+            .chain((4..12).map(|k| nested2mort(8 * nside_sq + k, order)))
+            .collect();
+        for (got, op) in [
+            (union(&a, &b), 0u8),
+            (intersection(&a, &b), 1),
+            (difference(&a, &b), 2),
+        ] {
+            let (sa, sb) = (leaf_set(&a, order), leaf_set(&b, order));
+            let expect: std::collections::BTreeSet<u64> = match op {
+                0 => sa.union(&sb).copied().collect(),
+                1 => sa.intersection(&sb).copied().collect(),
+                _ => sa.difference(&sb).copied().collect(),
+            };
+            assert_eq!(covered_set(&got, order), expect);
+        }
+    }
+
+    #[test]
+    fn test_setops_match_brute_force_random() {
+        // Random mixed-order covers over a shallow common depth; each op is
+        // checked against the leaf-set ground truth (densify both sides, do the
+        // set-op on leaf ids). order kept small so densification is cheap.
+        let order = 7u8;
+        let mut state = 0x243f6a8885a308d3u64;
+        let mut rng = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        let mut gen_cover = |rng: &mut dyn FnMut() -> u64| -> Vec<i64> {
+            let k = (rng() % 40) as usize + 1;
+            (0..k)
+                .map(|_| {
+                    let depth = (rng() % order as u64) as u8 + 1;
+                    let nside_sq = 1u64 << (2 * depth as u32);
+                    let base = rng() % 12;
+                    nested2mort(base * nside_sq + rng() % nside_sq, depth)
+                })
+                .collect()
+        };
+        for _ in 0..200 {
+            let a = gen_cover(&mut rng);
+            let b = gen_cover(&mut rng);
+            let (sa, sb) = (leaf_set(&a, order), leaf_set(&b, order));
+
+            let u_expect: std::collections::BTreeSet<u64> = sa.union(&sb).copied().collect();
+            assert_eq!(covered_set(&union(&a, &b), order), u_expect);
+            // union must also equal normalize(concat) bit-for-bit.
+            let mut concat = a.clone();
+            concat.extend_from_slice(&b);
+            assert_eq!(union(&a, &b), normalize(&concat));
+
+            let i_expect: std::collections::BTreeSet<u64> = sa.intersection(&sb).copied().collect();
+            assert_eq!(covered_set(&intersection(&a, &b), order), i_expect);
+
+            let d_expect: std::collections::BTreeSet<u64> = sa.difference(&sb).copied().collect();
+            assert_eq!(covered_set(&difference(&a, &b), order), d_expect);
         }
     }
 }


### PR DESCRIPTION
`Refs #50`

Implements the Option D decision from #50: fast boolean set-algebra over mortie's morton-index `i64` covers with **no new crate dependency** (no `moc`, no `cdshealpix`, no second HEALPix implementation, no FITS/IVOA serialization).

## What this adds

Three set operations over two mixed-order morton-cell arrays (the existing public MOC representation `moc.rs` operates on — signed decimal morton, order ≤ 18):

- `union(a, b)` — cells covering either input (equivalent to `compress_moc(concat(a, b))`).
- `intersection(a, b)` — cells covered by both (empty when disjoint).
- `difference(a, b)` — cells of `a` not covered by `b`.

Each returns a canonical compact MOC (sorted mixed-order `int64`).

**Rust** (`src_rust/src/moc.rs`): `pub fn union/intersection/difference(a: &[i64], b: &[i64]) -> Vec<i64>`.
**Python bindings** (`src_rust/src/lib.rs`): `rust_moc_union`, `rust_moc_intersection`, `rust_moc_difference` (numpy `i64` in/out, compute wrapped in `py.allow_threads`, mirroring the existing `rust_moc_normalize` style).
**Python API** (`mortie/coverage.py`, exported from `mortie/__init__.py`): `moc_union`, `moc_intersection`, `moc_difference` — thin wrappers mirroring `compress_moc` / `moc_to_order`.

Before, mortie could only union via Python `np.union1d` + `compress_moc`; there was no Rust intersection/difference.

## Backing path taken: in-house sorted-range merge (not BMOC)

The issue allows either the `healpix 0.3.2` BMOC ops *if public and usable*, or an in-house sorted-range merge. I inspected the crate (`~/.cargo/registry/.../healpix-0.3.2/src/bmoc/`) and **first wired the ops onto BMOC** `Bmoc::or`/`and`/`minus` (all public, packed-`u64` cell lists, z-order merges). `or` and `and` worked and passed parity tests, but **`minus` hangs (infinite loop) on mixed-order MOC inputs** — reproduced deterministically with two normalized polygon covers (190 and 182 cells); `union`/`intersection` returned instantly, `difference` never terminated. That makes the BMOC path only *partially* usable.

Rather than ship a fragile mix (two ops on BMOC, one in-house), I implemented **all three in-house** as the same single-pass sorted-range linear merge that the existing `moc::normalize` already uses:

1. `morton_to_ranges` — `normalize` the cover, map each cell to its half-open `[start, end)` range on the uniform `MAX_DEPTH=18` grid, sort by range, coalesce touching runs (note: `normalize` returns morton sorted by *signed* value, which is **not** grid-range order once depths mix or the southern sign flips, so the ranges are re-sorted explicitly — this was a bug in the first cut, now covered by tests).
2. Linear merge of the two sorted disjoint range lists (OR / AND / subtraction), all O(n+m).
3. `ranges_to_morton` — greedy largest-aligned-cell decomposition of each result range, then `normalize` to collapse quartets spanning adjacent ranges.

Signed-morton handling stays at the boundary (`mort2nested` decode → range op → `nested2mort` re-encode), as the existing code does. This is still Option D: no new dependency, no second HEALPix crate.

## Phases

- [x] **Phase 1** — `union`/`intersection`/`difference` over morton covers (Rust + numpy bindings + Python wrappers + tests). **Done.**
- [ ] **Phase 2 (proposed, not done)** — swap `normalize` onto a range/`pack`-style fast path if it's a clean win. Deferred per the issue's guidance to propose rather than do; `normalize` is unchanged here.

## How tested (real counts)

- `cargo test` (full): **151 passed, 0 failed**. New `moc::tests`: `test_union_equals_normalize_concat` (bit-for-bit `union == normalize(concat)`), `test_intersection_brute_force` / `test_difference_brute_force` (vs leaf-set expansion at the deepest order, the pattern `normalize`'s reference test uses), `test_mixed_order_inputs`, `test_setops_empty_inputs`, `test_setops_both_hemispheres`, and `test_setops_match_brute_force_random` (200 random mixed-order cover pairs, all three ops checked against the densified leaf-set ground truth + `union == normalize(concat)`).
- `cargo bench --no-run`: **clean** (`Finished bench profile`, 5m38s). No bench call sites changed (no bench references `moc::`).
- `cargo clippy --lib`: **moc.rs clean**. lib.rs shows only the pre-existing tree-wide `useless_conversion` warning (the `?`-on-`to_vec()` idiom every binding in the file already uses); my additions mirror it — see Questions for review.
- `cargo fmt --check`: **moc.rs and my lib.rs additions clean**. Pre-existing fmt drift in unrelated files (`benches/*`, `buffer.rs`, `cell_geom.rs`, `coverage/tests.rs`, `decimal_morton.rs`, `sphere.rs`, and earlier lib.rs lines) left untouched — see Questions for review.
- `flake8 mortie --select=E9,F63,F7,F82`: **clean** (exit 0).
- `pytest -v` (full suite): **259 passed, 8 skipped, 2 warnings** (warnings pre-existing: a pytest class-fixture deprecation). New Python `TestMOCSetOps` (13 tests): union==compress(concat) bit-for-bit, brute-force intersection/difference vs flat sets via `moc_to_order`, disjoint covers, self-difference empty, mixed-order, empty inputs, southern hemisphere.

## Questions for review

1. **Public API signatures** — Rust `union/intersection/difference(a: &[i64], b: &[i64]) -> Vec<i64>`; Python `moc_union(a, b)`, `moc_intersection(a, b)`, `moc_difference(a, b)` returning sorted compact `int64`. Naming mirrors `compress_moc`/`moc_to_order`. Happy to rename (e.g. `moc_or`/`moc_and`/`moc_minus`) if you prefer the BMOC verbs.
2. **Backing path** — I chose the in-house range merge over BMOC because the crate's `minus` hangs on mixed-order input. If you'd rather use BMOC `or`/`and` for those two and only do `minus` in-house, say so — but I think one uniform code path is more maintainable. (No `not`/`xor` exposed; not requested.)
3. **Signed-morton edge cases** — ops never produce order-0 cells from order≥1 inputs (range decomposition can't merge across base-cell boundaries since those align to `4^18`); both hemispheres covered by tests. The southern sign flip is why `morton_to_ranges` re-sorts by grid range rather than trusting `normalize`'s morton order.
4. **Pre-existing lint/fmt drift** — left the tree-wide `useless_conversion` clippy warnings and `rustfmt` drift in files I didn't change, per "don't fix unrelated CI noise." Flagging in case you want a separate cleanup pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_011s41CmMVwHT9TsKyjrRS8W)_