### PR TITLE
small fixes 2026-06-27: densify size guard (#80) + morton_polygon determinism tests (#83)

### DIFF
--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -295,9 +295,12 @@ def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD):
     Unlike :func:`morton_coverage`'s post-hoc warning, the densify path can
     over-allocate to the point of OOM before any warning is reachable — a tiny
     compact MOC densifies to ``Σ 4**(order - depth)`` flat cells (issue #80).
-    So this guards **pre-emptively**: the densified count is computed from the
-    compact MOC alone (an O(n) pass, no flat allocation) and, when it exceeds
-    ``max_cells``, a :class:`ValueError` is raised *before* materializing.
+    So this guards **pre-emptively**: an upper bound on the densified count is
+    computed from the input set alone (an O(n) pass, no flat allocation) and,
+    when it exceeds ``max_cells``, a :class:`ValueError` is raised *before*
+    materializing.  The bound is exact unless ``morton`` holds cells finer than
+    ``order`` (which coarsen and dedup on densify), where it is a safe over-count
+    — so the guard never lets more than ``max_cells`` cells through.
 
     Parameters
     ----------

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -289,10 +289,53 @@ def compress_moc(morton):
     return np.asarray(_rustie.rust_moc_normalize(morton))
 
 
-def moc_to_order(morton, order):
-    """Densify a (mixed-order) morton set to a flat list at ``order``."""
+def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD):
+    """Densify a (mixed-order) morton set to a flat list at ``order``.
+
+    Unlike :func:`morton_coverage`'s post-hoc warning, the densify path can
+    over-allocate to the point of OOM before any warning is reachable — a tiny
+    compact MOC densifies to ``Σ 4**(order - depth)`` flat cells (issue #80).
+    So this guards **pre-emptively**: the densified count is computed from the
+    compact MOC alone (an O(n) pass, no flat allocation) and, when it exceeds
+    ``max_cells``, a :class:`ValueError` is raised *before* materializing.
+
+    Parameters
+    ----------
+    morton : array_like
+        Morton indices (mixed order allowed).
+    order : int
+        Target HEALPix order to densify to.
+    max_cells : int or None, optional
+        Pre-emptive budget on the densified flat cell count.  Raises
+        :class:`ValueError` if the estimate exceeds it (default
+        ``1 << 20`` — the same ~1M-cell line as the flat-cover warning).  Pass
+        ``None`` to opt out and densify unconditionally.
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted 1-D array of flat morton indices at ``order`` (``uint64``).
+
+    Raises
+    ------
+    ValueError
+        If the estimated densified count exceeds ``max_cells``.
+
+    See Also
+    --------
+    morton_coverage : flat single-order cover (post-hoc large-cover warning).
+    """
 
     morton = np.asarray(morton, dtype=np.uint64).ravel()
+    if max_cells is not None:
+        estimated = int(_rustie.rust_moc_to_order_count(morton, order))
+        if estimated > max_cells:
+            raise ValueError(
+                f"moc_to_order would densify to ~{estimated} cells at order "
+                f"{order}, exceeding max_cells={max_cells}. Pass a larger "
+                f"max_cells, or max_cells=None to proceed (risking OOM), or "
+                f"densify to a coarser order."
+            )
     return np.asarray(_rustie.rust_moc_to_order(morton, order))
 
 

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -640,6 +640,28 @@ class TestMocToOrderGuard:
         ok = mortie.moc_to_order(moc, 8, max_cells=actual)
         assert len(ok) == actual
 
+    def test_empty_input(self):
+        # An empty MOC estimates 0 cells -> never raises, returns empty.
+        empty = np.array([], dtype=np.uint64)
+        dens = mortie.moc_to_order(empty, 8)
+        assert len(dens) == 0
+
+    def test_finer_cells_overcount_is_safe(self):
+        # Cells finer than `order` coarsen and dedup on densify, so the estimate
+        # is a safe over-count there: four order-6 siblings under one order-5
+        # ancestor flatten to 1, but the estimate counts 4. The guard must still
+        # be an upper bound (never lets more than max_cells through).
+        # The 4 order-6 children of the order-5 cell with in-base address 2
+        # (children 8..11) in base cell 0.
+        kids = np.atleast_1d(
+            mortie.norm2mort([8, 9, 10, 11], [0, 0, 0, 0], 6)).astype(np.uint64)
+        flat = mortie.moc_to_order(kids, 5, max_cells=None)
+        assert len(flat) == 1  # all four collapse to the order-5 ancestor
+        # Estimate (4) > actual (1): max_cells just below the estimate still
+        # trips even though the real count fits -- a conservative guard.
+        with pytest.raises(ValueError):
+            mortie.moc_to_order(kids, 5, max_cells=3)
+
 
 class TestCoverageHighOrder:
     """Order 19–29 coverage (issue #60).

--- a/mortie/tests/test_coverage.py
+++ b/mortie/tests/test_coverage.py
@@ -593,6 +593,54 @@ class TestCoverageMOCApi:
         assert len(cov) > 0
 
 
+class TestMocToOrderGuard:
+    """Pre-emptive densify size guard on ``moc_to_order`` (issue #80)."""
+
+    # One order-0 base cell densifies to 4**order flat cells: at order 12 that
+    # is 4**12 = ~16.7M cells, well over the 1<<20 (~1.05M) default budget.
+    BASE_CELL = np.atleast_1d(mortie.norm2mort(0, 0, 0)).astype(np.uint64)
+
+    def test_raises_by_default_above_budget(self):
+        with pytest.raises(ValueError) as exc:
+            mortie.moc_to_order(self.BASE_CELL, 12)
+        # The estimate and the budget are named in the message.
+        msg = str(exc.value)
+        assert "max_cells" in msg
+        assert str(4 ** 12) in msg
+
+    def test_max_cells_none_opts_out(self):
+        # order 10 -> 4**10 = ~1.05M cells: over the default, but None proceeds.
+        dens = mortie.moc_to_order(self.BASE_CELL, 10, max_cells=None)
+        assert len(dens) == 4 ** 10
+
+    def test_explicit_higher_budget_proceeds(self):
+        dens = mortie.moc_to_order(self.BASE_CELL, 10, max_cells=4 ** 10)
+        assert len(dens) == 4 ** 10
+
+    def test_cover_under_budget_unaffected(self):
+        # A handful of order-8 cells densify ~1:1 -> far under the budget.
+        sq_lats = TestCoverageMOCApi.SQ_LATS
+        sq_lons = TestCoverageMOCApi.SQ_LONS
+        moc = mortie.morton_coverage_moc(sq_lats, sq_lons, order=8)
+        flat = mortie.morton_coverage(sq_lats, sq_lons, order=8)
+        dens = mortie.moc_to_order(moc, 8)  # default budget, no raise
+        assert set(int(x) for x in dens) == set(int(x) for x in flat)
+
+    def test_estimate_matches_actual_flat_count(self):
+        # On a canonical MOC the estimate is exact: equal to the real flat len.
+        sq_lats = TestCoverageMOCApi.SQ_LATS
+        sq_lons = TestCoverageMOCApi.SQ_LONS
+        moc = mortie.compress_moc(
+            mortie.morton_coverage(sq_lats, sq_lons, order=8))
+        actual = len(mortie.moc_to_order(moc, 8, max_cells=None))
+        # The guard's estimate (max_cells == actual - 1 must trip; == actual
+        # must pass) brackets the exact count.
+        with pytest.raises(ValueError):
+            mortie.moc_to_order(moc, 8, max_cells=actual - 1)
+        ok = mortie.moc_to_order(moc, 8, max_cells=actual)
+        assert len(ok) == actual
+
+
 class TestCoverageHighOrder:
     """Order 19–29 coverage (issue #60).
 

--- a/mortie/tests/test_prefix_trie.py
+++ b/mortie/tests/test_prefix_trie.py
@@ -483,6 +483,22 @@ class TestMortonPolygonDeterminism:
             "f87e4659200f68b46cb9d68cbb48d65018228ca26d5c5fa4811c8ca774ee276d"
         )
 
+    def test_golden_tie_break_deeper(self):
+        """Second golden at budget 10 — a deeper mid-tie cut.
+
+        Budget 6 resolves a tie at the depth-1 level; budget 10 resolves one a
+        level deeper (the ``1111/1112/...`` frontier), so this guards the
+        tie-break order at a deeper cut too.
+        """
+        chars = self._chars(10)
+        assert chars == [
+            "1111", "1112", "1121", "1122", "121", "122",
+            "211", "212", "221", "222",
+        ]
+        assert hashlib.sha256("\n".join(chars).encode()).hexdigest() == (
+            "3ec1d2bcb813fee598fa61c1c821a3a509a27e7cd593a3d8b88701fea82de515"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: mantissa_array

--- a/mortie/tests/test_prefix_trie.py
+++ b/mortie/tests/test_prefix_trie.py
@@ -11,6 +11,10 @@ Tests cover:
 """
 
 import hashlib
+import os
+import subprocess
+import sys
+import textwrap
 
 import numpy as np
 import pytest
@@ -392,6 +396,92 @@ class TestMortonPolygon:
             assert r.nchildren == 0
         refined = morton_polygon(roots, n_cells=10)
         assert len(refined) == len(roots)
+
+
+# ---------------------------------------------------------------------------
+# Tests: morton_polygon tie-break determinism (issue #83)
+#
+# The heap is keyed by ``(-efficiency, seq, node)`` with a unique monotonic
+# ``seq`` (mortie/prefix_trie.py), so ties are resolved by insertion order — a
+# total order with no hash/dict/set dependence.  These pin that determinism:
+# a deliberately symmetric, tie-heavy input where several sibling subtrees have
+# identical area/efficiency, so the *budget cutoff falls in the middle of a tie*
+# and the seq tiebreak decides which symmetric subtree expands.
+# ---------------------------------------------------------------------------
+
+# Four identical-shape subtrees under base cells 1 and 2: every node at a given
+# depth has the same area, so efficiencies tie across all siblings.
+_TIE_HEAVY = [
+    1111, 1112, 1121, 1122, 1211, 1212, 1221, 1222,
+    2111, 2112, 2121, 2122, 2211, 2212, 2221, 2222,
+]
+
+
+class TestMortonPolygonDeterminism:
+    """Pin ``morton_polygon`` tie-break determinism (issue #83)."""
+
+    def _chars(self, n_cells):
+        roots = split_children(_packed_arr(_TIE_HEAVY))
+        return [n.characteristic for n in morton_polygon(roots, n_cells=n_cells)]
+
+    def test_repeatable_within_process(self):
+        """Many calls on a tie-rich input return a byte-identical cell set."""
+        # Budget 6 cuts through a tie: only some of the symmetric subtrees can
+        # expand, so the seq tiebreak picks which -- the exposed decision.
+        first = self._chars(6)
+        for _ in range(50):
+            assert self._chars(6) == first
+        # Several budgets, each rebuilt from scratch so node identity differs.
+        for budget in [4, 6, 8, 10, 12]:
+            assert self._chars(budget) == self._chars(budget)
+
+    def test_stable_across_pythonhashseed(self):
+        """Result is independent of PYTHONHASHSEED (no set/dict ordering leak).
+
+        Run in subprocesses with different hash seeds; the emitted characteristic
+        list must be identical.  This is the one real run-to-run exposure if
+        hash-ordered containers were ever reintroduced on this path.
+        """
+        script = textwrap.dedent(
+            """
+            import numpy as np
+            from mortie import _rustie
+            from mortie.prefix_trie import split_children, morton_polygon
+            legacies = [
+                1111, 1112, 1121, 1122, 1211, 1212, 1221, 1222,
+                2111, 2112, 2121, 2122, 2211, 2212, 2221, 2222,
+            ]
+            arr = np.ascontiguousarray(
+                _rustie.rust_mi_from_legacy(
+                    np.ascontiguousarray(legacies, dtype=np.int64)),
+                dtype=np.int64)
+            roots = split_children(arr)
+            refined = morton_polygon(roots, n_cells=6)
+            print(",".join(n.characteristic for n in refined))
+            """
+        )
+        outputs = set()
+        for seed in ("0", "1", "12345", "99999"):
+            env = {**os.environ, "PYTHONHASHSEED": seed}
+            res = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True, text=True, env=env, check=True)
+            outputs.add(res.stdout.strip())
+        assert len(outputs) == 1, f"hash-seed-dependent output: {outputs}"
+
+    def test_golden_tie_break(self):
+        """Pinned golden for the symmetric tie-heavy input at budget 6.
+
+        Captured from the (deterministic) Rust+Python path; if the tie-break
+        order ever changes, this golden flags it.
+        """
+        chars = self._chars(6)
+        assert chars == [
+            "111", "112", "121", "122", "21", "22",
+        ]
+        assert hashlib.sha256("\n".join(chars).encode()).hexdigest() == (
+            "f87e4659200f68b46cb9d68cbb48d65018228ca26d5c5fa4811c8ca774ee276d"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -714,6 +714,19 @@ fn rust_moc_to_order(
     Ok(densified.into_pyarray_bound(py).into_any().unbind())
 }
 
+/// Exact flat cell count `rust_moc_to_order` would produce at `order`, computed
+/// from the compact MOC without materializing the flat list (issue #80).
+#[pyfunction]
+#[pyo3(signature = (morton, order))]
+fn rust_moc_to_order_count(
+    py: Python<'_>,
+    morton: PyReadonlyArray1<u64>,
+    order: u8,
+) -> PyResult<u64> {
+    let data = morton.to_vec()?;
+    Ok(py.allow_threads(|| moc::to_order_count(&data, order)))
+}
+
 /// Union (OR) of two morton covers, backed by the healpix-crate BMOC.
 #[pyfunction]
 fn rust_moc_or(
@@ -1091,6 +1104,7 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_multipolygon_coverage_moc, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_normalize, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_to_order, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_moc_to_order_count, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_or, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_and, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_minus, m)?)?;

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -154,15 +154,19 @@ pub fn to_order(morton: &[u64], order: u8) -> Vec<u64> {
     out
 }
 
-/// Exact flat cell count [`to_order`] would produce, from the compact MOC alone
-/// (no flat allocation) — the pre-emptive densify guard's estimate (issue #80).
+/// Upper bound on the flat cell count [`to_order`] would produce, from the input
+/// set alone (no flat allocation) — the pre-emptive densify guard's estimate
+/// (issue #80).
 ///
 /// Each cell coarser than `order` densifies to `4^(order-depth)` leaves; a cell
 /// at or finer than `order` contributes 1.  The sum is `Σ 4^(order-depth)` over
-/// the input, an O(n_moc) pass — exact over a canonical (sibling-merged,
-/// ancestor-pruned) MOC, and a safe over-count otherwise (the flat path dedups,
-/// so the real count can only be smaller).  Saturates so a pathological estimate
-/// cannot overflow the guard it feeds.
+/// the input, an O(n_moc) pass.  It is **exact when no input cell is finer than
+/// `order`** (the common case for a densify target at/below the MOC's depth) and
+/// otherwise a safe *over*-count: `to_order` coarsens finer cells to their
+/// ancestor at `order` and dedups, so finer siblings sharing an ancestor collapse
+/// to one flat cell while this counts each as 1 — the real count can only be
+/// smaller, so the guard never lets through more than estimated.  Saturates so a
+/// pathological estimate cannot overflow the guard it feeds.
 pub fn to_order_count(morton: &[u64], order: u8) -> u64 {
     let mut total: u64 = 0;
     for &m in morton {
@@ -282,19 +286,37 @@ mod tests {
     }
 
     #[test]
-    fn test_to_order_count_matches_flat() {
-        // The estimate must equal the actual flat length over a canonical MOC.
-        // Mixed-order cover: a coarse cell, some same-order cells, one finer.
+    fn test_to_order_count_exact_when_no_finer_cells() {
+        // Exact when no input cell is finer than `order`: a coarse cell plus
+        // some at-order cells.  4^(5-2) + 1 + 1 = 66.
         let cover = vec![
-            nested2mort(7, 2),            // expands to 4^(5-2) = 64
-            nested2mort(10, 5),           // at order -> 1
-            nested2mort(11, 5),           // at order -> 1
-            nested2mort((9 << 2) | 1, 6), // finer than order -> 1
+            nested2mort(7, 2),  // expands to 4^(5-2) = 64
+            nested2mort(10, 5), // at order -> 1
+            nested2mort(11, 5), // at order -> 1
         ];
         let estimate = to_order_count(&cover, 5);
         let flat = to_order(&cover, 5);
-        assert_eq!(estimate, 67);
+        assert_eq!(estimate, 66);
         assert_eq!(estimate, flat.len() as u64);
+    }
+
+    #[test]
+    fn test_to_order_count_overcounts_finer_siblings() {
+        // Cells finer than `order` coarsen to a shared ancestor and dedup in
+        // `to_order`, so the estimate is a safe *over*-count there: four depth-6
+        // siblings under one depth-5 ancestor flatten to 1 cell, but the count
+        // adds 1 each (4).  estimate >= actual must hold.
+        let cover: Vec<u64> = (0..4).map(|s| nested2mort((9 << 2) | s, 6)).collect();
+        let estimate = to_order_count(&cover, 5);
+        let flat = to_order(&cover, 5);
+        assert_eq!(estimate, 4, "one per finer cell");
+        assert_eq!(flat.len(), 1, "all four collapse to ancestor 9@5");
+        assert!(estimate >= flat.len() as u64, "estimate is an upper bound");
+    }
+
+    #[test]
+    fn test_to_order_count_empty() {
+        assert_eq!(to_order_count(&[], 5), 0);
     }
 
     #[test]

--- a/src_rust/src/moc.rs
+++ b/src_rust/src/moc.rs
@@ -154,6 +154,29 @@ pub fn to_order(morton: &[u64], order: u8) -> Vec<u64> {
     out
 }
 
+/// Exact flat cell count [`to_order`] would produce, from the compact MOC alone
+/// (no flat allocation) — the pre-emptive densify guard's estimate (issue #80).
+///
+/// Each cell coarser than `order` densifies to `4^(order-depth)` leaves; a cell
+/// at or finer than `order` contributes 1.  The sum is `Σ 4^(order-depth)` over
+/// the input, an O(n_moc) pass — exact over a canonical (sibling-merged,
+/// ancestor-pruned) MOC, and a safe over-count otherwise (the flat path dedups,
+/// so the real count can only be smaller).  Saturates so a pathological estimate
+/// cannot overflow the guard it feeds.
+pub fn to_order_count(morton: &[u64], order: u8) -> u64 {
+    let mut total: u64 = 0;
+    for &m in morton {
+        let (_nested, depth) = mort2nested(m);
+        let cells = if depth < order {
+            1u64 << (2 * (order - depth) as u32)
+        } else {
+            1
+        };
+        total = total.saturating_add(cells);
+    }
+    total
+}
+
 /// Half-open range `[start, end)` a cell covers on the uniform `MAX_DEPTH` grid.
 #[inline]
 fn cell_range(nested: u64, depth: u8) -> (u64, u64) {
@@ -256,6 +279,22 @@ mod tests {
         let mut expected = cells.clone();
         expected.sort_unstable();
         assert_eq!(flat, expected);
+    }
+
+    #[test]
+    fn test_to_order_count_matches_flat() {
+        // The estimate must equal the actual flat length over a canonical MOC.
+        // Mixed-order cover: a coarse cell, some same-order cells, one finer.
+        let cover = vec![
+            nested2mort(7, 2),            // expands to 4^(5-2) = 64
+            nested2mort(10, 5),           // at order -> 1
+            nested2mort(11, 5),           // at order -> 1
+            nested2mort((9 << 2) | 1, 6), // finer than order -> 1
+        ];
+        let estimate = to_order_count(&cover, 5);
+        let flat = to_order(&cover, 5);
+        assert_eq!(estimate, 67);
+        assert_eq!(estimate, flat.len() as u64);
     }
 
     #[test]


### PR DESCRIPTION
Bundled `small-fix` PR for two issues.

Closes #80
Closes #83

## Phases

- [x] Phase 1 (#80): pre-emptive flat-cover size guard on `moc_to_order`
- [x] Phase 2 (#83): pin `morton_polygon` tie-break determinism (golden + repeatability tests)

---

## Phase 1 — #80: pre-emptive densify size guard

Per the [@espg decision](https://github.com/espg/mortie/issues/80#issuecomment-4815325679): **option (2)** — raise-by-default with an opt-out flag — applied **only** to the densify path `moc_to_order`. `morton_coverage`'s existing post-hoc warn behavior is **unchanged**.

**What/approach.** The densify path is the real OOM hazard: a tiny compact MOC can densify to billions of flat cells before any warning is reachable. The densified count is computable from the compact MOC *before* allocation, since each morton word self-encodes its depth — a cell coarser than `order` expands to `4**(order-depth)` leaves (`src_rust/src/moc.rs` `to_order`), so `estimated = Σ 4**(order-depth)` (cells at/below `order` contribute 1). This is an O(n_moc) pass with no flat allocation.

- New Rust `moc::to_order_count(morton, order)` mirrors `to_order`'s arithmetic and returns the flat count, saturating so a pathological input can't overflow the guard. Bound to Python as `rust_moc_to_order_count` (`src_rust/src/lib.rs`). The Rust estimate is used (not a Python loop) to keep it cheap over large arrays.
- `moc_to_order(morton, order, max_cells=1<<20)` (`mortie/coverage.py`) estimates first and **raises `ValueError` by default** when the estimate exceeds `max_cells`, naming the estimate and the budget. `max_cells=None` opts out and densifies unconditionally. Default budget reuses the existing `_FLAT_COVER_WARN_THRESHOLD = 1 << 20` constant.

**Estimate accuracy.** The bound is **exact when no input cell is finer than `order`** (the common densify case). When the input holds cells *finer* than `order`, `to_order` coarsens them to their ancestor and dedups, so finer siblings collapse to one flat cell while the count adds 1 each — a safe *over*-count, so the guard never lets more than `max_cells` through (it can only conservatively raise under budget). Docstrings and tests state this precisely (folded from the Phase 1 self-review — see the PR comment below).

**How tested.**
- Rust: `cargo test --release` (176 pass) — `test_to_order_count_exact_when_no_finer_cells` (estimate == real flat length, exact value 66), `test_to_order_count_overcounts_finer_siblings` (4 finer siblings collapse to 1; estimate is an upper bound), `test_to_order_count_empty`.
- Python: `pytest mortie/tests/test_coverage.py` `TestMocToOrderGuard` — above-budget raises by default with the estimate named; `max_cells=None` proceeds; under-budget unaffected; estimate brackets the actual flat count on a canonical MOC; empty input; finer-cell over-count is a safe upper bound.
- `cargo fmt`, `cargo clippy --release` (no new warnings reference the added fn; remaining are pre-existing in unrelated functions), `flake8 mortie --select=E9,F63,F7,F82` clean.

## Phase 2 — #83: pin `morton_polygon` tie-break determinism

Per the [@espg decision](https://github.com/espg/mortie/issues/83#issuecomment-4815291563): **option 1 — pin the current behavior + golden test**. **No change to the tie-break logic** — `morton_polygon` is already deterministic (Python `heapq` keyed by `(-efficiency, seq, node)` with a unique monotonic `seq`, `mortie/prefix_trie.py`), so ties resolve by insertion order with no hash/dict/set dependence. Tests only.

**What/approach.** Added `TestMortonPolygonDeterminism` in `mortie/tests/test_prefix_trie.py`. The input is a deliberately symmetric, tie-heavy set (four identical-shape subtrees under base cells 1 and 2), so at budget 6 the budget cutoff falls *in the middle of a tie* and the `seq` tiebreak decides which symmetric subtree expands — exactly the exposed decision.

- `test_repeatable_within_process`: 50 calls on the tie-rich input return a byte-identical characteristic list (and several budgets are each rebuilt-and-compared).
- `test_stable_across_pythonhashseed`: runs the cover in subprocesses under `PYTHONHASHSEED` ∈ {0, 1, 12345, 99999}; the emitted list is identical across all — the one real run-to-run exposure if hash-ordered containers were ever reintroduced on this path.
- `test_golden_tie_break`: pinned golden (list + sha256) for budget 6, in the style of the existing `test_prefix_trie.py` goldens.

**How tested.** `pytest mortie/tests/test_prefix_trie.py` (all pass, incl. the subprocess hash-seed test); full suite `pytest -q` → 451 passed, 8 skipped; `flake8 mortie --select=E9,F63,F7,F82` clean.

---

## Questions for review

Two choices on #80 that were not explicitly pinned (defaults applied, non-blocking):

1. **Exception type.** Used `ValueError`, consistent with `coverage.py`'s existing `1 <= order <= 29` / mutually-exclusive-arg raises. Alternative: `MemoryError` (signals the actual hazard more directly). Easy to switch if preferred.
2. **Threshold.** Reused the single `1 << 20` constant (the existing warn line) as the default `max_cells`. Alternative: a separate, higher hard-guard line — the warn is a nudge, an OOM wall could reasonably sit higher.

---

This PR's work was authored by an automated Claude routine run on the `claude/small-fixes-2026-06-27` branch.