### PR TITLE
Lift coverage/MOC/set-op order cap from 18 to 29

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -184,7 +184,7 @@ Convert geographic coordinates to morton indices.
 **Parameters:**
 - `lats` (float or array): Latitude(s) in degrees
 - `lons` (float or array): Longitude(s) in degrees
-- `order` (int): Tessellation order (1-18), default=18
+- `order` (int): Tessellation order (1-29), default=18
 
 **Returns:**
 - Morton index/indices as int64
@@ -287,7 +287,7 @@ descent; contract: a cell is included iff it intersects the closed polygon).
 
 **Parameters:**
 - `lats`, `lons` (array, or **list of rings** for multipart/holes): vertices in degrees
-- `order` (int): HEALPix order (1–18)
+- `order` (int): HEALPix order (1–29)
 
 **Returns:**
 - Sorted 1-D `int64` array of morton indices at `order`

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -19,7 +19,10 @@ from . import _rustie
 # A flat cover's cell count scales as ~4**order along the boundary, so a flat
 # `morton_coverage` at high order can grow to billions of cells and exhaust
 # memory.  Above this many cells we warn and point at the compact MOC form
-# (issue #60).  The real ceiling is this cell count, not the order itself.
+# (issue #60).  The warning is post-hoc (it fires after the cover is built), so
+# it flags the hazard but cannot prevent an OOM at very high order — the MOC
+# form is the real high-order path.  The true ceiling is this cell count, not
+# the order itself.
 _FLAT_COVER_WARN_THRESHOLD = 1 << 20  # ~1.05M cells (~8 MB of uint64)
 
 
@@ -132,10 +135,13 @@ def morton_coverage(lats, lons, order=18, normalize=True):
     Warns
     -----
     UserWarning
-        If the flat cover exceeds ~1M cells.  A flat cover scales as ``4**order``
-        along the boundary, so at high order it can grow to billions of cells and
-        exhaust memory; prefer :func:`morton_coverage_moc` (optionally with its
-        ``max_cells`` budget) for a compact mixed-order cover.
+        If the returned flat cover exceeds ~1M cells.  This is a **best-effort,
+        post-hoc** signal — it fires only *after* the cover is materialized, so
+        it does not prevent the blow-up: a flat cover scales as ``4**order``
+        along the boundary, and at very high order (≳27) materializing it can
+        exhaust memory *before* the warning is reached.  Treat high-order flat
+        covers as a footgun and use :func:`morton_coverage_moc` (optionally with
+        its ``max_cells`` budget) for a compact mixed-order cover instead.
 
     Notes
     -----

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -86,7 +86,7 @@ def morton_coverage(lats, lons, order=18, normalize=True):
     lons : array_like or list of array_like
         Vertex longitudes in degrees.  Must match the structure of *lats*.
     order : int, optional
-        HEALPix depth / tessellation order (1–18).  Default 18.
+        HEALPix depth / tessellation order (1–29).  Default 18.
     normalize : bool, optional
         Auto-correct ring orientation at ingest.  Default ``True`` (the
         convenience behaviour: a *sub-hemisphere* ring wound clockwise is
@@ -142,8 +142,8 @@ def morton_coverage(lats, lons, order=18, normalize=True):
     >>> lons_parts = [[-120.0, -120.0, -110.0], [-80.0, -80.0, -70.0]]
     >>> cells = mortie.morton_coverage(lats_parts, lons_parts, order=6)
     """
-    if not 1 <= order <= 18:
-        raise ValueError("Order must be between 1 and 18")
+    if not 1 <= order <= 29:
+        raise ValueError("Order must be between 1 and 29")
 
     if _is_multipart(lats):
         la, lo = _prep_rings(lats, lons)
@@ -171,7 +171,7 @@ def morton_coverage_moc(lats, lons, order=18, tolerance=None, max_cells=None):
     lats, lons : array_like
         Vertex latitudes / longitudes in degrees (single polygon ring).
     order : int, optional
-        Finest HEALPix order (1–18).  Default 18.
+        Finest HEALPix order (1–29).  Default 18.
     tolerance : float, optional
         Stop refining a boundary cell once its angular radius (in **degrees**)
         drops to this value, even if coarser than ``order``.  Approximate,
@@ -195,8 +195,8 @@ def morton_coverage_moc(lats, lons, order=18, tolerance=None, max_cells=None):
     morton_coverage : flat single-order cover.
     compress_moc : merge 4-sibling groups in an existing morton set.
     """
-    if not 1 <= order <= 18:
-        raise ValueError("Order must be between 1 and 18")
+    if not 1 <= order <= 29:
+        raise ValueError("Order must be between 1 and 29")
     if tolerance is not None and max_cells is not None:
         raise ValueError("pass at most one of tolerance / max_cells")
 

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -10,9 +10,30 @@ Set algebra over covers (union / intersection / difference) is done in Rust via
 set algebra here.
 """
 
+import warnings
+
 import numpy as np
 
 from . import _rustie
+
+# A flat cover's cell count scales as ~4**order along the boundary, so a flat
+# `morton_coverage` at high order can grow to billions of cells and exhaust
+# memory.  Above this many cells we warn and point at the compact MOC form
+# (issue #60).  The real ceiling is this cell count, not the order itself.
+_FLAT_COVER_WARN_THRESHOLD = 1 << 20  # ~1.05M cells (~8 MB of uint64)
+
+
+def _warn_large_flat(n_cells, order):
+    """Warn when a flat cover is large enough to be a memory hazard."""
+    if n_cells > _FLAT_COVER_WARN_THRESHOLD:
+        warnings.warn(
+            f"flat morton_coverage returned {n_cells} cells at order {order}; "
+            f"a flat cover scales as ~4**order along the boundary and can "
+            f"exhaust memory at high order. Use morton_coverage_moc(...) for a "
+            f"compact mixed-order cover, or its max_cells= budget.",
+            UserWarning,
+            stacklevel=3,
+        )
 
 
 def _is_multipart(lats):
@@ -108,6 +129,14 @@ def morton_coverage(lats, lons, order=18, normalize=True):
         If fewer than 3 vertices, mismatched lengths, invalid order,
         or coordinates containing NaN/infinity.
 
+    Warns
+    -----
+    UserWarning
+        If the flat cover exceeds ~1M cells.  A flat cover scales as ``4**order``
+        along the boundary, so at high order it can grow to billions of cells and
+        exhaust memory; prefer :func:`morton_coverage_moc` (optionally with its
+        ``max_cells`` budget) for a compact mixed-order cover.
+
     Notes
     -----
     - Self-intersecting polygons produce undefined results.
@@ -147,11 +176,14 @@ def morton_coverage(lats, lons, order=18, normalize=True):
 
     if _is_multipart(lats):
         la, lo = _prep_rings(lats, lons)
-        return np.asarray(
+        result = np.asarray(
             _rustie.rust_multipolygon_coverage(la, lo, order, normalize)
         )
+    else:
+        result = _single_coverage(lats, lons, order, normalize)
 
-    return _single_coverage(lats, lons, order, normalize)
+    _warn_large_flat(result.size, order)
+    return result
 
 
 def morton_coverage_moc(lats, lons, order=18, tolerance=None, max_cells=None):

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -137,11 +137,13 @@ def morton_coverage(lats, lons, order=18, normalize=True):
     UserWarning
         If the returned flat cover exceeds ~1M cells.  This is a **best-effort,
         post-hoc** signal — it fires only *after* the cover is materialized, so
-        it does not prevent the blow-up: a flat cover scales as ``4**order``
-        along the boundary, and at very high order (≳27) materializing it can
-        exhaust memory *before* the warning is reached.  Treat high-order flat
-        covers as a footgun and use :func:`morton_coverage_moc` (optionally with
-        its ``max_cells`` budget) for a compact mixed-order cover instead.
+        it does not prevent the blow-up: a flat cover's cell count grows as
+        ``4**order`` along the boundary, so a large polygon and/or a high order
+        can materialize billions of cells and exhaust memory *before* the
+        warning is reached.  The hazard is the *cell count*, not the order
+        alone.  Treat large flat covers as a footgun and use
+        :func:`morton_coverage_moc` (optionally with its ``max_cells`` budget)
+        for a compact mixed-order cover instead.
 
     Notes
     -----

--- a/mortie/linestring.py
+++ b/mortie/linestring.py
@@ -57,7 +57,7 @@ def linestring_coverage(lats, lons, order=18):
     lons : array_like or list of array_like
         Vertex longitudes in degrees. Must match the structure of *lats*.
     order : int, optional
-        HEALPix depth / tessellation order (1–18). Default 18.
+        HEALPix depth / tessellation order (1–29). Default 18.
 
     Returns
     -------
@@ -87,8 +87,8 @@ def linestring_coverage(lats, lons, order=18):
         >>> per_line = mortie.linestring_coverage(lats_parts, lons_parts, order=6)
         >>> [arr.shape for arr in per_line]
     """
-    if not 1 <= order <= 18:
-        raise ValueError("Order must be between 1 and 18")
+    if not 1 <= order <= 29:
+        raise ValueError("Order must be between 1 and 29")
 
     if _is_multi(lats):
         if len(lats) != len(lons):

--- a/mortie/tests/test_buffer.py
+++ b/mortie/tests/test_buffer.py
@@ -43,6 +43,13 @@ class TestMortonBuffer:
         with pytest.raises(ValueError):
             mortie.morton_buffer(mixed, k=1)
 
+    def test_high_order_29(self):
+        """morton_buffer is order-agnostic and works at order 29 (issue #60)."""
+        morton = mortie.geo2mort(38.9, -76.55, order=29)
+        border = mortie.morton_buffer(morton, k=1)
+        assert len(border) > 0
+        assert int(np.max(mortie.infer_order_from_morton(border))) == 29
+
     def test_hemisphere_handling_positive(self):
         """Works with northern hemisphere (bit-63-clear) morton indices."""
         bit63 = np.uint64(1) << np.uint64(63)

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -196,7 +196,7 @@ class TestCoverageSynthetic:
         with pytest.raises(ValueError):
             mortie.morton_coverage([0, 1, 2], [0, 1, 2], order=0)
         with pytest.raises(ValueError):
-            mortie.morton_coverage([0, 1, 2], [0, 1, 2], order=19)
+            mortie.morton_coverage([0, 1, 2], [0, 1, 2], order=30)
 
     def test_too_few_vertices(self):
         """Fewer than 3 vertices raises ValueError."""

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -656,6 +656,20 @@ class TestCoverageHighOrder:
         assert len(cells) > 0
         assert int(np.max(mortie.infer_order_from_morton(cells))) == 29
 
+    def test_large_flat_cover_warns(self, monkeypatch):
+        """A flat cover above the cell-count threshold warns and names the MOC
+        alternative (issue #60, phase 4)."""
+        from mortie import coverage
+
+        monkeypatch.setattr(coverage, "_FLAT_COVER_WARN_THRESHOLD", 1000)
+        with pytest.warns(UserWarning, match="morton_coverage_moc"):
+            mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=16)
+
+    def test_small_flat_cover_does_not_warn(self, recwarn):
+        """An ordinary small cover stays silent."""
+        mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=6)
+        assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]
+
 
 class TestMOCSetOps:
     """BMOC-backed boolean set algebra: moc_or / moc_and / moc_minus (issue #50).

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -549,6 +549,8 @@ class TestCoverageMOCApi:
     def test_moc_invalid_order(self):
         with pytest.raises(ValueError):
             mortie.morton_coverage_moc(self.SQ_LATS, self.SQ_LONS, order=0)
+        with pytest.raises(ValueError):
+            mortie.morton_coverage_moc(self.SQ_LATS, self.SQ_LONS, order=30)
 
     def test_moc_too_few_vertices(self):
         with pytest.raises(ValueError):
@@ -669,6 +671,13 @@ class TestCoverageHighOrder:
         """An ordinary small cover stays silent."""
         mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=6)
         assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]
+
+    @pytest.mark.slow
+    def test_large_flat_cover_warns_default_threshold(self):
+        """At the real (un-patched) ~1M-cell threshold, an order-21 cover of the
+        zagg ring (~2.4M cells) warns and names the MOC alternative."""
+        with pytest.warns(UserWarning, match="morton_coverage_moc"):
+            mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=21)
 
 
 class TestMOCSetOps:

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -626,7 +626,13 @@ class TestCoverageHighOrder:
     @pytest.mark.parametrize("order", [19, 22, 29])
     def test_moc_high_order(self, order):
         """The compact MOC form covers a ring at orders the old cap rejected and
-        refines to the requested order along the boundary."""
+        refines to the requested order along the boundary.
+
+        This sub-cell-scale ring is all boundary (no interior to coarsen), so
+        every MOC cell sits at exactly ``order``; the meaningful invariant is
+        that the cover is non-empty, reaches ``order``, and densifies losslessly
+        back to the flat cover at ``order``.
+        """
         # a ~30 m ring keeps the order-29 boundary count modest
         sr_lats = [38.9, 38.9, 38.9003, 38.9003, 38.9]
         sr_lons = [-76.55, -76.5497, -76.5497, -76.55, -76.55]
@@ -634,7 +640,10 @@ class TestCoverageHighOrder:
         assert len(moc) > 0
         orders = mortie.infer_order_from_morton(moc)
         assert int(np.max(orders)) == order
-        assert int(np.min(orders)) <= order
+        # Lossless densify: the MOC expands to exactly the flat order cover.
+        flat = set(int(x) for x in mortie.morton_coverage(sr_lats, sr_lons, order=order))
+        dens = set(int(x) for x in mortie.moc_to_order(moc, order))
+        assert dens == flat
 
     def test_zagg_child_order_plus_three(self):
         """englacial/zagg#92: a footprint MOC at child_order + 3 = 22 must build
@@ -672,10 +681,15 @@ class TestCoverageHighOrder:
         mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=6)
         assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]
 
-    @pytest.mark.slow
     def test_large_flat_cover_warns_default_threshold(self):
-        """At the real (un-patched) ~1M-cell threshold, an order-21 cover of the
-        zagg ring (~2.4M cells) warns and names the MOC alternative."""
+        """At the real (un-patched) ~1M-cell threshold the warning fires.
+
+        An order-21 cover of the zagg ring is 2_394_698 cells (> ``1<<20``),
+        built in ~0.2 s / ~19 MB — cheap enough to run in the default suite so
+        the *real* threshold is exercised in CI, not only the monkeypatched one.
+        """
+        cover = mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=21)
+        assert cover.size > (1 << 20), "fixture must exceed the warn threshold"
         with pytest.warns(UserWarning, match="morton_coverage_moc"):
             mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=21)
 

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -625,21 +625,23 @@ class TestCoverageHighOrder:
 
     @pytest.mark.parametrize("order", [19, 22, 29])
     def test_moc_high_order(self, order):
-        """The compact MOC form covers a ring at orders the old cap rejected and
-        refines to the requested order along the boundary.
+        """The compact MOC form covers a ring at orders the old cap rejected.
 
-        This sub-cell-scale ring is all boundary (no interior to coarsen), so
-        every MOC cell sits at exactly ``order``; the meaningful invariant is
-        that the cover is non-empty, reaches ``order``, and densifies losslessly
-        back to the flat cover at ``order``.
+        This sub-cell-scale ring is tiny enough that the adaptive descent may
+        stop just short of ``order`` (no boundary cell needs the finest split),
+        so the MOC's depth is bounded by ``order`` but need not reach it.  The
+        meaningful, order-independent invariant is that the cover is non-empty,
+        never exceeds ``order``, and densifies losslessly back to the flat cover
+        at ``order`` — the round-trip zagg relies on.
         """
-        # a ~30 m ring keeps the order-29 boundary count modest
-        sr_lats = [38.9, 38.9, 38.9003, 38.9003, 38.9]
-        sr_lons = [-76.55, -76.5497, -76.5497, -76.55, -76.55]
+        # a ~3 m ring keeps the order-29 flat cover small (~6e4 cells) so the
+        # densify round-trip below stays cheap in the default suite.
+        sr_lats = [38.9, 38.9, 38.90003, 38.90003, 38.9]
+        sr_lons = [-76.55, -76.54997, -76.54997, -76.55, -76.55]
         moc = mortie.morton_coverage_moc(sr_lats, sr_lons, order=order)
         assert len(moc) > 0
         orders = mortie.infer_order_from_morton(moc)
-        assert int(np.max(orders)) == order
+        assert int(np.max(orders)) <= order
         # Lossless densify: the MOC expands to exactly the flat order cover.
         flat = set(int(x) for x in mortie.morton_coverage(sr_lats, sr_lons, order=order))
         dens = set(int(x) for x in mortie.moc_to_order(moc, order))
@@ -680,6 +682,22 @@ class TestCoverageHighOrder:
         """An ordinary small cover stays silent."""
         mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=6)
         assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]
+
+    def test_warn_threshold_is_strict_boundary(self, monkeypatch, recwarn):
+        """The warn check is strict ``>``: a cover of *exactly* the threshold is
+        silent, one cell over warns.  Pins the boundary so a future
+        ``>``→``>=`` slip is caught (issue #60, phase 4)."""
+        from mortie import coverage
+
+        n = mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=6).size
+        # Threshold == cover size: strict ``>`` means no warning.
+        monkeypatch.setattr(coverage, "_FLAT_COVER_WARN_THRESHOLD", int(n))
+        mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=6)
+        assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]
+        # Threshold one below the cover size: now it must warn.
+        monkeypatch.setattr(coverage, "_FLAT_COVER_WARN_THRESHOLD", int(n) - 1)
+        with pytest.warns(UserWarning, match="morton_coverage_moc"):
+            mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=6)
 
     def test_large_flat_cover_warns_default_threshold(self):
         """At the real (un-patched) ~1M-cell threshold the warning fires.

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -591,6 +591,72 @@ class TestCoverageMOCApi:
         assert len(cov) > 0
 
 
+class TestCoverageHighOrder:
+    """Order 19–29 coverage (issue #60).
+
+    The polygon/linestring/MOC paths capped order at 18 while ``geo2mort`` and
+    the rest of the packed-u64 kernel already reached 29; the cap was a stale
+    ``MAX_DEPTH = 18`` constant, not a u64 limit.  These pin the lifted ceiling
+    at the orders the old cap rejected.  A *flat* cover scales as ``4**order``
+    along the boundary, so the order-29 flat case uses a sub-cell polygon (a
+    handful of cells) and the larger covers use the compact MOC form.
+    """
+
+    # ~3 mm triangle: sub-cell even at order 29 (cell edge ≈ 1.2 cm), so the
+    # flat cover stays tiny at any order.
+    TINY_LATS = [38.9, 38.9 + 3e-8, 38.9 + 1.5e-8]
+    TINY_LONS = [-76.55, -76.55, -76.55 + 3e-8]
+
+    # zagg's footprint ring (englacial/zagg#92): child_order = 19 → MOC order
+    # child_order + 3 = 22, which the old order-18 cap rejected.
+    RING_LATS = [38.85, 38.85, 38.93, 38.93, 38.85]
+    RING_LONS = [-76.62, -76.59, -76.59, -76.62, -76.62]
+
+    @pytest.mark.parametrize("order", [19, 22, 29])
+    def test_flat_subcell_high_order(self, order):
+        """A sub-cell polygon's flat cover at order 19/22/29 is a handful of
+        cells, each self-encoding the requested order."""
+        cells = mortie.morton_coverage(self.TINY_LATS, self.TINY_LONS, order=order)
+        assert 1 <= len(cells) <= 16
+        _, got_order = mortie.mort2healpix(cells)
+        assert int(np.max(np.atleast_1d(got_order))) == order
+
+    @pytest.mark.parametrize("order", [19, 22, 29])
+    def test_moc_high_order(self, order):
+        """The compact MOC form covers a ring at orders the old cap rejected and
+        refines to the requested order along the boundary."""
+        # a ~30 m ring keeps the order-29 boundary count modest
+        sr_lats = [38.9, 38.9, 38.9003, 38.9003, 38.9]
+        sr_lons = [-76.55, -76.5497, -76.5497, -76.55, -76.55]
+        moc = mortie.morton_coverage_moc(sr_lats, sr_lons, order=order)
+        assert len(moc) > 0
+        orders = mortie.infer_order_from_morton(moc)
+        assert int(np.max(orders)) == order
+        assert int(np.min(orders)) <= order
+
+    def test_zagg_child_order_plus_three(self):
+        """englacial/zagg#92: a footprint MOC at child_order + 3 = 22 must build
+        (the old cap rejected order 22) and reach order 22 on the boundary."""
+        moc = mortie.morton_coverage_moc(self.RING_LATS, self.RING_LONS, order=22)
+        assert len(moc) > 0
+        assert int(np.max(mortie.infer_order_from_morton(moc))) == 22
+
+    def test_moc_densifies_to_flat_order_19(self):
+        """MOC at order 19 densifies losslessly to the flat cover."""
+        flat = set(
+            int(x) for x in mortie.morton_coverage(self.RING_LATS, self.RING_LONS, order=19)
+        )
+        moc = mortie.morton_coverage_moc(self.RING_LATS, self.RING_LONS, order=19)
+        dens = set(int(x) for x in mortie.moc_to_order(moc, 19))
+        assert dens == flat
+
+    def test_linestring_high_order_29(self):
+        """linestring_coverage reaches order 29 too."""
+        cells = mortie.linestring_coverage([38.9, 38.9001], [-76.55, -76.5499], order=29)
+        assert len(cells) > 0
+        assert int(np.max(mortie.infer_order_from_morton(cells))) == 29
+
+
 class TestMOCSetOps:
     """BMOC-backed boolean set algebra: moc_or / moc_and / moc_minus (issue #50).
 

--- a/mortie/tests/test_linestring.py
+++ b/mortie/tests/test_linestring.py
@@ -139,7 +139,7 @@ class TestValidation:
 
     def test_order_out_of_range_high(self):
         with pytest.raises(ValueError, match="Order must be"):
-            mortie.linestring_coverage([0.0, 1.0], [0.0, 1.0], order=19)
+            mortie.linestring_coverage([0.0, 1.0], [0.0, 1.0], order=30)
 
     def test_nan_coordinates(self):
         with pytest.raises(ValueError, match="NaN"):

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -93,7 +93,7 @@ def norm2mort(normed, parent, order):
 def geo2uniq(lats, lons, order=18):
     """Calculates UNIQ coding for lat/lon
 
-    Defaults to max morton resolution of order 18"""
+    Defaults to order 18; the kernel reaches order 29 (``MAX_ORDER``)."""
 
     nside = 2**order
 

--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -49,7 +49,7 @@ use crate::sphere::{
 /// # Arguments
 /// * `lats` — vertex latitudes in degrees
 /// * `lons` — vertex longitudes in degrees
-/// * `order` — HEALPix depth (1–18)
+/// * `order` — HEALPix depth (1–29)
 ///
 /// # Returns
 /// Sorted unique `Vec<u64>` of morton indices at `order` whose cells intersect
@@ -60,7 +60,7 @@ use crate::sphere::{
 /// trusts the supplied vertex order exactly.
 ///
 /// # Panics
-/// * If `lats`/`lons` differ in length, fewer than 3 vertices, or order ∉ 1–18.
+/// * If `lats`/`lons` differ in length, fewer than 3 vertices, or order ∉ 1–29.
 pub fn polygon_to_morton_coverage(
     lats: &[f64],
     lons: &[f64],
@@ -111,7 +111,7 @@ pub fn polygon_to_morton_moc_budget(
         "lats and lons must have same length"
     );
     assert!(lats.len() >= 3, "Need at least 3 vertices for a polygon");
-    assert!((1..=18).contains(&order), "Order must be 1-18");
+    assert!((1..=29).contains(&order), "Order must be 1-29");
 
     let rings = vec![build_ring(lats, lons, true)];
     let (nodes, effective) = descend_best_first(&rings, order, max_cells);
@@ -166,7 +166,7 @@ fn validate_multi(lats: &[Vec<f64>], lons: &[Vec<f64>], order: u8) {
         lons.len(),
         "lats and lons must have the same number of rings"
     );
-    assert!((1..=18).contains(&order), "Order must be 1-18");
+    assert!((1..=29).contains(&order), "Order must be 1-29");
     for (la, lo) in lats.iter().zip(lons.iter()) {
         assert_eq!(la.len(), lo.len(), "ring lats/lons length mismatch");
         assert!(la.len() >= 3, "each ring needs at least 3 vertices");
@@ -202,7 +202,7 @@ fn polygon_descend(
         "lats and lons must have same length"
     );
     assert!(lats.len() >= 3, "Need at least 3 vertices for a polygon");
-    assert!((1..=18).contains(&order), "Order must be 1-18");
+    assert!((1..=29).contains(&order), "Order must be 1-29");
 
     let rings = vec![build_ring(lats, lons, normalize)];
     descend_parallel(&rings, order, tolerance)

--- a/src_rust/src/geo2mort.rs
+++ b/src_rust/src/geo2mort.rs
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_geo2mort_order_range() {
-        for order in 1..=18u8 {
+        for order in 1..=crate::decimal_morton::MAX_ORDER {
             let m = geo2mort_scalar(45.0, -122.0, order);
             assert!(m != 0, "Order {} should produce non-zero morton", order);
         }

--- a/src_rust/src/linestring.rs
+++ b/src_rust/src/linestring.rs
@@ -25,12 +25,12 @@ use crate::morton::nested2mort;
 /// # Arguments
 /// * `lats` — vertex latitudes in degrees
 /// * `lons` — vertex longitudes in degrees
-/// * `order` — HEALPix depth (1–18)
+/// * `order` — HEALPix depth (1–29)
 ///
 /// # Panics
 /// * If `lats` and `lons` have different lengths
 /// * If fewer than 2 vertices
-/// * If `order` not in 1..=18
+/// * If `order` not in 1..=29
 pub fn linestring_to_morton_coverage(lats: &[f64], lons: &[f64], order: u8) -> Vec<u64> {
     assert_eq!(
         lats.len(),
@@ -38,7 +38,7 @@ pub fn linestring_to_morton_coverage(lats: &[f64], lons: &[f64], order: u8) -> V
         "lats and lons must have same length"
     );
     assert!(lats.len() >= 2, "Need at least 2 vertices for a linestring");
-    assert!((1..=18).contains(&order), "Order must be 1-18");
+    assert!((1..=29).contains(&order), "Order must be 1-29");
 
     let depth = order;
     let cells = rasterize_linestring(lats, lons, depth);

--- a/src_rust/src/linestring.rs
+++ b/src_rust/src/linestring.rs
@@ -208,7 +208,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Order must be")]
     fn test_bad_order() {
-        linestring_to_morton_coverage(&[0.0, 1.0], &[0.0, 1.0], 19);
+        linestring_to_morton_coverage(&[0.0, 1.0], &[0.0, 1.0], 30);
     }
 
     #[test]

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -697,7 +697,7 @@ mod tests {
         // test depth (or one above), so `to_order` does no large expansion.
         for &order in &[22u8, 29] {
             let nside_sq = 1u64 << (2 * order as u32);
-            let origin = 7 * nside_sq; // base cell 7 (southern, bit 63 set path)
+            let origin = 7 * nside_sq; // base cell 7 (equatorial; morton sets bit 63)
             let a: Vec<u64> = (0..10).map(|n| nested2mort(origin + n, order)).collect();
             let b: Vec<u64> = (5..15).map(|n| nested2mort(origin + n, order)).collect();
             assert_eq!(moc_or(&a, &b), ref_or(&a, &b, order), "or @ {order}");

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -19,11 +19,16 @@
 use crate::morton::{mort2nested, nested2mort};
 use healpix::bmoc::{Bmoc, MutableBmoc};
 
-/// Maximum HEALPix depth mortie supports (order 18 → 64-bit morton limit).
+/// Maximum HEALPix depth mortie supports — tied to the packed-u64 kernel's
+/// [`crate::decimal_morton::MAX_ORDER`] (29) so the two cannot drift (issue #60).
 /// Cells are mapped to half-open ranges over the uniform grid at this depth so a
 /// single sort linearizes ancestry: a coarser cell's range strictly contains its
-/// descendants'.
-const MAX_DEPTH: u8 = 18;
+/// descendants'.  The range start of a depth-`d` cell is `nested << 2*(29-d)`;
+/// the deepest depth-29 nested hash is `12*4^29 - 1 < 2^61.6`, so a depth-29
+/// range `[start, start + 4^(29-d))` stays well within u64 — no shift, add, or
+/// `1 << shift` overflow at any depth in `1..=29` (the old `18` was the retired
+/// decimal-i64 morton's ceiling, not a u64 limit).
+const MAX_DEPTH: u8 = crate::decimal_morton::MAX_ORDER;
 
 // ── BMOC-backed boolean set algebra (issue #50, Option D) ──────────────────
 //
@@ -628,5 +633,113 @@ mod tests {
                 "minus mismatch"
             );
         }
+    }
+
+    // ── high-order (issue #60): MAX_DEPTH lifted 18 → 29 ───────────────────
+    //
+    // These pin `normalize` and each set-op at orders 22 and 29 — the orders
+    // the old `MAX_DEPTH = 18` cap rejected (zagg's `child_order + 3 = 22`
+    // case, and the kernel ceiling 29).  The brute-force references densify to
+    // a common order via `to_order`, so to keep that cheap every cell is built
+    // *at or near* the test order (a coarser cell would expand to `4^(29-d)`
+    // leaves).  Sibling quartets are placed deep so normalize still exercises
+    // the merge/cascade path at high depth.
+
+    /// Adjacent sibling-quartet roots at `depth`: roots `r, r+4, r+8, …` each
+    /// get their 4 children at `depth+1`, plus a couple of lone deep cells.
+    fn deep_mixed_cover(depth: u8, base: u64, roots: u64) -> Vec<u64> {
+        let nside_sq = 1u64 << (2 * depth as u32);
+        let origin = base * nside_sq; // first nested hash in base cell
+        let mut cells = Vec::new();
+        for r in 0..roots {
+            let root = origin + r * 4;
+            for s in 0..4u64 {
+                cells.push(nested2mort((root << 2) | s, depth + 1));
+            }
+        }
+        // a lone cell at `depth` and one at `depth+1` (no full quartet) so the
+        // ancestor-prune and partial-quartet arms are also hit.
+        cells.push(nested2mort(origin + 4 * roots, depth));
+        cells.push(nested2mort(((origin + 4 * roots + 1) << 2) | 2, depth + 1));
+        cells
+    }
+
+    #[test]
+    fn test_normalize_high_order_22_and_29() {
+        for &depth in &[21u8, 28] {
+            // depth+1 is 22 / 29 — the orders the old cap forbade.
+            let cover = deep_mixed_cover(depth, 5, 6);
+            let got = normalize(&cover);
+            assert_eq!(
+                got,
+                normalize_reference(&cover),
+                "normalize @ {}",
+                depth + 1
+            );
+            // Each complete quartet must have collapsed to its `depth` parent.
+            assert!(
+                got.iter().any(|&m| mort2nested(m).1 == depth),
+                "a sibling quartet must merge up to depth {depth}"
+            );
+            // Deepest input cell sits at depth+1 (22 or 29) and round-trips.
+            assert!(
+                got.iter().all(|&m| mort2nested(m).1 <= depth + 1),
+                "no cell may exceed the input depth {}",
+                depth + 1
+            );
+        }
+    }
+
+    #[test]
+    fn test_setops_high_order_22_and_29() {
+        // Overlapping deep covers at orders 22 and 29: each op must match the
+        // brute-force reference densified at that order.  Cells are all at the
+        // test depth (or one above), so `to_order` does no large expansion.
+        for &order in &[22u8, 29] {
+            let nside_sq = 1u64 << (2 * order as u32);
+            let origin = 7 * nside_sq; // base cell 7 (southern, bit 63 set path)
+            let a: Vec<u64> = (0..10).map(|n| nested2mort(origin + n, order)).collect();
+            let b: Vec<u64> = (5..15).map(|n| nested2mort(origin + n, order)).collect();
+            assert_eq!(moc_or(&a, &b), ref_or(&a, &b, order), "or @ {order}");
+            assert_eq!(moc_and(&a, &b), ref_and(&a, &b, order), "and @ {order}");
+            assert_eq!(
+                moc_minus(&a, &b),
+                ref_minus(&a, &b, order),
+                "minus @ {order}"
+            );
+            // and is the 5 shared cells (5..10); densifying back to `order` must
+            // recover exactly those, proving the deep BMOC round-trip is lossless.
+            let shared: Vec<u64> = (5..10).map(|n| nested2mort(origin + n, order)).collect();
+            assert_eq!(to_order(&moc_and(&a, &b), order), shared, "and @ {order}");
+            // a \ b is the 5 cells only in a (0..5).
+            let only_a: Vec<u64> = (0..5).map(|n| nested2mort(origin + n, order)).collect();
+            assert_eq!(
+                to_order(&moc_minus(&a, &b), order),
+                only_a,
+                "minus @ {order}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_setops_mixed_order_29_boundary() {
+        // A coarse depth-27 cell vs. its own depth-29 descendants: the BMOC
+        // path must encode/decode the full depth-29 range without overflow.
+        let nside_sq = 1u64 << (2 * 27u32);
+        let coarse_nested = 3 * nside_sq + 11; // some cell in base 3 at depth 27
+        let coarse = vec![nested2mort(coarse_nested, 27)];
+        // its 16 depth-29 descendants occupy nested [coarse<<4, coarse<<4 + 16)
+        let leaves: Vec<u64> = (0..16)
+            .map(|k| nested2mort((coarse_nested << 4) + k, 29))
+            .collect();
+        // and(coarse, all-its-leaves) = the leaves (normalized back to coarse).
+        assert_eq!(moc_and(&coarse, &leaves), normalize(&coarse));
+        // minus(coarse, half the leaves) drops only that half.
+        let half = &leaves[..8];
+        assert_eq!(
+            moc_minus(&coarse, half),
+            ref_minus(&coarse, half, 29),
+            "mixed-order minus @ depth 29"
+        );
     }
 }


### PR DESCRIPTION
Closes #60
Refs englacial/zagg#92

## What & approach

`morton_coverage` / `morton_coverage_moc` / `linestring_coverage` and the BMOC set-ops (`moc_or` / `moc_and` / `moc_minus` — the three verbs that exist in this tree) capped order at **18** while `geo2mort` and the rest of the packed-u64 kernel already reached **29**. The cap was a single stale constant — `MAX_DEPTH = 18` in `src_rust/src/moc.rs` — left over from the retired decimal-i64 morton (issue #58 migration), not a u64 limit. This PR lifts the whole coverage/MOC/set-op stack to order 29 and documents the real ceiling (the flat cover's cell count, not the encoding).

**Why 29 is safe in the range linearizer:** `normalize`/`cell_range` map every cell to a half-open range `nested << 2*(29-depth)`. The deepest depth-29 nested hash is `12*4^29 - 1 < 2^61.6`, so the range start and `start + 4^(29-d)` stay well inside u64 — no shift/add/`1 << shift` overflow at any depth in `1..=29`. `MAX_DEPTH` is now tied to `decimal_morton::MAX_ORDER` so the two cannot drift.

## Phases

- [x] **Phase 1 — lift the MOC core.** `moc.rs` `MAX_DEPTH` 18 → `MAX_ORDER` (29); audited `cell_range`/`normalize`/`build_bmoc`/`bmoc_to_morton` for overflow at depth 29; Rust tests pin `normalize` + each set-op at orders 22 and 29 against the brute-force reference, plus mixed-order 20↔22 and 27↔29 boundary cases (northern + southern base cells), and an ancestor-prune case at depth 22/29.
- [x] **Phase 2 — lift the guards + docstrings.** Rust asserts `(1..=18)` → `(1..=29)` in `coverage.rs` (×3) and `linestring.rs`; Python guards in `coverage.py` (×2) and `linestring.py`; "1–18" docstrings, the `geo2uniq` text (`tools.py`), and `USAGE.md` updated to reach 29.
- [x] **Phase 3 — tests/fixtures.** Flipped the `order=19`-raises assertions to `order=30` (Python + Rust); new `TestCoverageHighOrder` exercises flat coverage (sub-cell polygon), the compact MOC (with lossless densify-to-flat), `linestring_coverage`, and `morton_buffer` at orders 19/22/29; pinned the downstream zagg case (`child_order = 19` → MOC order 22, englacial/zagg#92).
- [x] **Phase 4 — guard the real ceiling.** A flat `morton_coverage`'s cell count grows as ~`4**order` along the boundary, so a large polygon and/or high order can reach billions of cells and exhaust memory. Added a `UserWarning` when the returned flat cover exceeds `_FLAT_COVER_WARN_THRESHOLD` (`1<<20` ≈ 1.05M cells) that names `morton_coverage_moc(...)` / its `max_cells=` budget; documented under a `Warns` section (the hazard is the cell count, not the order alone). The MOC form stays compact, uncapped, and is the high-order path. This is the **warn-and-proceed** resolution (open question 1 below, now resolved).

## Order-29 compatibility audit (Refs #60)

Per the request to "check if this happens anywhere else": the order-18 cap bottomed out at exactly one shared mechanism — `moc.rs` `MAX_DEPTH` — inherited by the coverage, linestring, and all set-op verbs. Everything else (`geo2mort`, `norm2mort`/`mort2norm`, `morton_index.from_latlon`, `morton_buffer`) was already order-29-native (the `geo2mort.rs` order-range test now loops `1..=MAX_ORDER`). `legacy_to_nested` (`decimal_morton.rs:602`) keeps its `order <= 18` assert — that is the deprecated legacy-decimal converter, correctly capped, left as-is.

## How it was tested

Built in the venv (`maturin develop --release`):

```
cargo test                             -> 160 passed
cargo fmt --check                      -> clean
cargo clippy                           -> only the pre-existing PyErr-conversion warnings in lib.rs (none in this PR's code)
flake8 mortie --select=E9,F63,F7,F82   -> clean
pytest mortie/tests/                   -> 401 passed, 8 skipped (+ 10 slow passed)
```

The 8 skips are pre-existing/environmental (shapely/parquet/coarse-cell placeholders), unchanged by this PR.

## Questions for review

1. ~~**Flat-cover ceiling: warn vs hard-cap.**~~ **Resolved: warn-and-proceed.** Implemented the `UserWarning` + proceed variant at `1<<20` cells (cell-count threshold, since the real ceiling is the cell count, not the order). Caveat documented in the `Warns` docstring: the warning is *post-hoc* (fires after the cover is materialized), so at very high cell counts a flat cover can exhaust memory before the warning is reached — the MOC form is the real high-order path. A hard pre-emptive guard (estimating densified size from the cheap MOC and raising before materializing) would be a larger, separate change; flag if you'd prefer it.
2. **MAX_DEPTH now shared with the mixed-order MOC work (#61).** Lifting `MAX_DEPTH` is the same one-constant change #61 and #59 (question 2) reference; #61 keeps the broader mixed-order *semantics* design. Confirm you're happy for this PR to own the constant bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLerxsqADoTsn5mVCXCPth)_