### PR TITLE
MOC boolean set algebra via the patched healpix BMOC fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src_rust/src/lib.rs"
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 numpy = "0.22"
 rayon = "1.10"
-healpix = "0.3.2"
+healpix = { git = "https://github.com/espg/healpix-rs", rev = "9118d3834b6c2a8860dc7a375d46df2d51516df9" }
 smallvec = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src_rust/src/lib.rs"
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 numpy = "0.22"
 rayon = "1.10"
-healpix = { git = "https://github.com/espg/healpix-rs", rev = "9118d3834b6c2a8860dc7a375d46df2d51516df9" }
+healpix = "0.3.3"
 smallvec = "1"
 
 [dev-dependencies]

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -42,6 +42,9 @@ from .coverage import (
     morton_coverage_moc,
     compress_moc,
     moc_to_order,
+    moc_or,
+    moc_and,
+    moc_minus,
 )
 from .linestring import linestring_coverage
 
@@ -81,6 +84,9 @@ __all__ = [
     'morton_coverage_moc',
     'compress_moc',
     'moc_to_order',
+    'moc_or',
+    'moc_and',
+    'moc_minus',
     'linestring_coverage',
     'MortonChild',
     'split_children',

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -254,3 +254,84 @@ def moc_to_order(morton, order):
 
     morton = np.asarray(morton, dtype=np.int64).ravel()
     return np.asarray(_rustie.rust_moc_to_order(morton, order))
+
+
+def moc_or(a, b):
+    """Union of two morton covers (the cells in ``a`` or ``b``).
+
+    Equivalent to ``compress_moc(concatenate([a, b]))``, but computed by the
+    healpix-crate BMOC ``or`` rather than a concatenate-then-compress pass.
+
+    Parameters
+    ----------
+    a, b : array_like
+        Morton covers (mixed order allowed).
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted, compacted union (``int64``).
+
+    See Also
+    --------
+    moc_and : intersection of two covers.
+    moc_minus : difference ``a \\ b``.
+    compress_moc : ``moc_or(a, b) == compress_moc(concatenate([a, b]))``.
+    """
+    from . import _rustie
+
+    a = np.asarray(a, dtype=np.int64).ravel()
+    b = np.asarray(b, dtype=np.int64).ravel()
+    return np.asarray(_rustie.rust_moc_or(a, b))
+
+
+def moc_and(a, b):
+    """Intersection of two morton covers (the cells in both ``a`` and ``b``).
+
+    Parameters
+    ----------
+    a, b : array_like
+        Morton covers (mixed order allowed).
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted, compacted intersection (``int64``).
+
+    See Also
+    --------
+    moc_or : union of two covers.
+    moc_minus : difference ``a \\ b``.
+    """
+    from . import _rustie
+
+    a = np.asarray(a, dtype=np.int64).ravel()
+    b = np.asarray(b, dtype=np.int64).ravel()
+    return np.asarray(_rustie.rust_moc_and(a, b))
+
+
+def moc_minus(a, b):
+    """Difference of two morton covers (the cells in ``a`` but not ``b``).
+
+    Computes ``a \\ b``.
+
+    Parameters
+    ----------
+    a, b : array_like
+        Morton covers (mixed order allowed).
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted, compacted difference (``int64``).
+
+    See Also
+    --------
+    moc_or : union of two covers.
+    moc_and : intersection of two covers.
+    """
+    from . import _rustie
+
+    a = np.asarray(a, dtype=np.int64).ravel()
+    b = np.asarray(b, dtype=np.int64).ravel()
+    return np.asarray(_rustie.rust_moc_minus(a, b))

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -574,3 +574,99 @@ class TestCoverageMOCApi:
         lo = [-125.0, -115.0, -115.0, -125.0, -125.0]
         cov = mortie.morton_coverage_moc(la, lo, order=8)
         assert len(cov) > 0
+
+
+class TestMOCSetOps:
+    """BMOC-backed boolean set algebra: moc_or / moc_and / moc_minus (issue #50).
+
+    `and`/`minus` are checked against a brute-force reference computed by
+    densifying both covers to a common deep order with `moc_to_order`, doing the
+    set op on the flat leaf sets, then re-compressing with `compress_moc`.
+    """
+
+    # Two overlapping mid-latitude squares, plus a disjoint southern square.
+    A_LATS = [40.0, 40.0, 50.0, 50.0]
+    A_LONS = [-125.0, -115.0, -115.0, -125.0]
+    B_LATS = [45.0, 45.0, 55.0, 55.0]
+    B_LONS = [-120.0, -110.0, -110.0, -120.0]
+    S_LATS = [-50.0, -50.0, -40.0, -40.0]
+    S_LONS = [10.0, 20.0, 20.0, 10.0]
+
+    def _cover(self, lats, lons, order=8):
+        return mortie.morton_coverage_moc(lats, lons, order=order)
+
+    def _ref(self, a, b, order, op):
+        la = set(int(x) for x in mortie.moc_to_order(a, order))
+        lb = set(int(x) for x in mortie.moc_to_order(b, order))
+        leaves = sorted(op(la, lb))
+        if not leaves:
+            return set()
+        comp = mortie.compress_moc(np.asarray(leaves, dtype=np.int64))
+        return set(int(x) for x in comp)
+
+    def test_or_equals_compress_concat(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        b = self._cover(self.B_LATS, self.B_LONS)
+        got = mortie.moc_or(a, b)
+        concat = np.concatenate([np.asarray(a), np.asarray(b)])
+        np.testing.assert_array_equal(got, mortie.compress_moc(concat))
+
+    def test_and_brute_force(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        b = self._cover(self.B_LATS, self.B_LONS)
+        got = set(int(x) for x in mortie.moc_and(a, b))
+        assert got == self._ref(a, b, 8, lambda x, y: x & y)
+        assert len(got) > 0, "the squares overlap, intersection must be non-empty"
+
+    def test_minus_brute_force(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        b = self._cover(self.B_LATS, self.B_LONS)
+        got = set(int(x) for x in mortie.moc_minus(a, b))
+        assert got == self._ref(a, b, 8, lambda x, y: x - y)
+
+    def test_disjoint(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        s = self._cover(self.S_LATS, self.S_LONS)
+        # disjoint: and empty, minus is a, or is the union of both
+        assert len(mortie.moc_and(a, s)) == 0
+        np.testing.assert_array_equal(mortie.moc_minus(a, s), mortie.compress_moc(a))
+        concat = np.concatenate([np.asarray(a), np.asarray(s)])
+        np.testing.assert_array_equal(mortie.moc_or(a, s), mortie.compress_moc(concat))
+
+    def test_self_minus_empty(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        assert len(mortie.moc_minus(a, a)) == 0
+        # self-and / self-or are idempotent (== compressed self)
+        np.testing.assert_array_equal(mortie.moc_and(a, a), mortie.compress_moc(a))
+        np.testing.assert_array_equal(mortie.moc_or(a, a), mortie.compress_moc(a))
+
+    def test_mixed_order(self):
+        # a finer cover (order 9) against a coarser one (order 6) of the same box.
+        a = self._cover(self.A_LATS, self.A_LONS, order=9)
+        b = self._cover(self.A_LATS, self.A_LONS, order=6)
+        # densify to the deeper order for the reference
+        got_and = set(int(x) for x in mortie.moc_and(a, b))
+        assert got_and == self._ref(a, b, 9, lambda x, y: x & y)
+        got_minus = set(int(x) for x in mortie.moc_minus(a, b))
+        assert got_minus == self._ref(a, b, 9, lambda x, y: x - y)
+
+    def test_empty(self):
+        a = self._cover(self.A_LATS, self.A_LONS)
+        empty = np.array([], dtype=np.int64)
+        np.testing.assert_array_equal(mortie.moc_or(a, empty), mortie.compress_moc(a))
+        np.testing.assert_array_equal(mortie.moc_or(empty, a), mortie.compress_moc(a))
+        assert len(mortie.moc_and(a, empty)) == 0
+        np.testing.assert_array_equal(mortie.moc_minus(a, empty), mortie.compress_moc(a))
+        assert len(mortie.moc_minus(empty, a)) == 0
+
+    def test_southern_hemisphere(self):
+        # Two overlapping southern boxes → negative morton; must round-trip.
+        b_lats = [-50.0, -50.0, -42.0, -42.0]
+        b_lons = [15.0, 25.0, 25.0, 15.0]
+        a = self._cover(self.S_LATS, self.S_LONS)
+        b = self._cover(b_lats, b_lons)
+        assert np.all(np.asarray(a) < 0), "southern cover must be all-negative"
+        got = set(int(x) for x in mortie.moc_and(a, b))
+        assert got == self._ref(a, b, 8, lambda x, y: x & y)
+        got_m = set(int(x) for x in mortie.moc_minus(a, b))
+        assert got_m == self._ref(a, b, 8, lambda x, y: x - y)

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -822,6 +822,42 @@ fn rust_moc_to_order(py: Python<'_>, morton: PyReadonlyArray1<i64>, order: u8) -
     Ok(densified.into_pyarray_bound(py).into_any().unbind())
 }
 
+/// Union (OR) of two morton covers, backed by the healpix-crate BMOC.
+#[pyfunction]
+fn rust_moc_or(
+    py: Python<'_>,
+    a: PyReadonlyArray1<i64>,
+    b: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let (da, db) = (a.to_vec()?, b.to_vec()?);
+    let out = py.allow_threads(|| moc::moc_or(&da, &db));
+    Ok(out.into_pyarray_bound(py).into_any().unbind())
+}
+
+/// Intersection (AND) of two morton covers, backed by the healpix-crate BMOC.
+#[pyfunction]
+fn rust_moc_and(
+    py: Python<'_>,
+    a: PyReadonlyArray1<i64>,
+    b: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let (da, db) = (a.to_vec()?, b.to_vec()?);
+    let out = py.allow_threads(|| moc::moc_and(&da, &db));
+    Ok(out.into_pyarray_bound(py).into_any().unbind())
+}
+
+/// Difference (`a \ b`) of two morton covers, backed by the healpix-crate BMOC.
+#[pyfunction]
+fn rust_moc_minus(
+    py: Python<'_>,
+    a: PyReadonlyArray1<i64>,
+    b: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let (da, db) = (a.to_vec()?, b.to_vec()?);
+    let out = py.allow_threads(|| moc::moc_minus(&da, &db));
+    Ok(out.into_pyarray_bound(py).into_any().unbind())
+}
+
 /// Compute morton indices tracing a linestring (open polyline).
 ///
 /// # Arguments
@@ -1095,6 +1131,9 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_multipolygon_coverage_moc, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_normalize, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_to_order, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_or, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_and, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_minus, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_from_nested, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_to_nested, m)?)?;

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -58,6 +58,10 @@ fn build_bmoc(morton: &[i64]) -> MutableBmoc {
 }
 
 /// Re-encode a BMOC's cells back to a normalized mortie morton cover.
+///
+/// Discarding each cell's full/partial flag is safe here: every cell mortie
+/// pushes is `is_full = true`, so the BMOC only ever emits full cells — the flag
+/// carries no information a `(hash, depth)` cover would lose.
 fn bmoc_to_morton(bmoc: MutableBmoc) -> Vec<i64> {
     let cells: Vec<i64> = bmoc
         .into_cells()
@@ -526,25 +530,36 @@ mod tests {
     /// whose finer cells are descendants of the other's coarse full cells.
     #[test]
     fn test_minus_mixed_order_terminates_regression() {
-        // a: depth-2 full cells (coarse) spanning two base cells.
-        let a: Vec<i64> = (0..3)
-            .map(|n| nested2mort(n, 2))
-            .chain((0..3).map(|n| nested2mort((4u64 << 4) + n, 2)))
+        // The hang is in `minus`'s `Greater` arm, which fires only when a *finer*
+        // LEFT (minuend) cell is a descendant of a coarser *full* RIGHT
+        // (subtrahend) cell — both `is_full`. So the minuend must be the FINER
+        // cover and the subtrahend the coarse full ancestor. (An earlier cut had
+        // the operands reversed, so only the always-advancing `Less`/`Equal` arms
+        // ran and the test would have passed on buggy 0.3.2 too.)
+        //
+        // minuend: scattered depth-5 + depth-3 cells inside base-cell-0's depth-1
+        // cell 0 (no complete quartets, so they stay finer than it through
+        // normalize), plus one depth-1 cell in base cell 5 so the result is
+        // non-empty.
+        let mut fine: Vec<i64> = [0u64, 5, 17, 42, 130]
+            .iter()
+            .map(|&n| nested2mort(n, 5))
             .collect();
-        // b: many depth-5 descendants of a's coarse cells (finer than a), mixed
-        // with a few coarser cells — the exact "finer-cell-inside-coarse-full"
-        // pattern that hung 0.3.2.
-        let mut b: Vec<i64> = Vec::new();
-        for n in 0..200u64 {
-            // descendants of cell 0@2
-            b.push(nested2mort(n, 5));
-        }
-        // a coarse cell shared with a
-        b.push(nested2mort(1, 2));
-        // If the fork fix is absent this loops forever; reaching the assert proves
-        // termination. Correctness is checked against the brute-force reference.
-        let got = moc_minus(&a, &b);
-        assert_eq!(got, ref_minus(&a, &b, 5));
+        fine.push(nested2mort(3, 3)); // depth-3 cell, also inside depth-1 cell 0
+        let outside = nested2mort((5u64 << 2) + 1, 1); // depth-1 cell in base cell 5
+        fine.push(outside);
+        // subtrahend: the coarse FULL depth-1 ancestor (base-cell-0 cell 0) of
+        // every "inside" cell above.
+        let coarse = vec![nested2mort(0, 1)];
+        // Minuend finer, subtrahend coarser-full => exercises the buggy `Greater`
+        // arm. On 0.3.2 this loops forever; reaching the assert proves the fork
+        // fix. Correctness is checked against the brute-force reference.
+        let got = moc_minus(&fine, &coarse);
+        assert_eq!(got, ref_minus(&fine, &coarse, 5));
+        assert!(
+            !got.is_empty(),
+            "the `outside` cell is not subtracted, so the result must be non-empty"
+        );
     }
 
     #[test]

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -16,12 +16,92 @@
 //! issue #28 bug).
 
 use crate::morton::{mort2nested, nested2mort};
+use healpix::bmoc::{Bmoc, MutableBmoc};
 
 /// Maximum HEALPix depth mortie supports (order 18 → 64-bit morton limit).
 /// Cells are mapped to half-open ranges over the uniform grid at this depth so a
 /// single sort linearizes ancestry: a coarser cell's range strictly contains its
 /// descendants'.
 const MAX_DEPTH: u8 = 18;
+
+// ── BMOC-backed boolean set algebra (issue #50, Option D) ──────────────────
+//
+// `moc_or`/`moc_and`/`moc_minus` are thin wrappers around the `healpix` crate's
+// BMOC `or`/`and`/`minus`.  A mortie cover is a `Vec<i64>` of signed decimal
+// morton indices at mixed orders; the BMOC works on `(depth, nested hash)`
+// pairs.  So each op follows the same decode → op → encode → normalize shape:
+//
+//   1. decode each morton i64 → `(depth, nested u64)` via `mort2nested`,
+//   2. build a `MutableBmoc` (packed/valid) per input,
+//   3. run the BMOC op,
+//   4. re-encode the result cells → morton i64 via `nested2mort`,
+//   5. `normalize` to mortie's canonical compact form.
+//
+// The decimal morton sign carries the hemisphere, which round-trips through the
+// nested hash, so southern covers need no special handling at this boundary.
+
+/// Build a packed, valid BMOC at `MAX_DEPTH` from a morton cover.
+///
+/// The BMOC ops require a canonical, non-overlapping input cover (a valid MOC):
+/// `pack()` only merges complete sibling quartets, it does not prune a cell that
+/// is a descendant of another in the same set.  `normalize` first delivers
+/// exactly that — sorted, sibling-merged, ancestor-pruned — so a raw mixed-order
+/// cover with overlaps is made valid before it reaches the BMOC.
+fn build_bmoc(morton: &[i64]) -> MutableBmoc {
+    let canonical = normalize(morton);
+    let mut builder = MutableBmoc::<false>::with_capacity(MAX_DEPTH, canonical.len());
+    for &m in &canonical {
+        let (nested, depth) = mort2nested(m);
+        builder.push_unchecked(depth, nested, true);
+    }
+    builder.into_packed()
+}
+
+/// Re-encode a BMOC's cells back to a normalized mortie morton cover.
+fn bmoc_to_morton(bmoc: MutableBmoc) -> Vec<i64> {
+    let cells: Vec<i64> = bmoc
+        .into_cells()
+        .map(|c| nested2mort(c.hash, c.depth))
+        .collect();
+    normalize(&cells)
+}
+
+/// Union (logical OR) of two morton covers.
+///
+/// Equivalent to `normalize(concat(a, b))`; backed by BMOC `or`.
+pub fn moc_or(a: &[i64], b: &[i64]) -> Vec<i64> {
+    if a.is_empty() {
+        return normalize(b);
+    }
+    if b.is_empty() {
+        return normalize(a);
+    }
+    bmoc_to_morton(build_bmoc(a).or(&build_bmoc(b)))
+}
+
+/// Intersection (logical AND) of two morton covers.
+///
+/// Backed by BMOC `and`.
+pub fn moc_and(a: &[i64], b: &[i64]) -> Vec<i64> {
+    if a.is_empty() || b.is_empty() {
+        return Vec::new();
+    }
+    bmoc_to_morton(build_bmoc(a).and(&build_bmoc(b)))
+}
+
+/// Difference `a \ b` of two morton covers.
+///
+/// Backed by BMOC `minus`.  The `minus` infinite-loop on mixed-order inputs in
+/// upstream `healpix` 0.3.2 is fixed in the pinned fork (see Cargo.toml).
+pub fn moc_minus(a: &[i64], b: &[i64]) -> Vec<i64> {
+    if a.is_empty() {
+        return Vec::new();
+    }
+    if b.is_empty() {
+        return normalize(a);
+    }
+    bmoc_to_morton(build_bmoc(a).minus(&build_bmoc(b)))
+}
 
 /// Densify a (possibly mixed-order) morton set to a flat list at `order`.
 ///
@@ -321,6 +401,188 @@ mod tests {
                 continue;
             }
             assert_eq!(normalize(&cells), normalize_reference(&cells));
+        }
+    }
+
+    // ── BMOC set-algebra tests (issue #50) ─────────────────────────────────
+
+    /// Brute-force reference for a binary set op: densify both covers to a deep
+    /// common order, run the op on the flat leaf sets, then normalize.  `order`
+    /// must be >= the deepest cell in either input for the result to be exact.
+    fn setop_reference(a: &[i64], b: &[i64], order: u8, op: fn(bool, bool) -> bool) -> Vec<i64> {
+        use std::collections::BTreeSet;
+        let la: BTreeSet<i64> = to_order(a, order).into_iter().collect();
+        let lb: BTreeSet<i64> = to_order(b, order).into_iter().collect();
+        let mut out: Vec<i64> = la
+            .union(&lb)
+            .filter(|&&m| op(la.contains(&m), lb.contains(&m)))
+            .copied()
+            .collect();
+        out.sort_unstable();
+        normalize(&out)
+    }
+
+    fn ref_or(a: &[i64], b: &[i64], order: u8) -> Vec<i64> {
+        setop_reference(a, b, order, |x, y| x || y)
+    }
+    fn ref_and(a: &[i64], b: &[i64], order: u8) -> Vec<i64> {
+        setop_reference(a, b, order, |x, y| x && y)
+    }
+    fn ref_minus(a: &[i64], b: &[i64], order: u8) -> Vec<i64> {
+        setop_reference(a, b, order, |x, y| x && !y)
+    }
+
+    #[test]
+    fn test_or_equals_normalize_concat() {
+        // `moc_or` must be bit-for-bit == normalize(concat(a, b)).
+        let a: Vec<i64> = (0..6).map(|n| nested2mort(n, 4)).collect();
+        let b: Vec<i64> = (3..10).map(|n| nested2mort(n, 4)).collect();
+        let mut concat = a.clone();
+        concat.extend_from_slice(&b);
+        assert_eq!(moc_or(&a, &b), normalize(&concat));
+    }
+
+    #[test]
+    fn test_and_brute_force() {
+        let a: Vec<i64> = (0..8).map(|n| nested2mort(n, 5)).collect();
+        let b: Vec<i64> = (4..12).map(|n| nested2mort(n, 5)).collect();
+        assert_eq!(moc_and(&a, &b), ref_and(&a, &b, 5));
+    }
+
+    #[test]
+    fn test_minus_brute_force() {
+        let a: Vec<i64> = (0..8).map(|n| nested2mort(n, 5)).collect();
+        let b: Vec<i64> = (4..12).map(|n| nested2mort(n, 5)).collect();
+        assert_eq!(moc_minus(&a, &b), ref_minus(&a, &b, 5));
+    }
+
+    #[test]
+    fn test_disjoint_covers() {
+        // Disjoint: and = empty, minus = a, or = a ∪ b.
+        let a: Vec<i64> = (0..4).map(|n| nested2mort(n, 4)).collect();
+        let b: Vec<i64> = (100..104).map(|n| nested2mort(n, 4)).collect();
+        assert_eq!(moc_and(&a, &b), Vec::<i64>::new());
+        assert_eq!(moc_minus(&a, &b), normalize(&a));
+        let mut concat = a.clone();
+        concat.extend_from_slice(&b);
+        assert_eq!(moc_or(&a, &b), normalize(&concat));
+    }
+
+    #[test]
+    fn test_self_minus_empty() {
+        let a: Vec<i64> = (0..10).map(|n| nested2mort(n, 5)).collect();
+        assert_eq!(moc_minus(&a, &a), Vec::<i64>::new());
+        // Self-and = self, self-or = self (idempotent).
+        assert_eq!(moc_and(&a, &a), normalize(&a));
+        assert_eq!(moc_or(&a, &a), normalize(&a));
+    }
+
+    #[test]
+    fn test_empty_inputs() {
+        let a: Vec<i64> = (0..4).map(|n| nested2mort(n, 4)).collect();
+        let empty: Vec<i64> = Vec::new();
+        assert_eq!(moc_or(&a, &empty), normalize(&a));
+        assert_eq!(moc_or(&empty, &a), normalize(&a));
+        assert_eq!(moc_and(&a, &empty), Vec::<i64>::new());
+        assert_eq!(moc_minus(&a, &empty), normalize(&a));
+        assert_eq!(moc_minus(&empty, &a), Vec::<i64>::new());
+        assert_eq!(moc_or(&empty, &empty), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn test_southern_hemisphere() {
+        // Southern parents (6-11) → negative morton; must round-trip cleanly.
+        let south_base = 8u64 << (2 * 4); // base cell 8, depth 4
+        let a: Vec<i64> = (0..6).map(|s| nested2mort(south_base + s, 4)).collect();
+        let b: Vec<i64> = (3..10).map(|s| nested2mort(south_base + s, 4)).collect();
+        assert!(a.iter().all(|&m| m < 0), "southern morton must be negative");
+        assert_eq!(moc_and(&a, &b), ref_and(&a, &b, 4));
+        assert_eq!(moc_minus(&a, &b), ref_minus(&a, &b, 4));
+        let mut concat = a.clone();
+        concat.extend_from_slice(&b);
+        assert_eq!(moc_or(&a, &b), normalize(&concat));
+    }
+
+    #[test]
+    fn test_mixed_order_inputs() {
+        // a: a coarse cell at depth 2; b: some of its depth-4 descendants plus a
+        // disjoint coarse cell. Exercises the mixed-order code paths in all ops.
+        let coarse = nested2mort(3, 2); // covers nested 48..64 at depth 4
+        let a = vec![coarse, nested2mort(20, 3)];
+        let b: Vec<i64> = (48..56)
+            .map(|n| nested2mort(n, 4))
+            .chain(std::iter::once(nested2mort(200, 4)))
+            .collect();
+        assert_eq!(moc_and(&a, &b), ref_and(&a, &b, 4));
+        assert_eq!(moc_minus(&a, &b), ref_minus(&a, &b, 4));
+        assert_eq!(moc_or(&a, &b), ref_or(&a, &b, 4));
+    }
+
+    /// Regression for the upstream `healpix` 0.3.2 BMOC `minus` infinite-loop on
+    /// mixed-order inputs (issue #50 / PR #52): when a finer left cell is fully
+    /// covered by a coarser full right cell, neither cursor advanced.  The pinned
+    /// fork adds the terminal `else` arm; this asserts `minus` now terminates and
+    /// returns the correct result on exactly that trigger condition — a cover
+    /// whose finer cells are descendants of the other's coarse full cells.
+    #[test]
+    fn test_minus_mixed_order_terminates_regression() {
+        // a: depth-2 full cells (coarse) spanning two base cells.
+        let a: Vec<i64> = (0..3)
+            .map(|n| nested2mort(n, 2))
+            .chain((0..3).map(|n| nested2mort((4u64 << 4) + n, 2)))
+            .collect();
+        // b: many depth-5 descendants of a's coarse cells (finer than a), mixed
+        // with a few coarser cells — the exact "finer-cell-inside-coarse-full"
+        // pattern that hung 0.3.2.
+        let mut b: Vec<i64> = Vec::new();
+        for n in 0..200u64 {
+            // descendants of cell 0@2
+            b.push(nested2mort(n, 5));
+        }
+        // a coarse cell shared with a
+        b.push(nested2mort(1, 2));
+        // If the fork fix is absent this loops forever; reaching the assert proves
+        // termination. Correctness is checked against the brute-force reference.
+        let got = moc_minus(&a, &b);
+        assert_eq!(got, ref_minus(&a, &b, 5));
+    }
+
+    #[test]
+    fn test_setops_match_reference_fuzz() {
+        // Randomized fuzz over many mixed-order cover pairs in both hemispheres.
+        let mut state = 0xd1b54a32d192ed03u64;
+        let mut rng = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        let gen_cover = |rng: &mut dyn FnMut() -> u64| -> (Vec<i64>, u8) {
+            let k = (rng() % 30) as usize + 1;
+            let mut max_depth = 1u8;
+            let cells: Vec<i64> = (0..k)
+                .map(|_| {
+                    let depth = (rng() % 5) as u8 + 1;
+                    max_depth = max_depth.max(depth);
+                    let nside_sq = 1u64 << (2 * depth as u32);
+                    let base = rng() % 12;
+                    let n = base * nside_sq + rng() % nside_sq;
+                    nested2mort(n, depth)
+                })
+                .collect();
+            (cells, max_depth)
+        };
+        for _ in 0..300 {
+            let (a, da) = gen_cover(&mut rng);
+            let (b, db) = gen_cover(&mut rng);
+            let order = da.max(db);
+            assert_eq!(moc_or(&a, &b), ref_or(&a, &b, order), "or mismatch");
+            assert_eq!(moc_and(&a, &b), ref_and(&a, &b, order), "and mismatch");
+            assert_eq!(
+                moc_minus(&a, &b),
+                ref_minus(&a, &b, order),
+                "minus mismatch"
+            );
         }
     }
 }


### PR DESCRIPTION
Refs #50

## What this does

Implements fast MOC boolean set-algebra over mortie's signed decimal-morton covers — the **Option D** decision in #50 — backed by the `healpix` crate's BMOC (`Bmoc::or` / `and` / `minus`). No `moc` crate, no `cdshealpix`, no FITS/IVOA serialization.

**Dependency swap (approved in https://github.com/espg/mortie/issues/50#issuecomment-4743717025):** the root `Cargo.toml` `healpix` dep is moved from crates.io `0.3.2` to the @espg-patched fork, pinned by rev:

```toml
healpix = { git = "https://github.com/espg/healpix-rs", rev = "9118d3834b6c2a8860dc7a375d46df2d51516df9" }
```

The fork is `healpix` v0.3.3 with the BMOC `minus` fix present. The crate name is still `healpix`, so the existing `use healpix::...` imports across the tree (`geo2mort.rs`, `buffer.rs`, `linestring.rs`, `decimal_morton.rs`, benches) are unaffected — they compile unchanged against the fork.

### Public API added (`mortie/coverage.py`, exported from `__all__`)
- `moc_or(a, b)` — union; `moc_or(a, b) == compress_moc(concatenate([a, b]))`
- `moc_and(a, b)` — intersection
- `moc_minus(a, b)` — difference `a \ b`

Names and design inherited from #52 (@espg chose the terser BMOC verbs over union/intersection/difference in https://github.com/espg/mortie/pull/52#issuecomment-4737665127). Docstrings note the equivalences and carry `See Also` cross-refs. Rust internals and PyO3 bindings are named consistently: `moc::moc_or/moc_and/moc_minus` → `rust_moc_or/rust_moc_and/rust_moc_minus`, registered in the module init and wrapping the compute in `py.allow_threads`, mirroring the existing `rust_moc_normalize` binding.

### Approach
Signed-morton handling stays at the boundary, mirroring the existing decode→op→encode pattern: decode each morton i64 → `(depth, nested u64)` via `mort2nested`, build a packed BMOC per input, run the BMOC op, extract cells, re-encode via `nested2mort`, then `normalize`. The decimal sign carries the hemisphere through the nested hash, so southern covers need no special-casing.

One correctness subtlety worth flagging: the BMOC ops require a **valid, non-overlapping** input cover, and `pack()` only merges complete sibling quartets — it does not prune a descendant of a coarser cell in the same set. A raw mortie cover can contain overlaps (e.g. a coarse cell plus a finer descendant), so `build_bmoc` runs mortie's `normalize` first to deliver the canonical, ancestor-pruned, sibling-merged cover the BMOC ops assume. Building straight from the raw cover produced wrong results in testing (spurious cells); normalizing first makes every op match the brute-force reference.

## Supersedes #52

This replaces #52's **in-house sorted-range merge** with the upstream BMOC. #52 went in-house because upstream `healpix` 0.3.2's `Bmoc::minus` **infinite-loops** on mixed-order inputs: in the `Greater` arm (right cell coarser than left), when the finer left cell is fully covered by a coarser *full* right cell, the original code fell through without advancing either cursor. The fork adds the terminal `else` arm (`bmoc/ops.rs::minus`):

```rust
} else {
    // hl_at_dr == r.hash && r.is_full && l.is_full:
    // the finer left cell is fully covered by the coarser full
    // right cell, so `l - r` is empty. Drop `l` and advance left;
    // keep `r`, since it may still cover further fine left cells.
    // (Without this branch neither cursor advanced => infinite loop.)
    left = it_left.next();
}
```

#52 stays **blocked** (per #50); this PR does not touch #52 or its branch.

## How tested (real local counts)
- `cargo test --release` — **154 passed, 0 failed** (21 of them in `moc::`, including the new set-ops tests).
- New Rust tests in `moc.rs`: `or` bit-for-bit == `normalize(concat(a,b))`; `and`/`minus` vs a brute-force deepest-order leaf-set reference; disjoint covers; self-minus empty; mixed-order; both hemispheres; empty inputs; and a 300-iteration randomized fuzz over mixed-order cover pairs in both hemispheres comparing all three ops to the reference.
- **Regression test (`test_minus_mixed_order_terminates_regression`)** reproduces the exact 0.3.2 trigger — a cover whose many finer (depth-5) cells are descendants of the other's coarse full (depth-2) cells — and asserts `minus` now *terminates* and matches the brute-force reference. On 0.3.2 this hangs forever; reaching the assert proves the fork fix.
- `cargo clippy` / `cargo fmt --check` — clean on the changed files (`moc.rs`, the new `lib.rs` bindings). The pre-existing tree-wide `useless_conversion` lint and pre-existing `lib.rs` fmt drift are left alone (the new bindings match the surrounding `.to_vec()?` idiom exactly).
- `flake8 mortie --select=E9,F63,F7,F82` — clean.
- `pytest -v` — **290 passed, 9 skipped, 0 failed** (93% coverage). New `TestMOCSetOps` in `test_coverage.py` covers `moc_or`/`moc_and`/`moc_minus`: ==compress(concat) for or, brute-force via `moc_to_order` for and/minus, disjoint, self-minus empty, mixed-order, empty, southern hemisphere. (The 3 `test_arrow.py` failures seen on a first pass were a missing-`pandas` environment gap — a docs/notebook extra, not this change — and all pass once `pandas` is installed.)

## Phases
- [x] Phase 1 — dependency swap to the pinned fork rev in `Cargo.toml`; confirm the tree still builds against it.
- [x] Phase 2 — Rust `moc_or`/`moc_and`/`moc_minus` backed by BMOC + PyO3 bindings in `lib.rs`; Rust tests incl. the mixed-order `minus` regression and fuzz.
- [x] Phase 3 — Python wrappers in `coverage.py`, exports in `__init__.py`, `TestMOCSetOps` in `test_coverage.py`.

## Questions for review
1. **Pin by `rev` vs `tag`** — pinned to the fork's commit `9118d383` for reproducibility. Prefer a tagged release on the fork (e.g. a `0.3.3-mortie` tag) instead, so the dep reads more clearly and survives force-pushes to the fork?
2. **Also expose `not` / `xor`?** The fork's BMOC implements `not` (complement) and `xor` (symmetric difference) too. Out of scope for #50 (Option D names only `or`/`and`/`minus`); add them in this PR, or leave for a follow-up?
3. **Rust internal fn naming** — kept the internal Rust fns as `moc_or`/`moc_and`/`moc_minus` (matching the public Python names and avoiding #52's `union` vs `moc_or` mismatch). Confirm that's the preferred convention over bare `or`/`and`/`minus` (which would shadow the BMOC trait verbs).
4. **Normalize-on-build** — `build_bmoc` normalizes each input before constructing the BMOC (rationale above). That's an extra sort/pass per operand; acceptable, or should callers be required to pass already-normalized covers and skip it?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fggjz7kP1WyxkWQbUdQahH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fggjz7kP1WyxkWQbUdQahH)_