### PR TITLE
morton index surface followup: points= encode + __from_arrow__

### DIFF
--- a/mortie/arrow.py
+++ b/mortie/arrow.py
@@ -124,7 +124,10 @@ def from_morton_index(array):
     same ``uint64`` words. ``array`` may also be a raw ``uint64`` array-like of
     words. Missing elements -- a ``MortonIndexArray`` for which :meth:`isna` is
     True, i.e. the all-zero empty sentinel word -- emit Arrow nulls, so a null
-    survives the round-trip back through :func:`to_morton_index`.
+    survives the round-trip back through :func:`to_morton_index`. (The missing
+    mask is read off the ``uint64`` words, so a sentinel word in a raw array is
+    treated as a null too; an already-built Arrow array goes back through
+    :func:`to_morton_index`, not here.)
     """
     pa = _require_pyarrow()
     ext_type = _build_type()

--- a/mortie/arrow.py
+++ b/mortie/arrow.py
@@ -122,12 +122,19 @@ def from_morton_index(array):
 
     Builds a pyarrow ``ExtensionArray`` of the ``morton_index`` type over the
     same ``uint64`` words. ``array`` may also be a raw ``uint64`` array-like of
-    words.
+    words. Missing elements -- a ``MortonIndexArray`` for which :meth:`isna` is
+    True, i.e. the all-zero empty sentinel word -- emit Arrow nulls, so a null
+    survives the round-trip back through :func:`to_morton_index`.
     """
     pa = _require_pyarrow()
     ext_type = _build_type()
-    data = getattr(array, "_data", array)
-    storage = pa.array(np.asarray(data, dtype=np.uint64), type=pa.uint64())
+    data = np.asarray(getattr(array, "_data", array), dtype=np.uint64)
+    # The empty sentinel (all-zero word, prefix 0) is the missing value on the
+    # pandas side; mirror it as an Arrow null so isna() round-trips both ways.
+    from .morton_index import MortonIndexArray
+
+    mask = data == MortonIndexArray._SENTINEL
+    storage = pa.array(data, type=pa.uint64(), mask=mask)
     return pa.ExtensionArray.from_storage(ext_type, storage)
 
 
@@ -136,12 +143,17 @@ def to_morton_index(array):
 
     Accepts the extension array (or its plain ``uint64`` storage) and returns the
     pandas-side :class:`~mortie.morton_index.MortonIndexArray` over the same
-    words.
+    words. Arrow nulls come back as the all-zero empty sentinel word, so the
+    pandas :meth:`isna` reports them as missing.
     """
     _require_pyarrow()
     from .morton_index import MortonIndexArray
 
     storage = getattr(array, "storage", array)
+    # Fill nulls with the empty sentinel before materializing: a uint64 array
+    # with a null buffer cannot go straight to numpy.
+    if storage.null_count:
+        storage = storage.fill_null(int(MortonIndexArray._SENTINEL))
     words = storage.to_numpy(zero_copy_only=False).astype(np.uint64, copy=False)
     return MortonIndexArray(words)
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -90,6 +90,25 @@ def _build_classes():
         def construct_array_type(cls):
             return MortonIndexArray
 
+        def __from_arrow__(self, array):
+            """Build a :class:`MortonIndexArray` from a pyarrow array.
+
+            This is the hook pandas calls on ``table.to_pandas()`` for a column
+            tagged with the ``morton_index`` Arrow extension type, so the words
+            land back as a ``MortonIndexArray`` (not a plain int64 Series).
+            Accepts a ``pa.Array`` or a ``pa.ChunkedArray``; the pyarrow import
+            stays lazy so this module remains numpy-only importable.
+            """
+            from .arrow import _require_pyarrow, to_morton_index
+
+            pa = _require_pyarrow()
+            if isinstance(array, pa.ChunkedArray):
+                parts = [to_morton_index(chunk) for chunk in array.chunks]
+                if not parts:
+                    return MortonIndexArray(np.empty(0, dtype=np.uint64))
+                return MortonIndexArray._concat_same_type(parts)
+            return to_morton_index(array)
+
     class MortonIndexArray(ExtensionArray):
         """An array of packed 64-bit ``morton_index`` MOC words.
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -129,19 +129,36 @@ def _build_classes():
             return cls(words, copy=copy)
 
         @classmethod
-        def from_latlon(cls, lat, lon, order=MAX_ORDER):
+        def from_latlon(cls, lat, lon, order=MAX_ORDER, points=False):
             """Hash lat/lon (degrees) to ``morton_index`` words at ``order``.
 
             Routes through the Rust ``healpix`` bridge: lat/lon -> NESTED ids ->
             packed words, so it matches the cross-library nested representation.
+
+            With ``points=False`` (the default) the result is an order-``order``
+            **area** cell (``Kind::Area``). With ``points=True`` the location is
+            encoded as a max-resolution **point** (``Kind::Point``); point
+            encoding is order-29-only, so an explicit ``order != 29`` raised
+            together with ``points=True`` is a ``ValueError`` (the default
+            ``order`` is ``MAX_ORDER`` so the point path needs no extra argument).
             """
+            if points and int(order) != MAX_ORDER:
+                raise ValueError(
+                    "points=True encodes an order-29 point; pass order=29 "
+                    "(the default) or omit it"
+                )
             lat = np.ascontiguousarray(np.asarray(lat), dtype=np.float64)
             lon = np.ascontiguousarray(np.asarray(lon), dtype=np.float64)
             if lat.shape != lon.shape:
                 raise ValueError("lat and lon must have the same shape")
-            nested = _rustie.rust_ang2pix(int(order), lon, lat)
-            nested = np.ascontiguousarray(nested, dtype=np.uint64)
-            words = _rustie.rust_mi_from_nested(nested, int(order))
+            if points:
+                nested = _rustie.rust_ang2pix(MAX_ORDER, lon, lat)
+                nested = np.ascontiguousarray(nested, dtype=np.uint64)
+                words = _rustie.rust_mi_from_nested_point(nested)
+            else:
+                nested = _rustie.rust_ang2pix(int(order), lon, lat)
+                nested = np.ascontiguousarray(nested, dtype=np.uint64)
+                words = _rustie.rust_mi_from_nested(nested, int(order))
             return cls(words)
 
         @classmethod

--- a/mortie/tests/test_arrow.py
+++ b/mortie/tests/test_arrow.py
@@ -169,7 +169,14 @@ class TestFromArrowHook:
 # Null / NA round-trip: sentinel <-> Arrow null (issue #79)
 # ---------------------------------------------------------------------------
 
-SENTINEL = 0  # the all-zero empty word MortonIndexArray.isna() treats as missing
+# The missing value is the all-zero empty word MortonIndexArray.isna() treats
+# as missing; derive it from the array constant (pandas-gated) rather than
+# hardcoding 0, falling back to the documented all-zero value when pandas is
+# absent so this module still imports numpy/pyarrow-only.
+try:
+    SENTINEL = int(mortie.MortonIndexArray._SENTINEL)
+except ImportError:  # pragma: no cover - pandas absent
+    SENTINEL = 0
 
 
 def _words_with_gap():
@@ -187,6 +194,28 @@ class TestNullRoundTrip:
         arr = marrow.from_morton_index(words)
         assert arr.null_count == 2
         assert arr.is_null().to_pylist() == [w == SENTINEL for w in words]
+
+    def test_no_null_words_round_trip_unchanged(self):
+        # The mask path leaves a null-free array byte-identical both ways.
+        words = _sample_words()
+        arr = marrow.from_morton_index(words)
+        assert arr.null_count == 0
+        np.testing.assert_array_equal(marrow.to_morton_index(arr)._data, words)
+
+    def test_all_null_array_round_trips_to_sentinel(self):
+        # Every element missing -> every word the sentinel, isna() all True.
+        pytest.importorskip("pandas")
+        arr = pa.array([None, None, None], type=pa.uint64())
+        mia = marrow.to_morton_index(arr)
+        np.testing.assert_array_equal(mia._data, np.zeros(3, dtype=np.uint64))
+        assert mia.isna().all()
+
+    def test_empty_plain_array_round_trips(self):
+        # The empty plain-Array path (distinct from the empty-chunked case).
+        empty = pa.array([], type=pa.uint64())
+        mia = marrow.to_morton_index(empty)
+        assert len(mia) == 0
+        assert marrow.from_morton_index(mia).null_count == 0
 
     def test_mortonindexarray_isna_emits_arrow_nulls(self):
         # Same, but starting from a MortonIndexArray (isna() drives the mask).

--- a/mortie/tests/test_arrow.py
+++ b/mortie/tests/test_arrow.py
@@ -116,6 +116,48 @@ class TestParquet:
 
 
 # ---------------------------------------------------------------------------
+# __from_arrow__ hook: table.to_pandas() yields a MortonIndexArray (issue #79)
+# ---------------------------------------------------------------------------
+
+
+class TestFromArrowHook:
+    def test_to_pandas_yields_morton_index_series(self):
+        pytest.importorskip("pandas")
+        words = _sample_words()
+        table = pa.table({"mi": marrow.from_morton_index(words)})
+        series = table.to_pandas()["mi"]
+        # Not a plain int64 column: the extension dtype survives.
+        assert series.dtype.name == "morton_index"
+        assert isinstance(series.array, mortie.MortonIndexArray)
+        np.testing.assert_array_equal(series.array._data, words)
+
+    def test_from_arrow_handles_chunked_array(self):
+        pytest.importorskip("pandas")
+        words = _sample_words(n=8)
+        ext = marrow.from_morton_index(words)
+        chunked = pa.chunked_array([ext[:3], ext[3:]])
+        mia = mortie.MortonIndexDtype().__from_arrow__(chunked)
+        assert isinstance(mia, mortie.MortonIndexArray)
+        np.testing.assert_array_equal(mia._data, words)
+
+    def test_from_arrow_handles_plain_array(self):
+        pytest.importorskip("pandas")
+        words = _sample_words()
+        mia = mortie.MortonIndexDtype().__from_arrow__(marrow.from_morton_index(words))
+        assert isinstance(mia, mortie.MortonIndexArray)
+        np.testing.assert_array_equal(mia._data, words)
+
+    def test_parquet_to_pandas_full_round_trip(self, tmp_path):
+        pytest.importorskip("pandas")
+        words = _sample_words()
+        path = tmp_path / "mi.parquet"
+        pq.write_table(pa.table({"mi": marrow.from_morton_index(words)}), path)
+        series = pq.read_table(path).to_pandas()["mi"]
+        assert series.dtype.name == "morton_index"
+        np.testing.assert_array_equal(series.array._data, words)
+
+
+# ---------------------------------------------------------------------------
 # Optional-extra contract
 # ---------------------------------------------------------------------------
 

--- a/mortie/tests/test_arrow.py
+++ b/mortie/tests/test_arrow.py
@@ -147,6 +147,13 @@ class TestFromArrowHook:
         assert isinstance(mia, mortie.MortonIndexArray)
         np.testing.assert_array_equal(mia._data, words)
 
+    def test_from_arrow_handles_empty_chunked_array(self):
+        pytest.importorskip("pandas")
+        empty = pa.chunked_array([], type=marrow.morton_index_type())
+        mia = mortie.MortonIndexDtype().__from_arrow__(empty)
+        assert isinstance(mia, mortie.MortonIndexArray)
+        assert len(mia) == 0
+
     def test_parquet_to_pandas_full_round_trip(self, tmp_path):
         pytest.importorskip("pandas")
         words = _sample_words()
@@ -154,6 +161,7 @@ class TestFromArrowHook:
         pq.write_table(pa.table({"mi": marrow.from_morton_index(words)}), path)
         series = pq.read_table(path).to_pandas()["mi"]
         assert series.dtype.name == "morton_index"
+        assert isinstance(series.array, mortie.MortonIndexArray)
         np.testing.assert_array_equal(series.array._data, words)
 
 

--- a/mortie/tests/test_arrow.py
+++ b/mortie/tests/test_arrow.py
@@ -166,6 +166,76 @@ class TestFromArrowHook:
 
 
 # ---------------------------------------------------------------------------
+# Null / NA round-trip: sentinel <-> Arrow null (issue #79)
+# ---------------------------------------------------------------------------
+
+SENTINEL = 0  # the all-zero empty word MortonIndexArray.isna() treats as missing
+
+
+def _words_with_gap():
+    """Sample words with the empty sentinel planted at two positions."""
+    words = _sample_words().copy()
+    words[2] = SENTINEL
+    words[5] = SENTINEL
+    return words
+
+
+class TestNullRoundTrip:
+    def test_isna_words_emit_arrow_nulls(self):
+        # An isna() element (sentinel word) goes OUT as an Arrow null.
+        words = _words_with_gap()
+        arr = marrow.from_morton_index(words)
+        assert arr.null_count == 2
+        assert arr.is_null().to_pylist() == [w == SENTINEL for w in words]
+
+    def test_mortonindexarray_isna_emits_arrow_nulls(self):
+        # Same, but starting from a MortonIndexArray (isna() drives the mask).
+        pytest.importorskip("pandas")
+        mia = mortie.MortonIndexArray(_words_with_gap())
+        arr = marrow.from_morton_index(mia)
+        assert arr.null_count == 2
+        assert arr.is_null().to_pylist() == list(mia.isna())
+
+    def test_arrow_nulls_come_back_as_sentinel(self):
+        # A null IN comes back as the sentinel so isna() is True.
+        pytest.importorskip("pandas")
+        words = _words_with_gap()
+        arr = marrow.from_morton_index(words)
+        mia = marrow.to_morton_index(arr)
+        np.testing.assert_array_equal(mia._data, words)
+        np.testing.assert_array_equal(mia.isna(), words == SENTINEL)
+
+    def test_from_arrow_handles_nulls_plain_array(self):
+        pytest.importorskip("pandas")
+        words = _words_with_gap()
+        arr = marrow.from_morton_index(words)
+        mia = mortie.MortonIndexDtype().__from_arrow__(arr)
+        np.testing.assert_array_equal(mia._data, words)
+        np.testing.assert_array_equal(mia.isna(), words == SENTINEL)
+
+    def test_from_arrow_handles_nulls_chunked_array(self):
+        pytest.importorskip("pandas")
+        words = _words_with_gap()
+        ext = marrow.from_morton_index(words)
+        chunked = pa.chunked_array([ext[:4], ext[4:]])
+        mia = mortie.MortonIndexDtype().__from_arrow__(chunked)
+        np.testing.assert_array_equal(mia._data, words)
+        np.testing.assert_array_equal(mia.isna(), words == SENTINEL)
+
+    def test_parquet_to_pandas_preserves_nulls(self, tmp_path):
+        pytest.importorskip("pandas")
+        words = _words_with_gap()
+        path = tmp_path / "mi_null.parquet"
+        pq.write_table(pa.table({"mi": marrow.from_morton_index(words)}), path)
+        # The parquet column carries the null buffer through.
+        assert pq.read_table(path).column("mi").null_count == 2
+        series = pq.read_table(path).to_pandas()["mi"]
+        assert series.dtype.name == "morton_index"
+        np.testing.assert_array_equal(series.array._data, words)
+        np.testing.assert_array_equal(series.array.isna(), words == SENTINEL)
+
+
+# ---------------------------------------------------------------------------
 # Optional-extra contract
 # ---------------------------------------------------------------------------
 

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -129,6 +129,19 @@ class TestPointEncode:
         np.testing.assert_array_equal(kinds_area, np.zeros(len(self.LATS), np.uint8))
         np.testing.assert_array_equal(kinds_def, np.zeros(len(self.LATS), np.uint8))
 
+    def test_point_words_differ_from_area_words(self):
+        # Same location, but the packed point word is a distinct value from the
+        # order-29 area word (the suffix carries the point flag).
+        pts = MIA.from_latlon(self.LATS, self.LONS, points=True)
+        area = MIA.from_latlon(self.LATS, self.LONS, order=29)
+        assert np.all(pts._data != area._data)
+
+    def test_points_true_explicit_order29_is_accepted(self):
+        # Passing the (redundant) explicit order=29 with points=True is allowed.
+        explicit = MIA.from_latlon(self.LATS, self.LONS, order=29, points=True)
+        default = MIA.from_latlon(self.LATS, self.LONS, points=True)
+        np.testing.assert_array_equal(explicit._data, default._data)
+
     def test_points_true_with_non29_order_raises(self):
         with pytest.raises(ValueError, match="order-29 point"):
             MIA.from_latlon(self.LATS, self.LONS, order=12, points=True)

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -87,6 +87,53 @@ class TestVsCdshealpix:
         np.testing.assert_array_equal(depth, np.full(len(lats), order))
 
 
+class TestPointEncode:
+    """from_latlon(points=True) surfaces the Kind::Point encode path (issue #79)."""
+
+    LATS = np.array([0.0, 41.8, -41.8, 80.0, -80.0, 12.3, -67.9])
+    LONS = np.array([0.0, 45.0, 135.0, 200.0, 305.0, 91.5, 270.2])
+
+    def test_points_true_yields_order29_points(self):
+        a = MIA.from_latlon(self.LATS, self.LONS, points=True)
+        # rust_mi_decode returns (base_cells, orders, kinds, tuples); kind 1=point.
+        _, orders, kinds, _ = _rustie.rust_mi_decode(a._data)
+        np.testing.assert_array_equal(orders, np.full(len(self.LATS), 29))
+        np.testing.assert_array_equal(kinds, np.ones(len(self.LATS), dtype=np.uint8))
+
+    def test_points_share_nested_cell_with_area(self):
+        # A point and the order-29 area cell for the same location carry the same
+        # nested cell (the point/area flag is the decimal_morton kind, not nested).
+        pts = MIA.from_latlon(self.LATS, self.LONS, points=True)
+        area = MIA.from_latlon(self.LATS, self.LONS, order=29)
+        pn, pd = pts.to_nested()
+        an, ad = area.to_nested()
+        np.testing.assert_array_equal(pn, an)
+        np.testing.assert_array_equal(pd, ad)
+
+    def test_points_coarsen_and_to_nested(self):
+        pts = MIA.from_latlon(self.LATS, self.LONS, points=True)
+        # to_nested recovers an order-29 cell for every point.
+        _, depth = pts.to_nested()
+        np.testing.assert_array_equal(depth, np.full(len(self.LATS), 29))
+        # Coarsening a point to order 5 yields an order-5 area cell.
+        coarse = pts.coarsen(5)
+        _, orders, kinds, _ = _rustie.rust_mi_decode(coarse._data)
+        np.testing.assert_array_equal(orders, np.full(len(self.LATS), 5))
+        np.testing.assert_array_equal(kinds, np.zeros(len(self.LATS), dtype=np.uint8))
+
+    def test_points_false_default_is_area(self):
+        area = MIA.from_latlon(self.LATS, self.LONS, order=12)
+        default = MIA.from_latlon(self.LATS, self.LONS)
+        _, _, kinds_area, _ = _rustie.rust_mi_decode(area._data)
+        _, _, kinds_def, _ = _rustie.rust_mi_decode(default._data)
+        np.testing.assert_array_equal(kinds_area, np.zeros(len(self.LATS), np.uint8))
+        np.testing.assert_array_equal(kinds_def, np.zeros(len(self.LATS), np.uint8))
+
+    def test_points_true_with_non29_order_raises(self):
+        with pytest.raises(ValueError, match="order-29 point"):
+            MIA.from_latlon(self.LATS, self.LONS, order=12, points=True)
+
+
 # ---------------------------------------------------------------------------
 # coarsen / order / base_cell domain ops
 # ---------------------------------------------------------------------------

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -526,6 +526,35 @@ pub fn from_nested(nested: u64, depth: u8) -> u64 {
     prefix | body | build_suffix(depth, t28, t29)
 }
 
+/// Pack an order-29 HEALPix NESTED index into a canonical `decimal_morton`
+/// **point** word (max resolution, no area claim).
+///
+/// The point twin of [`from_nested`]: decompose the order-29 `nested` into its
+/// 29 stored `0..=3` tuples and hand them to [`encode_point`], so the result
+/// decodes with `kind == Kind::Point` and `order == 29`. Point encoding is
+/// order-29-only, so this takes no `depth` argument.
+///
+/// # Panics
+/// Panics if the decoded base cell exceeds `11` (i.e. `nested` is too large for
+/// order 29 -- a malformed nested index).
+pub fn from_nested_point(nested: u64) -> u64 {
+    let base_u64 = nested >> (2 * MAX_ORDER as u32);
+    assert!(
+        base_u64 <= 11,
+        "nested index {} too large for order 29 (base {} > 11)",
+        nested,
+        base_u64
+    );
+
+    // Decompose into the 29 stored tuples: order n's tuple is the 2-bit pair at
+    // `2*(29-n)` of `nested` (order 1 most significant, order 29 lowest).
+    let mut tuples = [0u8; MAX_ORDER as usize];
+    for n in 1..=MAX_ORDER {
+        tuples[(n - 1) as usize] = ((nested >> (2 * (MAX_ORDER - n) as u32)) & 3) as u8;
+    }
+    encode_point(base_u64 as u8, &tuples)
+}
+
 /// Unpack a `decimal_morton` word back into its HEALPix `(depth, nested_idx)`.
 ///
 /// The inverse of [`from_nested`]: hands the cell to the `healpix` crate for
@@ -1108,6 +1137,31 @@ mod tests {
                 assert_eq!(kind_of(via_nested), Kind::Area);
             }
         }
+    }
+
+    #[test]
+    fn from_nested_point_matches_encode_point() {
+        // from_nested_point(nested) must be bit-identical to encode_point for the
+        // tuples implied by an order-29 nested index, decode as Kind::Point at
+        // order 29, and share its nested cell with the matching area word.
+        for base in 0..=11u8 {
+            let tuples = sample_tuples(MAX_ORDER, base as u64 + 5);
+            let nested = nested_from_tuples(base, &tuples, MAX_ORDER);
+            let via_nested = from_nested_point(nested);
+            let via_tuples = encode_point(base, &tuples);
+            assert_eq!(via_nested, via_tuples, "from_nested_point != encode_point");
+            assert_eq!(kind_of(via_nested), Kind::Point);
+            assert_eq!(order_of(via_nested), MAX_ORDER);
+            let (depth, back) = to_nested(via_nested).expect("to_nested");
+            assert_eq!((depth, back), (MAX_ORDER, nested));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "too large for order 29")]
+    fn from_nested_point_rejects_oversized_nested() {
+        // base would be 12 at order 29: malformed.
+        from_nested_point(12u64 << (2 * MAX_ORDER as u32));
     }
 
     #[test]

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -848,6 +848,32 @@ fn rust_mi_from_nested(
     }
 }
 
+/// Vectorized `from_nested_point`: pack order-29 HEALPix NESTED ids into
+/// `morton_index` **point** words (`Kind::Point`, u64 numpy array out). Point
+/// encoding is order-29-only, so this takes no `depth` argument.
+#[pyfunction]
+fn rust_mi_from_nested_point(
+    py: Python<'_>,
+    nested_array: PyReadonlyArray1<u64>,
+) -> PyResult<PyObject> {
+    let nested = nested_array.to_vec()?;
+    let result = py.allow_threads(|| {
+        std::panic::catch_unwind(|| {
+            nested
+                .par_iter()
+                .map(|&n| decimal_morton::from_nested_point(n))
+                .collect::<Vec<u64>>()
+        })
+    });
+    match result {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => Err(PyValueError::new_err(panic_msg(
+            e,
+            "mi_from_nested_point panicked",
+        ))),
+    }
+}
+
 /// Vectorized `to_nested`: unpack `morton_index` words (u64) back into
 /// `(nested ids u64, depths u8)`. Raises `ValueError` if any word is the empty
 /// sentinel or carries an invalid prefix.
@@ -1098,6 +1124,7 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_moc_min, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_from_nested, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_from_nested_point, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_to_nested, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_coarsen, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_order_of, m)?)?;


### PR DESCRIPTION
Closes #79

Surfaces the two `morton_index` skin gaps flagged in issue #79 (followups from #73 / #51): the `Kind::Point` encode path and the Arrow -> pandas `__from_arrow__` hook, plus proper Arrow null handling (per @espg's "Option B" directive). One PR, three phases.

## Phase (a) - thread `points=True` -> `Kind::Point`

The pandas/pyarrow skins only ever produced area cells; the kernel's point encode (`encode_point`, `decimal_morton.rs:206`) had no public surface. This adds the full bridge:

- **Rust kernel** (`src_rust/src/decimal_morton.rs`): new `from_nested_point(nested)` - the point twin of `from_nested`. It decomposes an order-29 nested id into its 29 stored `0..=3` tuples and calls `encode_point`, so the result decodes with `kind == Kind::Point`, `order == 29`. It guards an oversized nested index (base > 11) the same way `from_nested` does. Unit tests: `from_nested_point_matches_encode_point` (bit-identical to `encode_point`, `Kind::Point`, order 29, shares the nested cell with the area word) and `from_nested_point_rejects_oversized_nested`.
- **PyO3 binding** (`src_rust/src/lib.rs`): a dedicated single-purpose `rust_mi_from_nested_point(nested_array)`, mirroring `rust_mi_from_nested` (no `point: bool` flag), registered alongside it.
- **Python** (`mortie/morton_index.py`): `MortonIndexArray.from_latlon` gains `points=False`. When `points=True`, lat/lon is hashed at order 29 and routed through `rust_mi_from_nested_point`; an explicit `order != 29` passed with `points=True` raises `ValueError`. The default `order` is already `MAX_ORDER` (29), so the point path needs no extra argument.
- **Tests** (`mortie/tests/test_morton_index.py`, `TestPointEncode`): `points=True` words decode as `Kind::Point`/order 29; points share a nested cell with the matching area word; coarsening a point to a lower order yields an area cell; `points=False` (and the default) stay `Kind::Area`; `order != 29` + `points=True` raises.

### Answer to the `encode_point` order-arg question

**No, `encode_point` does not take an `order` argument.** Its signature is `pub fn encode_point(base_cell: u8, tuples: &[u8]) -> u64` (`decimal_morton.rs:206`). Point encoding is **order-29-only by construction**: it asserts `tuples.len() >= MAX_ORDER` (29) and hardcodes `MAX_ORDER` into both the body pack and the point suffix (`pack_prefix_body(base_cell, tuples, MAX_ORDER) | build_point_suffix(tuples[27], tuples[28])`). A point is the max-resolution "this exact location, no area claim" encoding, so there is no coarser-order point - that is why no order parameter exists. (By contrast the area `encode`/`from_nested` do take an order/depth, because area cells exist at every order 0..=29.) The Python side mirrors this: `points=True` forces order 29 and rejects any explicit `order != 29`, so a caller cannot ask for a non-existent "order-N point".

## Phase (b) - wire `__from_arrow__`

Before: `table.to_pandas()` on a `morton_index` Arrow column produced a plain int64 Series (the dtype had no `__from_arrow__` hook). Now:

- **Python** (`mortie/morton_index.py`): `MortonIndexDtype.__from_arrow__(self, array)` accepts a `pa.Array` or `pa.ChunkedArray`, delegates to `mortie.arrow.to_morton_index`, iterates chunks and concatenates via `MortonIndexArray._concat_same_type` for the chunked case, and returns a `MortonIndexArray`. The pyarrow import stays lazy (reuses `arrow._require_pyarrow`), so `morton_index.py` remains numpy-only importable.
- **Tests** (`mortie/tests/test_arrow.py`, `TestFromArrowHook`): `table.to_pandas()` yields a `morton_index`-dtyped Series backed by a `MortonIndexArray` with bit-identical words; `__from_arrow__` handles both plain and chunked arrays; full Parquet -> `read_table` -> `to_pandas()` preserves words + dtype.

## Phase (c) - Arrow null <-> sentinel round-trip (@espg "Option B")

Per @espg's directive (https://github.com/espg/mortie/pull/86#issuecomment-4845674053) answering the open "Questions for review" item: implement proper null handling as part of this PR. Before, a `pa.Array` null neither survived `to_morton_index` (a uint64 array with a null buffer cannot go straight to numpy) nor was emitted by `from_morton_index` for sentinel/`isna` elements. Now the null<->sentinel contract holds both directions:

- **`from_morton_index`** (`mortie/arrow.py`): builds the pyarrow storage with a validity `mask` set wherever the word equals `MortonIndexArray._SENTINEL` (the all-zero empty word `isna()` treats as missing). So an `isna()`/sentinel element going OUT becomes an Arrow null. Works from a `MortonIndexArray` (its `isna()` drives the mask) or a raw `uint64` array; the docstring notes the mask is read off the words and that re-wrapping an already-built Arrow array goes through `to_morton_index`, not here.
- **`to_morton_index`** (`mortie/arrow.py`): `fill_null(_SENTINEL)` before materializing, so an Arrow null coming IN lands as the all-zero sentinel word and `MortonIndexArray.isna()` reports it missing. `__from_arrow__` (Array + ChunkedArray + parquet) inherits this since it delegates here.
- The lazy pyarrow import is preserved; numpy stays the only runtime dep.
- **Tests** (`mortie/tests/test_arrow.py`, `TestNullRoundTrip`): sentinel words emit Arrow nulls (from raw words and from a `MortonIndexArray` via `isna()`); Arrow nulls come back as the sentinel with `isna()` True; `__from_arrow__` on null-bearing plain `pa.Array` and `pa.ChunkedArray`; full Parquet -> `read_table` -> `to_pandas()` preserves the null buffer and `isna()`; plus the all-null, no-null (mask path leaves null-free arrays byte-identical), and empty plain-array edges.

## Phases checklist

- [x] Phase (a): `from_nested_point` kernel + `rust_mi_from_nested_point` binding + `from_latlon(points=...)` + tests
- [x] Phase (b): `MortonIndexDtype.__from_arrow__` (Array + ChunkedArray) + tests
- [x] Phase (c): Arrow null <-> empty sentinel round-trip in `from_morton_index` / `to_morton_index` + tests

## How it was tested

All run in an isolated venv on this branch:

- `cargo fmt` (applied) + `cargo test` -> **175 passed** (includes the 2 new kernel tests)
- `cargo clippy` -> only pre-existing warnings (the `useless_vec` warnings in `coverage/tests.rs` and the `useless_conversion` on `PyResult` shared by all 31 existing `#[pyfunction]` bindings); the new binding matches that established pattern, so no new warning is introduced.
- `maturin develop --release` -> builds clean
- `flake8 mortie --select=E9,F63,F7,F82` -> clean; non-blocking `--max-line-length=88` pass clean on touched files
- `pytest -q` (phase c, after the self-review fold) -> **462 passed, 8 skipped** (`test_arrow.py` now 25 tests incl. the 10 `TestNullRoundTrip` cases; `test_morton_index.py` 31)

## Questions for review

- **Pre-existing clippy warnings, untouched.** `cargo clippy` reports 31 `useless_conversion` warnings on `PyResult` (every existing binding) and `useless_vec` warnings in `coverage/tests.rs`. None are introduced by this change; the new `rust_mi_from_nested_point` deliberately mirrors the existing `rust_mi_from_nested` style rather than diverging. Left as-is per the "don't fix unrelated CI noise / match the surrounding code" conventions - flag if you'd rather I clean up the binding pattern repo-wide in a separate PR.
- **`__from_arrow__` reuses `arrow._require_pyarrow`** (a leading-underscore helper) to keep the lazy-import contract in one place. If you'd prefer a public accessor instead of importing the private name, say so.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QP5rg6JZ69FxVtjH5mrixz)_