### PR TITLE
moc_min / common_ancestor: deepest-common-ancestor reduction

### DIFF
--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -13,8 +13,10 @@ except PackageNotFoundError:
 # Import all Python functions from tools module
 # Import coverage functions
 from .coverage import (
+    common_ancestor,
     compress_moc,
     moc_and,
+    moc_min,
     moc_minus,
     moc_not,
     moc_or,
@@ -88,6 +90,8 @@ __all__ = [
     'moc_minus',
     'moc_xor',
     'moc_not',
+    'common_ancestor',
+    'moc_min',
     'linestring_coverage',
     'MortonChild',
     'split_children',

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -484,3 +484,55 @@ def moc_not(cover, domain=None):
         )
 
     return moc_minus(domain, cover)
+
+
+def common_ancestor(morton):
+    """Deepest common ancestor (highest-order common parent) of a morton set.
+
+    The array-reduction sibling of :func:`clip2order` (coarsen): where coarsening
+    lowers each word to a *caller-given* order, ``common_ancestor`` *discovers*
+    the deepest order at which the whole input collapses to a single enclosing
+    cell, and returns that one cell.  Because a packed morton word self-encodes
+    its order and ancestry, this is the longest shared path prefix after the
+    common base cell, capped at each word's own order — so mixed-order input is
+    fine (each word is capped at its own order).
+
+    Parameters
+    ----------
+    morton : array_like
+        Morton indices (mixed order allowed).  A single index returns itself.
+
+    Returns
+    -------
+    numpy.uint64
+        The packed morton index of the deepest cell that contains every input.
+
+    Raises
+    ------
+    ValueError
+        If ``morton`` is empty, contains an empty/invalid word, or spans more
+        than one HEALPix base cell — there is then no common ancestor above the
+        (non-existent) whole-sphere root.
+
+    See Also
+    --------
+    clip2order : coarsen each word to a fixed order (the elementwise form;
+        ``common_ancestor`` is its reduce-by-common-coarsening reduction).
+
+    Examples
+    --------
+    The four order-4 children of an order-3 cell reduce to that parent:
+
+    >>> import mortie, numpy as np
+    >>> parent = mortie.norm2mort(7, 0, 3)             # one order-3 cell in base 0
+    >>> kids = mortie.clip2order(np.full(4, parent), 4)  # doctest: +SKIP
+    >>> mortie.common_ancestor(kids) == parent           # doctest: +SKIP
+    True
+    """
+
+    morton = np.asarray(morton, dtype=np.uint64).ravel()
+    return np.uint64(_rustie.rust_moc_min(morton))
+
+
+# ``moc_min`` is the MOC set-family alias for :func:`common_ancestor` (issue #61).
+moc_min = common_ancestor

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -506,10 +506,11 @@ def common_ancestor(morton):
     -------
     numpy.uint64
         The packed morton index of the deepest cell that contains every input.
-        Any genuine coarsening yields an **area** cell; the area/point kind is
-        preserved only when the whole input collapses to a single order-29 cell
-        (then the first word is returned unchanged, so a lone area or point
-        returns itself).
+        A batch (more than one input) always yields an **area** cell — even when
+        the inputs collapse to a single order-29 cell, since the shared cell is
+        an enclosing area, not any one input point.  Only a single-element input
+        is returned unchanged (its area/point kind preserved), so a lone area or
+        point returns itself.
 
     Raises
     ------

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -506,6 +506,10 @@ def common_ancestor(morton):
     -------
     numpy.uint64
         The packed morton index of the deepest cell that contains every input.
+        Any genuine coarsening yields an **area** cell; the area/point kind is
+        preserved only when the whole input collapses to a single order-29 cell
+        (then the first word is returned unchanged, so a lone area or point
+        returns itself).
 
     Raises
     ------
@@ -521,12 +525,12 @@ def common_ancestor(morton):
 
     Examples
     --------
-    The four order-4 children of an order-3 cell reduce to that parent:
+    The four order-5 children of an order-4 cell reduce to that parent:
 
     >>> import mortie, numpy as np
-    >>> parent = mortie.norm2mort(7, 0, 3)             # one order-3 cell in base 0
-    >>> kids = mortie.clip2order(np.full(4, parent), 4)  # doctest: +SKIP
-    >>> mortie.common_ancestor(kids) == parent           # doctest: +SKIP
+    >>> parent = mortie.norm2mort(11, 0, 4)              # one order-4 cell in base 0
+    >>> kids = mortie.norm2mort([11 * 4 + s for s in range(4)], [0] * 4, 5)
+    >>> int(mortie.common_ancestor(kids)) == int(parent)
     True
     """
 

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -1086,6 +1086,18 @@ class TestCommonAncestor:
         got = mortie.common_ancestor(cell)
         assert int(got) == int(cell[0])
 
+    def test_order_29_identical_batch_returns_order_29_cell(self):
+        # Two *identical* order-29 cells (no coarsening) still reduce to the
+        # order-29 cell that encloses them. Mirrors the Rust point-kind case:
+        # a batch always yields the enclosing area, never a passed-through point.
+        # (geo2mort emits area words, so the value is the same cell.)
+        cell = int(mortie.geo2mort(45.0, -100.0, 29)[0])
+        pts = np.array([cell, cell], dtype=np.uint64)
+        anc = mortie.common_ancestor(pts)
+        assert int(anc) == cell
+        _, anc_order = mortie.mort2healpix(anc)
+        assert int(anc_order) == 29
+
     def test_order_29_batch_encloses_to_common_cell(self):
         # A batch of nearby order-29 cells reduces to their common enclosing
         # cell. Check containment by *coarsening* each input to the ancestor's

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -985,3 +985,91 @@ class TestMOCNot:
             warnings.simplefilter("error")
             got = mortie.moc_not(cover, domain=empty)
         assert len(got) == 0
+
+
+class TestCommonAncestor:
+    """Deepest common ancestor / moc_min reduction (issue #61).
+
+    `common_ancestor(words)` returns the single highest-order cell that contains
+    every input word; `moc_min` is its alias.  Containment is checked by
+    densifying the ancestor and the inputs to a common deep order with
+    `moc_to_order` and asserting the ancestor's leaves are a superset.
+    """
+
+    def test_moc_min_is_common_ancestor_alias(self):
+        assert mortie.moc_min is mortie.common_ancestor
+
+    def test_single_returns_itself(self):
+        cell = mortie.norm2mort(7, 3, 5)  # one order-5 cell in base 3
+        assert int(mortie.common_ancestor(np.atleast_1d(cell))) == int(cell)
+
+    def test_identical_returns_the_cell(self):
+        cell = mortie.norm2mort(42, 9, 6)
+        words = np.full(4, cell, dtype=np.uint64)
+        assert int(mortie.common_ancestor(words)) == int(cell)
+
+    def test_four_children_reduce_to_parent(self):
+        # The four order-5 children of an order-4 cell reduce to that parent.
+        parent = mortie.norm2mort(11, 0, 4)  # within-base norm 11 @ order 4
+        # The four order-5 children share parent's norm prefix (norm*4 + s).
+        kids = mortie.norm2mort([11 * 4 + s for s in range(4)], [0] * 4, 5)
+        assert int(mortie.common_ancestor(kids)) == int(parent)
+
+    def test_diverging_cells_reduce_to_base_cell(self):
+        # Two cells diverging at order 1 share only the base cell -> order 0.
+        base = 7
+        a = mortie.norm2mort(0, base, 3)  # nested 0 @ order 3
+        b = mortie.norm2mort(1 << 4, base, 3)  # different first tuple @ order 3
+        got = mortie.common_ancestor(mortie.norm2mort([0, 1 << 4], [base, base], 3))
+        assert int(got) == int(mortie.norm2mort(0, base, 0))
+        # sanity: a and b really are in the same base cell.
+        assert (int(a) >> 60) == (int(b) >> 60)
+
+    def test_mixed_order_input(self):
+        # A deep order-8 cell and a shallow order-5 cell sharing a common prefix
+        # reduce to the prefix cell; the ancestor contains both.
+        base = 2
+        deep = mortie.norm2mort(0b00_01_10_11_00_01_10_11, base, 9)
+        shallow = mortie.norm2mort(0b00_01_10, base, 3)  # shares first 3 tuples
+        anc = mortie.common_ancestor(
+            np.concatenate([np.atleast_1d(deep), np.atleast_1d(shallow)])
+        )
+        anc_leaves = set(int(x) for x in mortie.moc_to_order(np.atleast_1d(anc), 9))
+        for w in (deep, shallow):
+            leaves = set(int(x) for x in mortie.moc_to_order(np.atleast_1d(w), 9))
+            assert leaves.issubset(anc_leaves), "ancestor must contain every input"
+
+    def test_order_29_reduces_to_28(self):
+        # Two order-29 cells differing only at order 29 reduce to their order-28
+        # parent (exercises the suffix-tail path through the binding).
+        base = 9
+        a = mortie.norm2mort(0, base, 29)
+        b = mortie.norm2mort(1, base, 29)  # differs only in the lowest tuple
+        got = mortie.common_ancestor(
+            np.concatenate([np.atleast_1d(a), np.atleast_1d(b)])
+        )
+        _, order = mortie.mort2healpix(got)  # scalar form: (norm, order)
+        assert int(order) == 28
+        assert int(got) == int(mortie.norm2mort(0, base, 28))
+
+    def test_cross_base_cell_raises(self):
+        a = mortie.norm2mort(0, 2, 4)
+        b = mortie.norm2mort(0, 5, 4)  # different base cell
+        with pytest.raises(ValueError, match="base cell"):
+            mortie.common_ancestor(
+                np.concatenate([np.atleast_1d(a), np.atleast_1d(b)])
+            )
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            mortie.common_ancestor(np.array([], dtype=np.uint64))
+
+    def test_invalid_word_raises(self):
+        with pytest.raises(ValueError, match="invalid"):
+            mortie.common_ancestor(np.array([0], dtype=np.uint64))
+
+    def test_returns_scalar_uint64(self):
+        cell = mortie.norm2mort(7, 3, 5)
+        got = mortie.common_ancestor(np.atleast_1d(cell))
+        assert isinstance(got, np.uint64)
+        assert got.shape == ()

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -1088,7 +1088,10 @@ class TestCommonAncestor:
 
     def test_order_29_batch_encloses_to_common_cell(self):
         # A batch of nearby order-29 cells reduces to their common enclosing
-        # cell, which must contain every input when densified back to order 29.
+        # cell. Check containment by *coarsening* each input to the ancestor's
+        # order (every input's ancestor at that order must equal it) rather than
+        # densifying the ancestor to order 29 — a coarse ancestor would expand to
+        # ~4**(29-order) leaves and exhaust memory.
         lats = [45.0, 45.0001, 45.0002]
         lons = [-100.0, -100.0001, -100.0002]
         pts = np.array(
@@ -1096,7 +1099,6 @@ class TestCommonAncestor:
             dtype=np.uint64,
         )
         anc = mortie.common_ancestor(pts)
-        anc_leaves = set(int(x) for x in mortie.moc_to_order(np.atleast_1d(anc), 29))
-        for p in pts:
-            leaves = set(int(x) for x in mortie.moc_to_order(np.atleast_1d(p), 29))
-            assert leaves.issubset(anc_leaves)
+        _, anc_order = mortie.mort2healpix(anc)  # scalar form: (norm, order)
+        coarsened = mortie.clip2order(int(anc_order), pts)
+        assert all(int(c) == int(anc) for c in np.atleast_1d(coarsened))

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -1073,3 +1073,30 @@ class TestCommonAncestor:
         got = mortie.common_ancestor(np.atleast_1d(cell))
         assert isinstance(got, np.uint64)
         assert got.shape == ()
+
+    def test_order_zero_input_returns_base_cell(self):
+        # Order-0 base cells in the same base trivially reduce to that base cell.
+        base0 = mortie.norm2mort(0, 4, 0)
+        got = mortie.common_ancestor(np.full(3, base0, dtype=np.uint64))
+        assert int(got) == int(base0)
+
+    def test_order_29_single_returns_itself(self):
+        # A lone order-29 cell (a point cast to max resolution) returns itself.
+        cell = np.atleast_1d(mortie.geo2mort(45.0, -100.0, 29))
+        got = mortie.common_ancestor(cell)
+        assert int(got) == int(cell[0])
+
+    def test_order_29_batch_encloses_to_common_cell(self):
+        # A batch of nearby order-29 cells reduces to their common enclosing
+        # cell, which must contain every input when densified back to order 29.
+        lats = [45.0, 45.0001, 45.0002]
+        lons = [-100.0, -100.0001, -100.0002]
+        pts = np.array(
+            [int(mortie.geo2mort(la, lo, 29)[0]) for la, lo in zip(lats, lons)],
+            dtype=np.uint64,
+        )
+        anc = mortie.common_ancestor(pts)
+        anc_leaves = set(int(x) for x in mortie.moc_to_order(np.atleast_1d(anc), 29))
+        for p in pts:
+            leaves = set(int(x) for x in mortie.moc_to_order(np.atleast_1d(p), 29))
+            assert leaves.issubset(anc_leaves)

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -408,6 +408,12 @@ impl std::error::Error for CommonAncestorError {}
 /// A single-element input returns that element unchanged.  An empty input, an
 /// undecodable word, or words spanning more than one base cell are errors
 /// ([`CommonAncestorError`]).
+///
+/// Kind: any genuine coarsening (`k <` the result word's source order) produces a
+/// [`Kind::Area`] cell via [`coarsen`]; the area/point kind survives only when
+/// the input collapses to a single order-29 cell (no coarsening), where `words[0]`
+/// is returned verbatim.  So a lone [`Kind::Point`] returns itself, while a batch
+/// of points reduces to their enclosing area cell.
 pub fn common_ancestor(words: &[u64]) -> Result<u64, CommonAncestorError> {
     let (&first, rest) = words.split_first().ok_or(CommonAncestorError::Empty)?;
     let base0 = base_cell_of(first).ok_or(CommonAncestorError::Invalid(first))?;
@@ -428,7 +434,9 @@ pub fn common_ancestor(words: &[u64]) -> Result<u64, CommonAncestorError> {
 
     // Lower `k` until every word shares `first`'s order-`k` ancestor.  This
     // terminates at `k == 0` at the latest: there every word reduces to its base
-    // cell, which we have already proved equal across the input.
+    // cell, which we have already proved equal across the input.  Every shift
+    // `o - k` is non-negative: `k` is seeded from the `min` order over *all*
+    // words (including `first`, via `order0`) and only ever decrements.
     loop {
         let target = nested0 >> (2 * (order0 - k) as u32);
         if others
@@ -1379,6 +1387,28 @@ mod tests {
         let parent = encode(base, &t, 28);
         assert_eq!(common_ancestor(&[a, b]), Ok(parent));
         assert_eq!(order_of(parent), 28);
+    }
+
+    #[test]
+    fn common_ancestor_point_kind_behavior() {
+        // A lone max-encoded point returns itself (kind preserved, no coarsening).
+        let point = encode_point(6, &sample_tuples(29, 30));
+        assert_eq!(common_ancestor(&[point]), Ok(point));
+        // A batch of distinct points reduces to their enclosing AREA cell: the
+        // result must be an area word, never a point.
+        let base = 6u8;
+        let t = sample_tuples(29, 31);
+        let mut t_b = t.clone();
+        t_b[5] = (t[5] + 1) & 3; // diverge at order 6
+        let p_a = encode_point(base, &t);
+        let p_b = encode_point(base, &t_b);
+        let anc = common_ancestor(&[p_a, p_b]).expect("same base => Ok");
+        assert_eq!(
+            kind_of(anc),
+            Kind::Area,
+            "points must enclose to an area cell"
+        );
+        assert_eq!(common_ancestor(&[p_a, p_b]), Ok(encode(base, &t, 5)));
     }
 
     #[test]

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -365,6 +365,85 @@ pub fn coarsen(word: u64, k: u8) -> Option<u64> {
     Some(prefix | body | suffix)
 }
 
+/// Why a [`common_ancestor`] reduction is undefined for its input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommonAncestorError {
+    /// The input was empty -- there is no cell to reduce.
+    Empty,
+    /// A word did not decode (empty sentinel or invalid prefix); carries it.
+    Invalid(u64),
+    /// The words span more than one base cell, so they share no ancestor above
+    /// the (non-existent) whole-sphere root.
+    MixedBaseCell,
+}
+
+impl std::fmt::Display for CommonAncestorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommonAncestorError::Empty => write!(f, "empty input has no common ancestor"),
+            CommonAncestorError::Invalid(w) => {
+                write!(f, "input contains an empty or invalid word ({})", w)
+            }
+            CommonAncestorError::MixedBaseCell => {
+                write!(
+                    f,
+                    "inputs span multiple base cells and have no common ancestor"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CommonAncestorError {}
+
+/// Deepest common ancestor (highest-order common parent) of a set of words.
+///
+/// The array-reduction sibling of [`coarsen`]: where `coarsen` lowers one word
+/// to a *caller-given* order, `common_ancestor` *discovers* the deepest order at
+/// which the whole input collapses to a single enclosing cell and returns that
+/// cell.  Ancestry is the shared tuple prefix of the packed words, so this is the
+/// longest common path prefix (after the shared base cell), capped at each word's
+/// own order.  Mixed-order input is fine: each word is capped at its own order.
+///
+/// A single-element input returns that element unchanged.  An empty input, an
+/// undecodable word, or words spanning more than one base cell are errors
+/// ([`CommonAncestorError`]).
+pub fn common_ancestor(words: &[u64]) -> Result<u64, CommonAncestorError> {
+    let (&first, rest) = words.split_first().ok_or(CommonAncestorError::Empty)?;
+    let base0 = base_cell_of(first).ok_or(CommonAncestorError::Invalid(first))?;
+    // `first`'s order/nested anchor the shared-prefix search.
+    let (order0, nested0) = to_nested(first).ok_or(CommonAncestorError::Invalid(first))?;
+
+    // `k` can be no deeper than the shallowest word's order.
+    let mut k = order0;
+    let mut others: Vec<(u8, u64)> = Vec::with_capacity(rest.len());
+    for &w in rest {
+        if base_cell_of(w).ok_or(CommonAncestorError::Invalid(w))? != base0 {
+            return Err(CommonAncestorError::MixedBaseCell);
+        }
+        let (o, n) = to_nested(w).expect("base_cell_of accepted this word");
+        k = k.min(o);
+        others.push((o, n));
+    }
+
+    // Lower `k` until every word shares `first`'s order-`k` ancestor.  This
+    // terminates at `k == 0` at the latest: there every word reduces to its base
+    // cell, which we have already proved equal across the input.
+    loop {
+        let target = nested0 >> (2 * (order0 - k) as u32);
+        if others
+            .iter()
+            .all(|&(o, n)| n >> (2 * (o - k) as u32) == target)
+        {
+            break;
+        }
+        k -= 1;
+    }
+    // `coarsen(first, k)` with `k <= order0` is the canonical order-`k` ancestor
+    // word; at `k == order0` (single / identical input) it returns `first` as-is.
+    Ok(coarsen(first, k).expect("first decoded above"))
+}
+
 // ---------------------------------------------------------------------------
 // healpix-crate bridge: decimal_morton <-> (depth, nested_idx)
 // ---------------------------------------------------------------------------
@@ -1220,6 +1299,151 @@ mod tests {
                 assert_eq!(dec.order, order, "order base {}", base);
                 assert_eq!(dec.kind, Kind::Area);
             }
+        }
+    }
+
+    // -- common_ancestor / moc_min (issue #61) -------------------------------
+
+    #[test]
+    fn common_ancestor_single_returns_itself() {
+        // A single element (area cell and max-encoded point) is its own ancestor.
+        let area = encode(3, &sample_tuples(5, 4), 5);
+        assert_eq!(common_ancestor(&[area]), Ok(area));
+        let point = encode_point(7, &sample_tuples(29, 8));
+        assert_eq!(common_ancestor(&[point]), Ok(point));
+    }
+
+    #[test]
+    fn common_ancestor_identical_returns_the_cell() {
+        // Duplicates collapse to the shared cell, not a coarser one.
+        let c = encode(9, &sample_tuples(6, 2), 6);
+        assert_eq!(common_ancestor(&[c, c, c]), Ok(c));
+    }
+
+    #[test]
+    fn common_ancestor_four_children_reduce_to_parent() {
+        // The four order-(k+1) children sharing an order-k prefix reduce to that
+        // order-k parent (they differ only in the final tuple).
+        let base = 4u8;
+        let t = sample_tuples(6, 1); // >= 6 entries; parent uses the first 5.
+        let parent = encode(base, &t, 5);
+        let children: Vec<u64> = (0..4u8)
+            .map(|c| {
+                let mut tc = t.clone();
+                tc[5] = c;
+                encode(base, &tc, 6)
+            })
+            .collect();
+        assert_eq!(common_ancestor(&children), Ok(parent));
+    }
+
+    #[test]
+    fn common_ancestor_full_base_cell_reduces_to_order_zero() {
+        // Cells diverging at order 1 (different first tuple) share only the base
+        // cell, so the common ancestor is the order-0 base cell itself.
+        let base = 7u8;
+        let mut t0 = sample_tuples(3, 2);
+        t0[0] = 0;
+        let mut t1 = t0.clone();
+        t1[0] = 1;
+        let a = encode(base, &t0, 3);
+        let b = encode(base, &t1, 3);
+        assert_eq!(common_ancestor(&[a, b]), Ok(encode(base, &[], 0)));
+    }
+
+    #[test]
+    fn common_ancestor_mixed_order() {
+        // A deep cell (order 8) and a shallower one (order 5) that diverge at
+        // order 4: the ancestor is the order-3 cell, capped by the divergence,
+        // not by either operand's own order.
+        let base = 2u8;
+        let t = sample_tuples(8, 9);
+        let a = encode(base, &t, 8);
+        let mut t2 = t.clone();
+        t2[3] = (t[3] + 1) & 3; // differ at order 4 (tuple index 3)
+        let b = encode(base, &t2, 5);
+        assert_eq!(common_ancestor(&[a, b]), Ok(encode(base, &t, 3)));
+    }
+
+    #[test]
+    fn common_ancestor_order_29_reduces_to_28() {
+        // Two order-29 cells sharing the first 28 tuples but differing at order
+        // 29 reduce to their order-28 parent -- exercises the suffix-tail path.
+        let base = 9u8;
+        let mut t = sample_tuples(29, 5);
+        t[28] = 0;
+        let a = encode(base, &t, 29);
+        let mut t_b = t.clone();
+        t_b[28] = 1;
+        let b = encode(base, &t_b, 29);
+        let parent = encode(base, &t, 28);
+        assert_eq!(common_ancestor(&[a, b]), Ok(parent));
+        assert_eq!(order_of(parent), 28);
+    }
+
+    #[test]
+    fn common_ancestor_cross_base_cell_errors() {
+        let a = encode(2, &sample_tuples(4, 1), 4);
+        let b = encode(5, &sample_tuples(4, 1), 4);
+        assert_eq!(
+            common_ancestor(&[a, b]),
+            Err(CommonAncestorError::MixedBaseCell)
+        );
+    }
+
+    #[test]
+    fn common_ancestor_empty_and_invalid_error() {
+        assert_eq!(common_ancestor(&[]), Err(CommonAncestorError::Empty));
+        assert_eq!(common_ancestor(&[0]), Err(CommonAncestorError::Invalid(0)));
+        // an invalid word among valid ones is reported too.
+        let good = encode(0, &sample_tuples(3, 1), 3);
+        let bad = 13u64 << PREFIX_SHIFT; // invalid prefix
+        assert_eq!(
+            common_ancestor(&[good, bad]),
+            Err(CommonAncestorError::Invalid(bad))
+        );
+    }
+
+    #[test]
+    fn common_ancestor_contains_every_input() {
+        // Property: the returned ancestor's range on the deepest grid contains
+        // every input cell's range, for a randomized same-base mixed-order set.
+        let mut state = 0x243f6a8885a308d3u64;
+        let mut rng = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for _ in 0..300 {
+            let base = (rng() % 12) as u8;
+            let k = (rng() % 6) as usize + 1;
+            let words: Vec<u64> = (0..k)
+                .map(|_| {
+                    let order = (rng() % 29) as u8 + 1;
+                    let tuples: Vec<u8> = (0..order).map(|_| (rng() & 3) as u8).collect();
+                    encode(base, &tuples, order)
+                })
+                .collect();
+            let anc = common_ancestor(&words).expect("same base => Ok");
+            let (ao, an) = to_nested(anc).unwrap();
+            let (a_start, a_end) = (
+                an << (2 * (MAX_ORDER - ao) as u32),
+                (an + 1) << (2 * (MAX_ORDER - ao) as u32),
+            );
+            for &w in &words {
+                let (wo, wn) = to_nested(w).unwrap();
+                let w_start = wn << (2 * (MAX_ORDER - wo) as u32);
+                let w_end = (wn + 1) << (2 * (MAX_ORDER - wo) as u32);
+                assert!(
+                    a_start <= w_start && w_end <= a_end,
+                    "ancestor must contain every input cell"
+                );
+            }
+            // and the ancestor is the *deepest* such: no order > its own contains
+            // all (unless all inputs are that one cell). If every input equals the
+            // ancestor's order, it can only be because they collapse there.
+            assert!(ao <= words.iter().map(|&w| order_of(w)).min().unwrap());
         }
     }
 

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -405,15 +405,16 @@ impl std::error::Error for CommonAncestorError {}
 /// longest common path prefix (after the shared base cell), capped at each word's
 /// own order.  Mixed-order input is fine: each word is capped at its own order.
 ///
-/// A single-element input returns that element unchanged.  An empty input, an
-/// undecodable word, or words spanning more than one base cell are errors
-/// ([`CommonAncestorError`]).
+/// A single-element input returns that element unchanged (its kind is preserved).
+/// An empty input, an undecodable word, or words spanning more than one base cell
+/// are errors ([`CommonAncestorError`]).
 ///
-/// Kind: any genuine coarsening (`k <` the result word's source order) produces a
-/// [`Kind::Area`] cell via [`coarsen`]; the area/point kind survives only when
-/// the input collapses to a single order-29 cell (no coarsening), where `words[0]`
-/// is returned verbatim.  So a lone [`Kind::Point`] returns itself, while a batch
-/// of points reduces to their enclosing area cell.
+/// Kind: a batch (`words.len() > 1`) always yields a [`Kind::Area`] cell -- even
+/// when the inputs collapse to a single order-29 cell with no coarsening, because
+/// the shared cell is an *enclosing area*, not any one input point.  Only the
+/// single-element case (`words.len() == 1`) preserves the input kind.  So a lone
+/// [`Kind::Point`] returns itself, while a batch of identical order-29 points
+/// reduces to their enclosing order-29 area cell.
 pub fn common_ancestor(words: &[u64]) -> Result<u64, CommonAncestorError> {
     let (&first, rest) = words.split_first().ok_or(CommonAncestorError::Empty)?;
     let base0 = base_cell_of(first).ok_or(CommonAncestorError::Invalid(first))?;
@@ -447,9 +448,15 @@ pub fn common_ancestor(words: &[u64]) -> Result<u64, CommonAncestorError> {
         }
         k -= 1;
     }
-    // `coarsen(first, k)` with `k <= order0` is the canonical order-`k` ancestor
-    // word; at `k == order0` (single / identical input) it returns `first` as-is.
-    Ok(coarsen(first, k).expect("first decoded above"))
+    // Single-element input returns `first` verbatim, preserving its kind. A batch
+    // is always an enclosing *area*: `from_nested` packs the order-`k` ancestor
+    // (the shared nested prefix) into an `Kind::Area` word, even when `k == order0`
+    // (all inputs the same order-29 cell), where `coarsen` would have kept a point.
+    if rest.is_empty() {
+        Ok(coarsen(first, k).expect("first decoded above"))
+    } else {
+        Ok(from_nested(nested0 >> (2 * (order0 - k) as u32), k))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1409,6 +1416,16 @@ mod tests {
             "points must enclose to an area cell"
         );
         assert_eq!(common_ancestor(&[p_a, p_b]), Ok(encode(base, &t, 5)));
+        // Two *identical* order-29 points (no coarsening, k == 29) still emit an
+        // order-29 AREA: both points live in the same enclosing order-29 area.
+        let same = common_ancestor(&[p_a, p_a]).expect("same base => Ok");
+        assert_eq!(
+            kind_of(same),
+            Kind::Area,
+            "identical points => area, not point"
+        );
+        assert_eq!(order_of(same), 29);
+        assert_eq!(same, encode(base, &t, 29));
     }
 
     #[test]

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -763,6 +763,17 @@ fn rust_moc_xor(
     Ok(out.into_pyarray_bound(py).into_any().unbind())
 }
 
+/// Deepest common ancestor (`moc_min`) of a morton cover: the highest-order cell
+/// that contains every input word, returned as a scalar u64.  Raises
+/// `ValueError` on empty input, an empty/invalid word, or inputs spanning more
+/// than one base cell (no common ancestor exists).
+#[pyfunction]
+fn rust_moc_min(py: Python<'_>, morton: PyReadonlyArray1<u64>) -> PyResult<u64> {
+    let data = morton.to_vec()?;
+    py.allow_threads(|| decimal_morton::common_ancestor(&data))
+        .map_err(|e| PyValueError::new_err(format!("moc_min: {}", e)))
+}
+
 /// Compute morton indices tracing a linestring (open polyline).
 ///
 /// # Arguments
@@ -1084,6 +1095,7 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_moc_and, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_minus, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_xor, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_min, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_from_nested, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_to_nested, m)?)?;


### PR DESCRIPTION
Refs #61.

Implements the new `min` / deepest-common-ancestor reduction requested on #61 ([comment](https://github.com/espg/mortie/issues/61#issuecomment-4804033539)), per the [approved plan](https://github.com/espg/mortie/issues/61#issuecomment-4804156053) and @espg's [answers to the open questions](https://github.com/espg/mortie/issues/61#issuecomment-4804257689).

The other parts of #61 (the mixed-order MOC *semantics* decision and the depth-ceiling lift 18→29) were already discharged — the ceiling landed in #59/#70 and the storage/normalize/set-op-composition semantics were settled in the [plan comment](https://github.com/espg/mortie/issues/61#issuecomment-4804156053). This PR is the last open *code* deliverable on the issue. Left as `Refs` (not `Closes`) so the close stays @espg's call.

## What it does
Adds a reduction over an array of packed morton words that returns the **highest-order common parent** (deepest common ancestor) of the whole input, and **raises** when the words span more than one base cell (no common ancestor above the root).

The op is cheap because ancestry is already a prefix relation in the packed word: the deepest common ancestor is the longest shared path prefix (after the common base cell), capped at each word's own order. Decisions captured from the thread:

- **Name:** public Python `common_ancestor`, with `moc_min` kept as the MOC-family **alias** (`moc_min = common_ancestor`).
- **Return:** a single packed morton index — scalar `numpy.uint64`, not a length-1 array.
- **Single element** returns itself; **empty** raises `ValueError`; **irreducible** (mixed base cell) raises `ValueError`.
- **Mixed orders accepted** — each member is capped at its own order when computing the shared prefix.
- Documented as the **reduce-by-common-coarsening** sibling of `clip2order` / the deferred `//` operator.

## Approach
- `decimal_morton::common_ancestor(words) -> Result<u64, CommonAncestorError>` (`src_rust/src/decimal_morton.rs`): verifies one shared base cell, then lowers the candidate order `k` (starting at the shallowest word's order) until every word shares the order-`k` ancestor of `words[0]`, and returns `coarsen(words[0], k)`. Termination is guaranteed — at `k == 0` every word reduces to the (already-checked-equal) base cell. Reuses the existing `base_cell_of` / `to_nested` / `coarsen` kernel primitives; no new bit-twiddling. Built directly on the kernel (not via a `moc.rs` pass-through) since it operates on the packed-word path layout, which is `decimal_morton`'s domain.
- `rust_moc_min` PyO3 binding (`src_rust/src/lib.rs`): takes a `u64` array, returns a scalar `u64`, maps each `CommonAncestorError` variant to a `ValueError` (mirrors `rust_moc_xor` registration).
- Python `common_ancestor` + `moc_min` alias (`mortie/coverage.py`), exported from `mortie/__init__.py`.

## Phases
- [x] **Phase 1** — Rust kernel `common_ancestor` + `CommonAncestorError`, `rust_moc_min` binding + registration, and Rust unit tests (single/identical, four-children→parent, full-base-cell→order-0, mixed-order, order-29→28 suffix-tail, cross-base-cell raise, empty/invalid raise, plus a 300-case randomized containment property).
- [x] **Phase 2** — Python `common_ancestor` / `moc_min` wrapper + exports, and Python tests (`TestCommonAncestor`).
- [x] **Phase 3 (self-review fold)** — fixed a reversed `clip2order` call in the docstring example, added an underflow-safety note on the shift, documented the area/point kind behavior, and added tests pinning it (Rust: lone point returns itself, point batch → area cell; Python: order-0 input, order-29 single/batch).

## How it was tested
- `cargo test` — 173 passing (12 `common_ancestor` cases incl. the randomized containment property and the point-kind cases). `cargo fmt` clean.
- `cargo clippy` — no new findings beyond the pre-existing pyo3-macro `useless_conversion` warnings that every `#[pyfunction]` carries (deferred to the wholesale clippy sweep tracked on #48); `rust_moc_min` is consistent with its `moc_or`/`and`/`minus`/`xor` siblings.
- `maturin develop --release`, then `flake8 mortie --select=E9,F63,F7,F82` clean and the `TestCommonAncestor` suite + the `common_ancestor` doctest green. (CI runs the full `pytest` matrix on 3.10/3.11/3.12.)

## Questions for review
1. **Area/point kind of the result.** A genuine common ancestor is an enclosing region, so any real coarsening yields a `Kind::Area` cell. The one ambiguous case is when the input collapses to a *single* order-29 cell (no coarsening): the current behavior returns `words[0]` verbatim, so a lone `Kind::Point` returns itself (honoring "single element returns itself"), but a `{point, area}` pair at the same order-29 cell takes the first element's kind. The zagg consumer ([#87 context](https://github.com/espg/mortie/issues/61#issuecomment-4804175424)) casts points, so if you'd rather `common_ancestor` always canonicalize to the area form (dropping the point flag even for a single point), I can make that change — flagging rather than guessing, since it trades off against the "returns itself" contract.
2. **Close #61 on merge?** This delivers the issue's remaining code item; the semantics/ceiling parts already landed. Happy to switch `Refs` → `Closes`, or leave #61 open for the broader 1.x freeze statement.
