### PR TITLE
add split_base_cells

### DIFF
--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -24,6 +24,7 @@ from .coverage import (
     moc_xor,
     morton_coverage,
     morton_coverage_moc,
+    split_base_cells,
 )
 from .linestring import linestring_coverage
 
@@ -92,6 +93,7 @@ __all__ = [
     'moc_not',
     'common_ancestor',
     'moc_min',
+    'split_base_cells',
     'linestring_coverage',
     'MortonChild',
     'split_children',

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -599,8 +599,8 @@ def split_base_cells(words, sort=False):
 
     bases = _rustie.rust_mi_base_cell_of(words)
     out = {}
-    # Stable group-by preserving first-seen base-cell order; within each group
-    # the input order is preserved (np.unique keeps the original positions).
+    # Stable group-by: dict.fromkeys yields base cells in first-seen order, and
+    # the boolean mask below keeps each group's words in input order.
     for base in dict.fromkeys(bases.tolist()):
         group = words[bases == base]
         if sort:

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -541,3 +541,69 @@ def common_ancestor(morton):
 
 # ``moc_min`` is the MOC set-family alias for :func:`common_ancestor` (issue #61).
 moc_min = common_ancestor
+
+
+def split_base_cells(words, sort=False):
+    """Partition a morton set by HEALPix base cell, keyed by each group's
+    :func:`moc_min`.
+
+    The companion to :func:`moc_min` for the cross-base-cell case it refuses:
+    where ``moc_min`` reduces a *single* base cell's words to one ancestor and
+    raises on mixed base cells, ``split_base_cells`` groups the words by base
+    cell and hands back each group untouched.  Every group is keyed by its own
+    ``moc_min`` — the deepest cell enclosing that group — which is self-
+    describing (a packed word the same 64 bits wide as the data) and from which
+    the base cell id is cheap to recover (e.g. ``mort2healpix`` /
+    ``MortonIndexArray.base_cell``).
+
+    Parameters
+    ----------
+    words : array_like
+        Morton indices (mixed order and mixed base cell allowed).
+    sort : bool, optional
+        If ``False`` (default, the faster path) each group keeps the input
+        order of its words.  If ``True`` each group's words are sorted, giving a
+        canonical MOC per base cell.
+
+    Returns
+    -------
+    dict[int, numpy.ndarray]
+        Maps the ``int`` of each group's ``moc_min`` word to that group's
+        ``uint64`` array of words.  Empty input returns ``{}``; a single base
+        cell returns a one-entry dict.
+
+    Raises
+    ------
+    ValueError
+        If a group's ``moc_min`` reduction fails — e.g. ``words`` contains an
+        empty/invalid word (``moc_min`` rejects it).
+
+    See Also
+    --------
+    moc_min : the single-base-cell reduction this partitions for; its mixed-
+        base-cell error points here.
+
+    Examples
+    --------
+    >>> import mortie, numpy as np
+    >>> a = np.atleast_1d(mortie.norm2mort(0, 2, 4))   # one cell in base 2
+    >>> b = np.atleast_1d(mortie.norm2mort(0, 5, 4))   # one cell in base 5
+    >>> groups = mortie.split_base_cells(np.concatenate([a, b]))
+    >>> sorted(int(np.uint64(k) >> np.uint64(60)) - 1 for k in groups)
+    [2, 5]
+    """
+
+    words = np.asarray(words, dtype=np.uint64).ravel()
+    if words.size == 0:
+        return {}
+
+    bases = _rustie.rust_mi_base_cell_of(words)
+    out = {}
+    # Stable group-by preserving first-seen base-cell order; within each group
+    # the input order is preserved (np.unique keeps the original positions).
+    for base in dict.fromkeys(bases.tolist()):
+        group = words[bases == base]
+        if sort:
+            group = np.sort(group)
+        out[int(moc_min(group))] = group
+    return out

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -1114,3 +1114,98 @@ class TestCommonAncestor:
         _, anc_order = mortie.mort2healpix(anc)  # scalar form: (norm, order)
         coarsened = mortie.clip2order(int(anc_order), pts)
         assert all(int(c) == int(anc) for c in np.atleast_1d(coarsened))
+
+
+class TestSplitBaseCells:
+    """Partition a morton set by base cell, keyed by each group's moc_min
+    (issue #74).
+
+    `split_base_cells(words)` groups the input by HEALPix base cell and returns
+    a dict whose key is each group's `moc_min` word and whose value is that
+    group's `uint64` array.  It is the companion to `moc_min` for the mixed-
+    base-cell case `moc_min` refuses.
+    """
+
+    def test_empty_returns_empty_dict(self):
+        got = mortie.split_base_cells(np.array([], dtype=np.uint64))
+        assert got == {}
+
+    def test_single_base_cell_one_entry(self):
+        # Several cells all in base 3 form a single group.
+        words = mortie.norm2mort([0, 1, 2, 3], [3, 3, 3, 3], 4)
+        groups = mortie.split_base_cells(words)
+        assert len(groups) == 1
+        (key,), (arr,) = groups.keys(), groups.values()
+        # The single group's moc_min is its dict key, and the group is the input.
+        assert int(key) == int(mortie.moc_min(words))
+        np.testing.assert_array_equal(arr, words)
+
+    def test_multi_base_cell_partition(self):
+        # Cells from base 2 and base 5 split into two groups.
+        a = mortie.norm2mort([0, 1], [2, 2], 4)
+        b = np.atleast_1d(mortie.norm2mort([3], [5], 4))
+        words = np.concatenate([a, b])
+        groups = mortie.split_base_cells(words)
+        assert len(groups) == 2
+        # Every word within a group shares one base cell (the 4-bit prefix).
+        for group in groups.values():
+            prefixes = {int(w) >> 60 for w in np.atleast_1d(group)}
+            assert len(prefixes) == 1
+        # The two groups together are exactly the whole input.
+        recombined = np.sort(np.concatenate(list(groups.values())))
+        np.testing.assert_array_equal(recombined, np.sort(words))
+
+    def test_dict_key_is_moc_min_of_group(self):
+        # The invariant: each key equals moc_min of its value array.
+        a = mortie.norm2mort([0, 1, 2, 3], [4, 4, 4, 4], 4)  # four children
+        b = np.atleast_1d(mortie.norm2mort([0], [9], 6))
+        words = np.concatenate([a, b])
+        groups = mortie.split_base_cells(words)
+        for key, group in groups.items():
+            assert int(key) == int(mortie.moc_min(group))
+
+    def test_base_cell_recoverable_from_key(self):
+        # The base cell id is cheap to extract from each moc_min key.
+        a = np.atleast_1d(mortie.norm2mort([0], [2], 4))
+        b = np.atleast_1d(mortie.norm2mort([0], [7], 4))
+        groups = mortie.split_base_cells(np.concatenate([a, b]))
+        key_bases = {int(np.uint64(k) >> np.uint64(60)) - 1 for k in groups}
+        assert key_bases == {2, 7}
+
+    def test_sort_false_preserves_input_order(self):
+        # Default sort=False keeps each group's words in input order.
+        base = 6
+        words = mortie.norm2mort([3, 1, 2, 0], [base] * 4, 4)
+        groups = mortie.split_base_cells(words, sort=False)
+        (arr,) = groups.values()
+        np.testing.assert_array_equal(arr, words)
+
+    def test_sort_true_canonical_order(self):
+        # sort=True sorts each group's words (canonical MOC per base cell).
+        base = 6
+        words = mortie.norm2mort([3, 1, 2, 0], [base] * 4, 4)
+        groups = mortie.split_base_cells(words, sort=True)
+        (arr,) = groups.values()
+        np.testing.assert_array_equal(arr, np.sort(words))
+        # The moc_min key is order-insensitive, so the same group keys either way.
+        unsorted = mortie.split_base_cells(words, sort=False)
+        assert set(unsorted.keys()) == set(groups.keys())
+
+    def test_values_are_uint64(self):
+        a = np.atleast_1d(mortie.norm2mort([0], [2], 4))
+        b = np.atleast_1d(mortie.norm2mort([0], [5], 4))
+        groups = mortie.split_base_cells(np.concatenate([a, b]))
+        for group in groups.values():
+            assert group.dtype == np.uint64
+
+    def test_invalid_word_raises(self):
+        # A 0 word is the empty sentinel; its group's moc_min rejects it.
+        with pytest.raises(ValueError):
+            mortie.split_base_cells(np.array([0], dtype=np.uint64))
+
+    def test_moc_min_mixed_base_cell_points_here(self):
+        # moc_min's mixed-base-cell error names split_base_cells as the remedy.
+        a = np.atleast_1d(mortie.norm2mort(0, 2, 4))
+        b = np.atleast_1d(mortie.norm2mort(0, 5, 4))
+        with pytest.raises(ValueError, match="split_base_cells"):
+            mortie.moc_min(np.concatenate([a, b]))

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -1203,6 +1203,15 @@ class TestSplitBaseCells:
         with pytest.raises(ValueError):
             mortie.split_base_cells(np.array([0], dtype=np.uint64))
 
+    def test_invalid_word_mixed_with_valid_raises(self):
+        # A 0 sentinel mixed with valid words still raises: the sentinel forms
+        # its own group whose moc_min rejects the empty word.
+        a = np.atleast_1d(mortie.norm2mort(0, 2, 4))
+        with pytest.raises(ValueError):
+            mortie.split_base_cells(
+                np.concatenate([a, np.array([0], dtype=np.uint64)])
+            )
+
     def test_moc_min_mixed_base_cell_points_here(self):
         # moc_min's mixed-base-cell error names split_base_cells as the remedy.
         a = np.atleast_1d(mortie.norm2mort(0, 2, 4))

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -387,7 +387,8 @@ impl std::fmt::Display for CommonAncestorError {
             CommonAncestorError::MixedBaseCell => {
                 write!(
                     f,
-                    "inputs span multiple base cells and have no common ancestor"
+                    "inputs span multiple base cells and have no common ancestor; \
+                     use split_base_cells to partition them by base cell first"
                 )
             }
         }


### PR DESCRIPTION
Closes #74
Refs #72, Refs #61

## What it does

Adds `split_base_cells(words, sort=False)`, the companion primitive to `moc_min` for the cross-base-cell case `moc_min` refuses. It partitions a morton set by HEALPix base cell and returns a **dict keyed by each group's `moc_min`**, exactly per the binding spec in #74:

- **Group-by, not further reduced.** The value of each entry is that group's raw array of words (a `uint64` `np.ndarray`), preserving input order within the group.
- **Key is the group's `moc_min`.** Per @espg's [answer](https://github.com/espg/mortie/issues/74#issuecomment-4814336560): "split to list of arrays, then run `moc_min` on each of the groups; the dict return then has the `moc_min` output as the dict key." Self-describing, same 64-bit width as the data, and the base-cell id is cheap to recover from the key (`key >> 60` minus the `+1` prefix offset, or `mort2healpix` / `MortonIndexArray.base_cell`).
- **`sort` flag.** Default `sort=False` (faster — preserves input order within each group); `sort=True` sorts each group's words for a canonical MOC per base cell. The `moc_min` key is order-insensitive, so both modes produce the same keys.
- **Standalone primitive, not a flag on `moc_min`.** `moc_min` stays strict; its mixed-base-cell error message now **points at `split_base_cells`** as the remedy (`src_rust/src/decimal_morton.rs`, `CommonAncestorError::MixedBaseCell` Display).
- Edge cases: empty input → `{}`; single base cell → one-entry dict; an empty/invalid word makes that group's `moc_min` raise `ValueError`.

## Approach

Implemented as a **thin Python wrapper in `mortie/coverage.py`**, next to `common_ancestor` / `moc_min`. It composes two existing Rust primitives rather than adding a new kernel:

- `_rustie.rust_mi_base_cell_of(words)` — the existing vectorized per-element base-cell extraction (already used by `MortonIndexArray.base_cells`) — so the 4-bit-prefix layout isn't re-hardcoded in Python.
- `moc_min` per group for the dict key.

```python
bases = _rustie.rust_mi_base_cell_of(words)
out = {}
for base in dict.fromkeys(bases.tolist()):   # stable, first-seen order
    group = words[bases == base]
    if sort:
        group = np.sort(group)
    out[int(moc_min(group))] = group
```

This matches @espg's acceptance of "a thin Python wrapper that groups by base-cell prefix then calls the existing `moc_min` per group … if it matches surrounding style." The only Rust change is the one-line `moc_min` error-message pointer the spec requires. Exported from `mortie/__init__.py` (`__all__`) consistent with `moc_min`.

## Phases

- [x] **Phase 1** — `split_base_cells` wrapper + docstring in `coverage.py`, `moc_min` mixed-base-cell error message points here (Rust), export in `__init__.py`, and `TestSplitBaseCells` tests.

(Single coherent phase: a thin wrapper over existing primitives plus a one-line Rust message edit; no useful sub-phase split.)

## How it was tested

- `cargo fmt --check` clean; `cargo test --release` — **173 passed** (the message edit touches only `Display`; no test pins the old string).
- `cargo clippy --release` — no new findings (only the pre-existing pyo3-macro `useless_conversion` warnings deferred to #48).
- `maturin develop --release`, then `flake8 mortie --select=E9,F63,F7,F82` clean and `pytest -q` — **440 passed, 8 skipped**. New `TestSplitBaseCells` (10 cases) covers: empty → `{}`, single-base-cell one-entry, multi-base-cell partition, the dict-key-is-`moc_min` invariant, base-cell id recoverable from each key, `sort=False` preserves input order vs `sort=True` canonical order (same keys), values are `uint64`, invalid-word raise, and that `moc_min` on mixed base cells raises with a message naming `split_base_cells`. The `split_base_cells` doctest also passes under `--doctest-modules`.

## Questions for review

1. **Container ordering of the dict.** Entries are inserted in first-seen base-cell order (stable `dict.fromkeys`), not sorted by base id. The spec pinned the within-group order (the `sort` flag) but not the order of the dict's entries; first-seen is the cheaper default and dicts are nominally unordered. Happy to sort entries by base id if you'd prefer a deterministic key order.
2. **Implementation site.** Done as a Python wrapper composing `rust_mi_base_cell_of` + `moc_min` (your "thin wrapper … acceptable" path) rather than a new Rust group-by kernel, since the partition is a one-pass vectorized mask and a kernel would duplicate `rust_mi_base_cell_of`. Say the word if you'd rather it live in Rust for a single-pass group-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YMu5m9gvKY6dvjYTPRyeR

---
_Generated by [Claude Code](https://claude.ai/code/session_012YMu5m9gvKY6dvjYTPRyeR)_