### PR TITLE
WKB/WKT geometry I/O: ingest + dissolved emit (issue #71)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 
 # Virtual environments
 .venv/
+.venv-*/
 venv/
 
 # Testing

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -26,6 +26,11 @@ from .coverage import (
     morton_coverage_moc,
     split_base_cells,
 )
+from .geometry import (
+    from_geometry,
+    from_wkb,
+    from_wkt,
+)
 from .linestring import linestring_coverage
 
 # Import prefix trie functions
@@ -95,6 +100,10 @@ __all__ = [
     'moc_min',
     'split_base_cells',
     'linestring_coverage',
+    'from_wkb',
+    'from_wkt',
+    'from_geometry',
+    'geometry',
     'MortonChild',
     'split_children',
     'split_children_geo',

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -30,6 +30,9 @@ from .geometry import (
     from_geometry,
     from_wkb,
     from_wkt,
+    to_geometry,
+    to_wkb,
+    to_wkt,
 )
 from .linestring import linestring_coverage
 
@@ -103,6 +106,9 @@ __all__ = [
     'from_wkb',
     'from_wkt',
     'from_geometry',
+    'to_wkb',
+    'to_wkt',
+    'to_geometry',
     'geometry',
     'MortonChild',
     'split_children',

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -21,17 +21,11 @@ _BACKEND = None
 
 # GEOS / shapely geometry type ids (shapely.get_type_id); spherely follows the
 # same numbering.  Only the ones we classify on are named.
-_TYPE_POINT = 0
 _TYPE_LINESTRING = 1
 _TYPE_LINEARRING = 2
 _TYPE_POLYGON = 3
-_TYPE_MULTIPOINT = 4
 _TYPE_MULTILINESTRING = 5
 _TYPE_MULTIPOLYGON = 6
-_TYPE_GEOMETRYCOLLECTION = 7
-
-_POLYGONAL = (_TYPE_POLYGON, _TYPE_MULTIPOLYGON)
-_LINEAR = (_TYPE_LINESTRING, _TYPE_MULTILINESTRING, _TYPE_LINEARRING)
 
 
 def _require_backend():
@@ -65,6 +59,27 @@ def _require_backend():
     )
 
 
+def _require_shapely(what):
+    """Require the shapely backend for *what*, raising a clear error otherwise.
+
+    The raw WKB/WKT codec works on either backend, but ring decomposition and
+    SRID-tagged emit lean on shapely's geometry-introspection API
+    (``get_exterior_ring`` / ``get_parts`` / ``set_srid``), which spherely's
+    published surface does not yet expose.  Rather than fail with an opaque
+    ``AttributeError`` deep inside, refuse up front with guidance.  Whether to
+    invest in a spherely introspection shim is an open question for the issue
+    thread (see the PR's "Questions for review").
+    """
+    name, mod = _require_backend()
+    if name != "shapely":
+        raise NotImplementedError(
+            f"{what} currently requires the shapely>=2 backend; the active "
+            f"backend is {name!r}, which mortie uses only as a raw WKB/WKT "
+            "codec. Install shapely>=2 for this operation."
+        )
+    return mod
+
+
 def _strip_ewkt_srid(text):
     """Drop a leading ``SRID=<n>;`` prefix from an EWKT string, if present.
 
@@ -94,13 +109,15 @@ def geometry_from_wkt(text):
 def geometry_to_wkb(geom, srid=None):
     """Encode a backend geometry to WKB bytes.
 
-    With ``srid`` set (e.g. ``4326``), emit **EWKB** carrying that SRID;
-    otherwise emit plain ISO/OGC WKB (the default, no embedded CRS).
+    With ``srid`` set (e.g. ``4326``), emit **EWKB** carrying that SRID
+    (shapely backend only); otherwise emit plain ISO/OGC WKB (the default, no
+    embedded CRS) — works on either backend.
     """
-    _, mod = _require_backend()
     if srid is not None:
+        mod = _require_shapely("EWKB emit (srid=)")
         geom = mod.set_srid(geom, int(srid))
         return mod.to_wkb(geom, include_srid=True)
+    _, mod = _require_backend()
     return mod.to_wkb(geom)
 
 
@@ -144,11 +161,17 @@ def decompose(geom):
     * ``kind == "linear"`` and ``parts`` is a list of lines, one per
       (multi)linestring component.
 
-    Each entry is a ``(lat, lon)`` pair of float64 degree arrays.  Points,
-    geometry collections, and empty geometries are rejected — coverage has no
-    meaning for them.
+    Each entry is a ``(lat, lon)`` pair of float64 degree arrays.  Any Z
+    coordinate is dropped (mortie is 2-D lon/lat).  Points, geometry
+    collections, and empty geometries are rejected — coverage has no meaning
+    for them.
+
+    Requires the shapely backend (it leans on shapely's ring/parts
+    introspection); see :func:`_require_shapely`.
     """
-    _, mod = _require_backend()
+    mod = _require_shapely("geometry decomposition")
+    if bool(mod.is_empty(geom)):
+        raise ValueError("empty geometry has no coverage")
     type_id = int(mod.get_type_id(geom))
 
     if type_id == _TYPE_POLYGON:
@@ -166,4 +189,94 @@ def decompose(geom):
     raise ValueError(
         f"unsupported geometry type for coverage (type id {type_id}); "
         "expected Polygon, MultiPolygon, LineString, or MultiLineString"
+    )
+
+
+# ── ingest: geometry → morton coverage ─────────────────────────────────────
+
+
+def from_geometry(geom, order=18, moc=False, normalize=True,
+                  tolerance=None, max_cells=None):
+    """Cover a backend geometry with morton indices (issue #71).
+
+    The geometry is decomposed via :func:`decompose` and routed to mortie's
+    existing coverage entry points — so WKB/WKT ingest produces exactly the same
+    cover as calling those functions on the same ``(lats, lons)`` arrays.
+
+    * **Polygon / MultiPolygon** → :func:`mortie.morton_coverage` (flat) or, with
+      ``moc=True``, :func:`mortie.morton_coverage_moc` (compact mixed-order).
+      Holes and disjoint parts are handled by the one even-odd descent.
+    * **LineString / MultiLineString** → :func:`mortie.linestring_coverage`.
+
+    Parameters
+    ----------
+    geom : backend geometry
+        A shapely/spherely geometry object (e.g. from :func:`geometry_from_wkb`).
+    order : int, optional
+        HEALPix order (1–29).  Default 18.
+    moc : bool, optional
+        Polygonal only: return a compact MOC instead of a flat cover.
+    normalize : bool, optional
+        Flat polygon cover only: auto-correct ring orientation at ingest
+        (see :func:`mortie.morton_coverage`).  Ignored when ``moc=True``.
+    tolerance, max_cells : optional
+        Polygonal ``moc=True`` only: the adaptive stop criteria of
+        :func:`mortie.morton_coverage_moc` (mutually exclusive).
+
+    Returns
+    -------
+    numpy.ndarray or list of numpy.ndarray
+        Polygonal → 1-D ``uint64`` morton array.  LineString → 1-D array;
+        MultiLineString → list of arrays, one per line (the
+        :func:`mortie.linestring_coverage` contract).
+    """
+    from .coverage import morton_coverage, morton_coverage_moc
+    from .linestring import linestring_coverage
+
+    kind, parts = decompose(geom)
+
+    if kind == "polygonal":
+        lats = [p[0] for p in parts]
+        lons = [p[1] for p in parts]
+        if moc:
+            return morton_coverage_moc(
+                lats, lons, order=order, tolerance=tolerance, max_cells=max_cells
+            )
+        return morton_coverage(lats, lons, order=order, normalize=normalize)
+
+    # linear
+    if moc or tolerance is not None or max_cells is not None:
+        raise ValueError(
+            "moc / tolerance / max_cells apply only to polygonal geometry"
+        )
+    if len(parts) == 1:
+        return linestring_coverage(parts[0][0], parts[0][1], order=order)
+    lats = [p[0] for p in parts]
+    lons = [p[1] for p in parts]
+    return linestring_coverage(lats, lons, order=order)
+
+
+def from_wkb(data, order=18, moc=False, normalize=True,
+             tolerance=None, max_cells=None):
+    """Cover a geometry given as WKB (or EWKB) bytes.
+
+    Thin wrapper: decode with :func:`geometry_from_wkb`, then
+    :func:`from_geometry`.  See :func:`from_geometry` for the parameters.
+    """
+    return from_geometry(
+        geometry_from_wkb(data), order=order, moc=moc, normalize=normalize,
+        tolerance=tolerance, max_cells=max_cells,
+    )
+
+
+def from_wkt(text, order=18, moc=False, normalize=True,
+             tolerance=None, max_cells=None):
+    """Cover a geometry given as WKT (or EWKT) text.
+
+    Thin wrapper: decode with :func:`geometry_from_wkt`, then
+    :func:`from_geometry`.  See :func:`from_geometry` for the parameters.
+    """
+    return from_geometry(
+        geometry_from_wkt(text), order=order, moc=moc, normalize=normalize,
+        tolerance=tolerance, max_cells=max_cells,
     )

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -1,0 +1,169 @@
+"""Lazy WKB/WKT geometry codec for mortie (issue #71).
+
+The runtime stays **numpy-only**: this module imports a geometry backend
+(``shapely>=2`` preferred, ``spherely`` accepted) lazily and uses it *only* as a
+codec — bytes/text ↔ ring coordinate arrays.  All spherical correctness
+(antimeridian / pole handling) stays mortie's own job; the backend is never
+asked for spatial predicates.  Importing :mod:`mortie` succeeds with neither
+backend installed; the geometry functions raise a clear :class:`ImportError`
+when first touched without one (the same lazy-gate pattern :mod:`mortie.arrow`
+uses for pyarrow).
+
+Coordinate convention: WKB/WKT store ``(x, y) = (lon, lat)`` degrees
+(EPSG:4326).  mortie's coverage entry points take ``(lats, lons)``, so this
+module flips the axes at the boundary and works in degrees throughout.
+"""
+
+import numpy as np
+
+# Cached backend: a ``(name, module)`` pair, resolved once on first use.
+_BACKEND = None
+
+# GEOS / shapely geometry type ids (shapely.get_type_id); spherely follows the
+# same numbering.  Only the ones we classify on are named.
+_TYPE_POINT = 0
+_TYPE_LINESTRING = 1
+_TYPE_LINEARRING = 2
+_TYPE_POLYGON = 3
+_TYPE_MULTIPOINT = 4
+_TYPE_MULTILINESTRING = 5
+_TYPE_MULTIPOLYGON = 6
+_TYPE_GEOMETRYCOLLECTION = 7
+
+_POLYGONAL = (_TYPE_POLYGON, _TYPE_MULTIPOLYGON)
+_LINEAR = (_TYPE_LINESTRING, _TYPE_MULTILINESTRING, _TYPE_LINEARRING)
+
+
+def _require_backend():
+    """Import a geometry backend lazily, raising a clear error if absent.
+
+    ``shapely>=2`` is the primary backend (its WKB/WKT codec is mature and is
+    all we lean on); ``spherely`` is accepted if it is the one present.  Returns
+    a ``(name, module)`` pair and caches it.
+    """
+    global _BACKEND
+    if _BACKEND is not None:
+        return _BACKEND
+    try:
+        import shapely
+
+        _BACKEND = ("shapely", shapely)
+        return _BACKEND
+    except ImportError:
+        pass
+    try:
+        import spherely
+
+        _BACKEND = ("spherely", spherely)
+        return _BACKEND
+    except ImportError:
+        pass
+    raise ImportError(
+        "mortie's WKB/WKT geometry I/O requires a geometry backend; install "
+        "`shapely>=2` (preferred) or `spherely` (e.g. `pip install shapely`). "
+        "mortie's runtime is numpy-only, so the backend is an optional extra."
+    )
+
+
+def _strip_ewkt_srid(text):
+    """Drop a leading ``SRID=<n>;`` prefix from an EWKT string, if present.
+
+    Plain WKT parsers reject the PostGIS EWKT prefix, so ingest tolerates it by
+    stripping it (the SRID is advisory; mortie's contract is always EPSG:4326).
+    """
+    s = text.lstrip()
+    if s[:5].upper() == "SRID=":
+        semi = s.find(";")
+        if semi != -1:
+            return s[semi + 1:]
+    return text
+
+
+def geometry_from_wkb(data):
+    """Decode WKB (or EWKB) bytes into a backend geometry object."""
+    _, mod = _require_backend()
+    return mod.from_wkb(data)
+
+
+def geometry_from_wkt(text):
+    """Decode WKT (or EWKT) text into a backend geometry object."""
+    _, mod = _require_backend()
+    return mod.from_wkt(_strip_ewkt_srid(text))
+
+
+def geometry_to_wkb(geom, srid=None):
+    """Encode a backend geometry to WKB bytes.
+
+    With ``srid`` set (e.g. ``4326``), emit **EWKB** carrying that SRID;
+    otherwise emit plain ISO/OGC WKB (the default, no embedded CRS).
+    """
+    _, mod = _require_backend()
+    if srid is not None:
+        geom = mod.set_srid(geom, int(srid))
+        return mod.to_wkb(geom, include_srid=True)
+    return mod.to_wkb(geom)
+
+
+def geometry_to_wkt(geom, srid=None):
+    """Encode a backend geometry to WKT text.
+
+    With ``srid`` set, emit **EWKT** (``SRID=<n>;<WKT>``); otherwise plain WKT.
+    """
+    _, mod = _require_backend()
+    text = mod.to_wkt(geom)
+    if srid is not None:
+        return f"SRID={int(srid)};{text}"
+    return text
+
+
+def _ring_latlon(mod, ring_geom):
+    """Extract a ring's vertices as ``(lat, lon)`` float64 arrays (degrees)."""
+    coords = np.asarray(mod.get_coordinates(ring_geom), dtype=np.float64)
+    # WKB/WKT store (x, y) = (lon, lat).
+    return coords[:, 1].copy(), coords[:, 0].copy()
+
+
+def _polygon_rings(mod, poly):
+    """All rings of one polygon as ``(lat, lon)`` pairs: exterior then holes."""
+    rings = [_ring_latlon(mod, mod.get_exterior_ring(poly))]
+    for i in range(int(mod.get_num_interior_rings(poly))):
+        rings.append(_ring_latlon(mod, mod.get_interior_ring(poly, i)))
+    return rings
+
+
+def decompose(geom):
+    """Decompose a backend geometry into mortie coverage inputs.
+
+    Returns ``(kind, parts)`` where:
+
+    * ``kind == "polygonal"`` and ``parts`` is a list of rings — exterior and
+      interior (hole) rings of every polygon, flattened.  mortie's even-odd
+      descent covers them in one pass, so disjoint outers union and nested
+      rings carve holes (matching :func:`mortie.morton_coverage`'s multipart
+      contract).
+    * ``kind == "linear"`` and ``parts`` is a list of lines, one per
+      (multi)linestring component.
+
+    Each entry is a ``(lat, lon)`` pair of float64 degree arrays.  Points,
+    geometry collections, and empty geometries are rejected — coverage has no
+    meaning for them.
+    """
+    _, mod = _require_backend()
+    type_id = int(mod.get_type_id(geom))
+
+    if type_id == _TYPE_POLYGON:
+        return "polygonal", _polygon_rings(mod, geom)
+    if type_id == _TYPE_MULTIPOLYGON:
+        rings = []
+        for poly in mod.get_parts(geom):
+            rings.extend(_polygon_rings(mod, poly))
+        return "polygonal", rings
+    if type_id in (_TYPE_LINESTRING, _TYPE_LINEARRING):
+        return "linear", [_ring_latlon(mod, geom)]
+    if type_id == _TYPE_MULTILINESTRING:
+        return "linear", [_ring_latlon(mod, ln) for ln in mod.get_parts(geom)]
+
+    raise ValueError(
+        f"unsupported geometry type for coverage (type id {type_id}); "
+        "expected Polygon, MultiPolygon, LineString, or MultiLineString"
+    )

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -486,16 +486,16 @@ def _antimeridian_winding(lon):
     return net, crossings
 
 
-def _split_at_antimeridian(coords):
-    """Split a lon/lat ring crossing the ±180° meridian exactly twice into two
-    clean closed pieces.
+def _cut_at_antimeridian(coords):
+    """Cut an open lon/lat ring at every ±180° crossing.
 
-    ``coords`` is an open list of ``(lon, lat)`` with exactly two antimeridian
-    crossings (the only case routed here — pole-enclosing rings and rings with
-    more than two crossings are rejected upstream).  Each crossing edge is cut at
-    the meridian (latitude linearly interpolated) and each segment is closed
-    along its own ±180° side, so both pieces sit within a single hemisphere of
-    longitude and the planar polygon is unambiguous.
+    Returns ``(whole, segments)``: a ring that never crosses gives
+    ``(closed_ring, [])`` (the caller keeps it whole); a crossing ring gives
+    ``(None, [seg, ...])`` where each segment is an open polyline whose two free
+    ends sit on ±180° (latitude linearly interpolated at the cut).  This is the
+    GeoJSON-convention building block — :func:`_stitch_segments` reconnects the
+    segments along the meridian (and, for a pole-enclosing region, through a
+    ±90° pole vertex).
     """
     n = len(coords)
     segments = []
@@ -512,11 +512,90 @@ def _split_at_antimeridian(coords):
             cur.append((boundary, la_x))
             segments.append(cur)
             cur = [(-boundary, la_x)]
-    if segments:
-        segments[0] = cur + segments[0]  # the wrap-around segment closes the first
+    if not segments:
+        return coords + [coords[0]], []
+    segments[0] = cur + segments[0]  # the wrap-around segment closes the first
+    return None, segments
+
+
+def _stitch_segments(segments, pole):
+    """Reconnect antimeridian-cut *segments* into closed lon/lat rings.
+
+    Every segment runs from a free end on ±180° to another on ±180°.  Walking
+    from a segment's end, the next segment is the one whose **start** sits on the
+    **same ±180° side** at the next latitude inward — on +180° the next start
+    above, on -180° the next start below — so the connector edge runs straight
+    along the meridian without crossing the boundary.  When no same-side start
+    lies in that direction the region wraps a pole: insert the ``pole`` (±90°)
+    vertex, cross to the other side at that pole, and resume.  ``pole`` is the
+    pole the **filled** region encloses (``+90``/``-90``); it is only ever
+    reached when the segments are genuinely unbalanced, so a non-pole cover
+    never touches it.
+
+    This is the GeoJSON / ``antimeridian``-package convention: a single split
+    ``MultiPolygon`` with explicit ±90° pole vertices stitched down ±180°.  It
+    generalises the old two-crossing split (each segment closing on its own
+    side) to any even crossing count, to pole-enclosing caps, and to
+    antimeridian-crossing holes.
+    """
+    segs = [list(s) for s in segments]
+    used = [False] * len(segs)
+    rings = []
+    for seed in range(len(segs)):
+        if used[seed]:
+            continue
+        ring = []
+        idx = seed
+        guard = 0
+        while idx is not None and not used[idx]:
+            guard += 1
+            if guard > 8 * len(segs) + 16:  # pragma: no cover - convergence guard
+                raise RuntimeError("antimeridian stitch did not converge")
+            used[idx] = True
+            ring.extend(segs[idx])
+            idx = _next_segment(segs, used, ring, pole, seed)
+        ring.append(ring[0])
+        rings.append(ring)
+    return rings
+
+
+def _next_segment(segs, used, ring, pole, seed):
+    """Append meridian/pole connectors from the current ring end and return the
+    next segment index (``None`` closes the ring).  See :func:`_stitch_segments`.
+    """
+    side, end_lat = ring[-1]
+    cands = [(segs[i][0][1], i) for i in range(len(segs))
+             if abs(segs[i][0][0] - side) < 1e-9 and (not used[i] or i == seed)]
+    # +180° connects upward to the next start above; -180° downward to the next
+    # start below — the direction that keeps the connector inside the region.
+    if side > 0:
+        pick = min(((la, i) for la, i in cands if la >= end_lat - 1e-9),
+                   default=None)
     else:
-        segments = [cur]
-    return [seg + [seg[0]] for seg in segments]
+        pick = max(((la, i) for la, i in cands if la <= end_lat + 1e-9),
+                   default=None)
+    if pick is not None:
+        la, i = pick
+        ring.append((side, la))
+        return None if (i == seed and used[seed]) else i
+
+    # No same-side start in that direction: the region wraps ``pole``.  Run the
+    # seam to the pole, cross to the other side, and resume from the pole.
+    if pole == 0:  # pragma: no cover - guarded by the caller's pole detection
+        raise RuntimeError("unbalanced antimeridian segments but no pole enclosed")
+    other = -side
+    ring.append((side, pole))
+    ring.append((other, pole))
+    ocands = [(segs[i][0][1], i) for i in range(len(segs))
+              if abs(segs[i][0][0] - other) < 1e-9 and (not used[i] or i == seed)]
+    if not ocands:  # pragma: no cover - a closed boundary always has a partner
+        return None
+    if other > 0:
+        la, i = min(ocands) if pole < 0 else max(ocands)
+    else:
+        la, i = max(ocands) if pole < 0 else min(ocands)
+    ring.append((other, la))
+    return None if (i == seed and used[seed]) else i
 
 
 def _point_in_ring(x, y, ring):
@@ -542,15 +621,32 @@ def _planar_signed_area(ring):
     return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
 
 
+def _ring_signed_area_lonlat(ring):
+    """Spherical signed area (steradians) of a closed lon/lat-degree ring.
+
+    Positive ⟺ the ring winds CCW (an exterior); negative ⟺ a hole.  Used to
+    classify a stitched ring whose seam runs through a pole, where the planar
+    shoelace sign is unreliable but the spherical area stays exact.
+    """
+    a = np.asarray(ring[:-1], dtype=np.float64)
+    rlat = np.radians(a[:, 1])
+    rlon = np.radians(a[:, 0])
+    v = np.column_stack(
+        [np.cos(rlat) * np.cos(rlon), np.cos(rlat) * np.sin(rlon), np.sin(rlat)]
+    )
+    return _spherical_signed_area(v)
+
+
 def _dissolved_polygons(mod, morton, step):
     """Build the dissolved outline of *morton* as a list of backend Polygons.
 
-    Exterior and hole rings come from the edge-cancellation engine; holes are
-    nested into the exterior that contains them.  The following are rejected with
-    a clear :class:`NotImplementedError` — the spherical→planar pole/hole split
-    is the remaining sub-piece of issue #71 (see the PR thread): covers whose
-    outline encloses a pole, an exterior crossing the antimeridian more than
-    twice, and antimeridian-crossing holes.
+    Exterior and hole rings come from the edge-cancellation engine; rings that
+    cross the ±180° meridian are cut and reconnected by the GeoJSON-convention
+    splitter (:func:`_cut_at_antimeridian` / :func:`_stitch_segments`), which
+    inserts explicit ±90° pole vertices for a pole-enclosing region.  Holes are
+    then nested into the exterior that contains them.  This handles pole caps
+    (the project's polar data), exteriors crossing the antimeridian any even
+    number of times, and antimeridian-crossing holes.
     """
     rings_xyz = _boundary_rings_xyz(morton, step)
     if not rings_xyz:
@@ -567,35 +663,35 @@ def _dissolved_polygons(mod, morton, step):
         rings_xyz = [r[::-1] for r in rings_xyz]
         areas = [-a for a in areas]
 
+    # Rings that never cross the antimeridian are emitted whole; crossing rings
+    # contribute open segments that are stitched together below.  The pole the
+    # filled region encloses is set by the cover's *total* net longitude winding
+    # (an exterior and a hole that both wrap the pole cancel to net 0 — a band
+    # that does not enclose the pole — so per-ring winding would be wrong here).
     ext_pieces = []
     holes = []
+    segments = []
+    total_net = 0.0
     for ring, area in zip(rings_xyz, areas):
         lat, lon = _xyz_to_latlon(ring)
-        net_winding, crossings = _antimeridian_winding(lon)
-        if abs(net_winding) > 180.0:  # net ≈ ±360° ⟺ the ring encircles a pole
-            raise NotImplementedError(
-                "dissolved emit of a pole-enclosing cover (e.g. a polar cap) is "
-                "not yet supported; pass dissolve=False for the per-cell "
-                "MultiPolygon (issue #71 phase 4 follow-up)"
-            )
         ll = list(zip(lon.tolist(), lat.tolist()))
-        if area < 0.0:
-            if crossings > 0:
-                raise NotImplementedError(
-                    "dissolved emit with an antimeridian-crossing hole is not "
-                    "yet supported; pass dissolve=False (issue #71 phase 4 "
-                    "follow-up)"
-                )
-            holes.append(ll + [ll[0]])
-        elif crossings == 0:
-            ext_pieces.append(ll + [ll[0]])
-        elif crossings == 2:
-            ext_pieces.extend(_split_at_antimeridian(ll))
+        net, _ = _antimeridian_winding(lon)
+        total_net += net
+        whole, segs = _cut_at_antimeridian(ll)
+        if whole is not None:
+            (holes if area < 0.0 else ext_pieces).append(whole)
         else:
-            raise NotImplementedError(
-                "dissolved emit of an exterior crossing the antimeridian more "
-                "than twice is not yet supported; pass dissolve=False (issue "
-                "#71 phase 4 follow-up)"
+            segments.extend(segs)
+
+    if segments:
+        pole = 0.0
+        if abs(total_net) > 180.0:  # net ≈ ±360° ⟺ the filled region wraps a pole
+            pole = 90.0 if total_net > 0.0 else -90.0
+        for piece in _stitch_segments(segments, pole):
+            # Classify by spherical signed area — a pole-spanning ring's planar
+            # shoelace sign is unreliable, but its spherical area is exact.
+            (ext_pieces if _ring_signed_area_lonlat(piece) >= 0.0 else holes).append(
+                piece
             )
 
     # Nest each hole into the smallest exterior piece that contains it.  A hole
@@ -648,10 +744,11 @@ def to_geometry(morton, dissolve=True, step=1):
     Notes
     -----
     Emit requires the shapely backend (it constructs geometry objects).  The
-    dissolved emit (``dissolve=True``) does not yet support covers whose outline
-    encloses a pole or holes that cross the antimeridian — both raise
-    :class:`NotImplementedError`; use ``dissolve=False`` for those (issue #71
-    phase 4 follow-up).
+    dissolved emit (``dissolve=True``) handles pole-enclosing covers (e.g. polar
+    caps), exteriors crossing the antimeridian any even number of times, and
+    antimeridian-crossing holes: crossing rings are cut at ±180° and reconnected
+    by the GeoJSON convention — a single split ``MultiPolygon`` with explicit
+    ±90° pole vertices stitched down the antimeridian.
     """
     mod = _require_shapely("geometry emit")
     if dissolve:

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -218,7 +218,10 @@ def from_geometry(geom, order=18, moc=False, normalize=True,
         Polygonal only: return a compact MOC instead of a flat cover.
     normalize : bool, optional
         Flat polygon cover only: auto-correct ring orientation at ingest
-        (see :func:`mortie.morton_coverage`).  Ignored when ``moc=True``.
+        (see :func:`mortie.morton_coverage`).  Ignored when ``moc=True`` and for
+        linear geometry.  Note ``morton_coverage_moc`` has no orientation
+        auto-correct, so with ``moc=True`` the ring winding is taken **as
+        authored** — for hemisphere-plus polygons wind exteriors CCW / holes CW.
     tolerance, max_cells : optional
         Polygonal ``moc=True`` only: the adaptive stop criteria of
         :func:`mortie.morton_coverage_moc` (mutually exclusive).
@@ -280,3 +283,84 @@ def from_wkt(text, order=18, moc=False, normalize=True,
         geometry_from_wkt(text), order=order, moc=moc, normalize=normalize,
         tolerance=tolerance, max_cells=max_cells,
     )
+
+
+# ── emit: morton coverage → geometry ───────────────────────────────────────
+
+
+def _per_cell_polygons(mod, morton, step):
+    """Build one backend Polygon per cell of *morton* (lon/lat degrees).
+
+    Reuses :func:`mortie.mort2polygon` for the corner→lon/lat boundary (with its
+    antimeridian normalization), grouping by order so a mixed-order MOC cover is
+    handled — ``mort2polygon`` itself requires a single order per call.
+    """
+    from .tools import _rust_mort2nested, mort2polygon
+
+    morton = np.atleast_1d(np.asarray(morton, dtype=np.uint64))
+    if morton.size == 0:
+        return []
+
+    _, depths = _rust_mort2nested(np.ascontiguousarray(morton))
+    polys = []
+    for d in np.unique(depths):
+        grp = morton[depths == d]
+        if grp.size == 1:
+            rings_ll = [mort2polygon(int(grp[0]), step=step)]
+        else:
+            rings_ll = mort2polygon(grp, step=step)
+        for ring in rings_ll:
+            # mort2polygon yields closed [lat, lon] pairs; WKB wants (lon, lat).
+            polys.append(mod.Polygon([(lon, lat) for lat, lon in ring]))
+    return polys
+
+
+def to_geometry(morton, dissolve=True, step=1):
+    """Convert a morton cover to a backend geometry (issue #71).
+
+    Parameters
+    ----------
+    morton : array_like of uint64
+        A morton cover (flat or mixed-order MOC; each word self-encodes order).
+    dissolve : bool, optional
+        ``True`` (default) emits the single dissolved outline of the whole cover
+        (exterior rings, holes, and disjoint components).  ``False`` emits a
+        per-cell ``MultiPolygon`` — one quad per cell.
+    step : int, optional
+        Boundary points per cell edge (default 1 = 4 corners / straight chords).
+        ``step>1`` densifies each edge to follow the curved HEALPix boundary.
+
+    Returns
+    -------
+    backend geometry
+        A shapely (or spherely) ``MultiPolygon`` in EPSG:4326 lon/lat degrees.
+
+    Notes
+    -----
+    Emit requires the shapely backend (it constructs geometry objects).
+    """
+    mod = _require_shapely("geometry emit")
+    if dissolve:
+        raise NotImplementedError(
+            "dissolve=True (the dissolved-outline emit) lands in phase 4 of "
+            "issue #71; pass dissolve=False for the per-cell MultiPolygon"
+        )
+    return mod.MultiPolygon(_per_cell_polygons(mod, morton, step))
+
+
+def to_wkb(morton, dissolve=True, step=1, srid=None):
+    """Emit a morton cover as WKB (or EWKB) bytes.
+
+    See :func:`to_geometry` for ``dissolve`` / ``step``.  With ``srid`` set
+    (e.g. ``4326``), emit EWKB carrying that SRID; otherwise plain WKB.
+    """
+    return geometry_to_wkb(to_geometry(morton, dissolve=dissolve, step=step), srid=srid)
+
+
+def to_wkt(morton, dissolve=True, step=1, srid=None):
+    """Emit a morton cover as WKT (or EWKT) text.
+
+    See :func:`to_geometry` for ``dissolve`` / ``step``.  With ``srid`` set,
+    emit EWKT (``SRID=<n>;<WKT>``); otherwise plain WKT.
+    """
+    return geometry_to_wkt(to_geometry(morton, dissolve=dissolve, step=step), srid=srid)

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -14,6 +14,8 @@ Coordinate convention: WKB/WKT store ``(x, y) = (lon, lat)`` degrees
 module flips the axes at the boundary and works in degrees throughout.
 """
 
+import math
+
 import numpy as np
 
 # Cached backend: a ``(name, module)`` pair, resolved once on first use.
@@ -405,46 +407,95 @@ def _boundary_rings_xyz(morton, step):
 
     # An interior edge appears as (a, b) in one cell and (b, a) in its neighbour;
     # the surviving boundary is the net direction at each undirected edge.
-    from collections import Counter, defaultdict
+    from collections import Counter
 
     counts = Counter(edges)
-    out = defaultdict(list)
+    survivors = []
     for (a, b), c in counts.items():
         net = c - counts.get((b, a), 0)
-        for _ in range(net):
-            out[a].append(b)
+        survivors.extend([(a, b)] * net)
+    return _chain_rings(survivors, id_xyz)
 
-    # Chain the surviving directed edges into closed rings.
+
+def _tangent_azimuth(p, q):
+    """Azimuth (radians) from unit vector *p* toward unit vector *q*, in p's
+    tangent plane (north-referenced).  Used to order edges around a vertex."""
+    d = q - np.dot(q, p) * p
+    nd = np.linalg.norm(d)
+    if nd < 1e-15:
+        return 0.0
+    d = d / nd
+    east = np.cross([0.0, 0.0, 1.0], p)
+    ne = np.linalg.norm(east)
+    east = np.array([1.0, 0.0, 0.0]) if ne < 1e-9 else east / ne
+    north = np.cross(p, east)
+    return math.atan2(float(np.dot(d, east)), float(np.dot(d, north)))
+
+
+def _chain_rings(survivors, id_xyz):
+    """Chain surviving directed boundary edges into closed rings.
+
+    At a non-manifold vertex (out-degree > 1 — e.g. two cells touching only at a
+    corner) the next edge is chosen by angular order: the surviving edge whose
+    departure azimuth is the smallest turn anticlockwise from the reversed
+    arrival direction.  This right-hand-rule traversal yields *simple* rings
+    (the cells' boundaries stay separate rather than crossing into a bowtie),
+    independent of the cover's global winding.
+    """
+    from collections import defaultdict
+
+    az = {e: _tangent_azimuth(id_xyz[e[0]], id_xyz[e[1]]) for e in survivors}
+    records = [[a, b, True] for a, b in survivors]
+    by_start = defaultdict(list)
+    for rec in records:
+        by_start[rec[0]].append(rec)
+
     rings = []
-    for start in list(out.keys()):
-        while out[start]:
-            cur = start
-            chain = [cur]
-            while True:
-                nxt = out[cur].pop()
-                chain.append(nxt)
-                cur = nxt
-                if cur == start:
-                    break
-            rings.append(id_xyz[np.asarray(chain[:-1])])
+    for seed in records:
+        if not seed[2]:
+            continue
+        seed_start = seed[0]
+        cur = seed
+        chain = []
+        while cur is not None and cur[2]:
+            cur[2] = False
+            chain.append(cur[0])
+            v = cur[1]
+            if v == seed_start:
+                break  # returned to the start vertex — ring closed
+            cand = [r for r in by_start[v] if r[2]]
+            if not cand:
+                break
+            if len(cand) == 1:
+                cur = cand[0]
+            else:
+                # Smallest turn anticlockwise from the reversed arrival keeps the
+                # walk on the same face (no crossing) at a non-manifold vertex.
+                back = _tangent_azimuth(id_xyz[v], id_xyz[cur[0]])
+                cur = min(cand, key=lambda r: (az[(r[0], r[1])] - back) % (2 * math.pi))
+        rings.append(id_xyz[np.asarray(chain)])
     return rings
 
 
-def _count_antimeridian_crossings(lon):
-    """How many ring edges jump >180° in longitude (closed ring of lon degrees)."""
-    closed = np.concatenate([lon, lon[:1]])
-    return int(np.sum(np.abs(np.diff(closed)) > 180.0))
+def _antimeridian_winding(lon):
+    """Net signed longitude winding (degrees) and antimeridian-crossing count of
+    a closed ring of longitudes.  Net ≈ ±360 ⟺ the ring encircles a pole."""
+    deltas = np.diff(np.concatenate([lon, lon[:1]]))
+    crossings = int(np.sum(np.abs(deltas) > 180.0))
+    net = float(np.sum((deltas + 180.0) % 360.0 - 180.0))
+    return net, crossings
 
 
 def _split_at_antimeridian(coords):
-    """Split a lon/lat ring at the ±180° meridian into clean closed pieces.
+    """Split a lon/lat ring crossing the ±180° meridian exactly twice into two
+    clean closed pieces.
 
-    ``coords`` is an open list of ``(lon, lat)`` with an even number of
-    antimeridian crossings (no enclosed pole — that case is rejected upstream).
-    Each crossing edge is cut at the meridian (latitude linearly interpolated),
-    and each resulting segment is closed along its own ±180° side.  Returns a
-    list of closed ``(lon, lat)`` rings, all within a single hemisphere of
-    longitude so the planar polygon is unambiguous.
+    ``coords`` is an open list of ``(lon, lat)`` with exactly two antimeridian
+    crossings (the only case routed here — pole-enclosing rings and rings with
+    more than two crossings are rejected upstream).  Each crossing edge is cut at
+    the meridian (latitude linearly interpolated) and each segment is closed
+    along its own ±180° side, so both pieces sit within a single hemisphere of
+    longitude and the planar polygon is unambiguous.
     """
     n = len(coords)
     segments = []
@@ -495,10 +546,11 @@ def _dissolved_polygons(mod, morton, step):
     """Build the dissolved outline of *morton* as a list of backend Polygons.
 
     Exterior and hole rings come from the edge-cancellation engine; holes are
-    nested into the exterior that contains them.  Covers whose outline encloses a
-    pole, and antimeridian-crossing holes, are rejected with a clear
-    :class:`NotImplementedError` (the spherical→planar pole/hole split is the
-    remaining sub-piece of issue #71 — see the PR thread).
+    nested into the exterior that contains them.  The following are rejected with
+    a clear :class:`NotImplementedError` — the spherical→planar pole/hole split
+    is the remaining sub-piece of issue #71 (see the PR thread): covers whose
+    outline encloses a pole, an exterior crossing the antimeridian more than
+    twice, and antimeridian-crossing holes.
     """
     rings_xyz = _boundary_rings_xyz(morton, step)
     if not rings_xyz:
@@ -508,6 +560,8 @@ def _dissolved_polygons(mod, morton, step):
     # holes) is the covered area, always positive.  HEALPix orders boundary
     # points one way for step==1 and the other for step>1, so key the
     # exterior/hole sign off this invariant rather than a fixed convention.
+    # (Spherical signed area is defined mod 4π, so this assumes the cover stays
+    # well under a hemisphere — true for every realistic emit input.)
     areas = [_spherical_signed_area(r) for r in rings_xyz]
     if sum(areas) < 0.0:
         rings_xyz = [r[::-1] for r in rings_xyz]
@@ -517,37 +571,53 @@ def _dissolved_polygons(mod, morton, step):
     holes = []
     for ring, area in zip(rings_xyz, areas):
         lat, lon = _xyz_to_latlon(ring)
-        crossings = _count_antimeridian_crossings(lon)
-        if crossings % 2 == 1:
+        net_winding, crossings = _antimeridian_winding(lon)
+        if abs(net_winding) > 180.0:  # net ≈ ±360° ⟺ the ring encircles a pole
             raise NotImplementedError(
                 "dissolved emit of a pole-enclosing cover (e.g. a polar cap) is "
                 "not yet supported; pass dissolve=False for the per-cell "
                 "MultiPolygon (issue #71 phase 4 follow-up)"
             )
         ll = list(zip(lon.tolist(), lat.tolist()))
-        if area >= 0.0:
-            ext_pieces.extend(_split_at_antimeridian(ll))
-        elif crossings > 0:
-            raise NotImplementedError(
-                "dissolved emit with an antimeridian-crossing hole is not yet "
-                "supported; pass dissolve=False (issue #71 phase 4 follow-up)"
-            )
-        else:
+        if area < 0.0:
+            if crossings > 0:
+                raise NotImplementedError(
+                    "dissolved emit with an antimeridian-crossing hole is not "
+                    "yet supported; pass dissolve=False (issue #71 phase 4 "
+                    "follow-up)"
+                )
             holes.append(ll + [ll[0]])
+        elif crossings == 0:
+            ext_pieces.append(ll + [ll[0]])
+        elif crossings == 2:
+            ext_pieces.extend(_split_at_antimeridian(ll))
+        else:
+            raise NotImplementedError(
+                "dissolved emit of an exterior crossing the antimeridian more "
+                "than twice is not yet supported; pass dissolve=False (issue "
+                "#71 phase 4 follow-up)"
+            )
 
-    # Nest each hole into the smallest exterior piece that contains it.
+    # Nest each hole into the smallest exterior piece that contains it.  A hole
+    # vertex lies strictly inside its surrounding exterior, so test a vertex
+    # (a guaranteed-interior point) rather than the centroid, which a concave or
+    # split ring can push outside the region.
     hole_groups = [[] for _ in ext_pieces]
     ext_areas = [abs(_planar_signed_area(p)) for p in ext_pieces]
     for hole in holes:
-        cx = float(np.mean([p[0] for p in hole]))
-        cy = float(np.mean([p[1] for p in hole]))
+        hx, hy = hole[0]
         best = None
         for idx, piece in enumerate(ext_pieces):
-            if _point_in_ring(cx, cy, piece) and (
+            if _point_in_ring(hx, hy, piece) and (
                 best is None or ext_areas[idx] < ext_areas[best]
             ):
                 best = idx
-        hole_groups[best if best is not None else 0].append(hole)
+        if best is None:
+            raise NotImplementedError(
+                "dissolved emit could not nest a hole into any exterior (an "
+                "unsupported self-touching outline); pass dissolve=False"
+            )
+        hole_groups[best].append(hole)
 
     return [
         mod.Polygon(ext_pieces[i], hole_groups[i]) for i in range(len(ext_pieces))

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -19,6 +19,12 @@ import numpy as np
 # Cached backend: a ``(name, module)`` pair, resolved once on first use.
 _BACKEND = None
 
+# Snap scale for vertex identity in the dissolve edge-cancellation (rounding
+# unit-vector components to 1e-10 makes a shared HEALPix corner — which both
+# adjacent cells compute identically — a single integer-keyed vertex, so their
+# shared edge cancels exactly without a floating tolerance search).
+_DISSOLVE_SNAP = 1e10
+
 # GEOS / shapely geometry type ids (shapely.get_type_id); spherely follows the
 # same numbering.  Only the ones we classify on are named.
 _TYPE_LINESTRING = 1
@@ -315,6 +321,239 @@ def _per_cell_polygons(mod, morton, step):
     return polys
 
 
+# ── emit: dissolved-boundary outline (phase 4) ─────────────────────────────
+#
+# The dissolved outline is built natively (no backend spatial predicate): every
+# cell contributes its boundary as a loop of directed edges; interior edges that
+# two adjacent cells share are traversed in opposite directions and cancel, and
+# the surviving edges chain into the outline rings.  Correctness is mortie's own
+# job throughout — the backend is only asked to *construct* the final Polygon.
+
+
+def _xyz_to_latlon(vecs):
+    """Unit vectors ``(M, 3)`` → ``(lat, lon)`` degree arrays, lon in (-180, 180]."""
+    z = np.clip(vecs[:, 2], -1.0, 1.0)
+    lat = np.degrees(np.arcsin(z))
+    lon = np.degrees(np.arctan2(vecs[:, 1], vecs[:, 0]))
+    return lat, lon
+
+
+def _spherical_signed_area(ring_xyz):
+    """Signed area (steradians) of a spherical polygon of unit vectors.
+
+    Positive = the region lies to the left of the directed boundary (an exterior
+    ring); negative = the boundary winds the other way (a hole).  Uses the
+    van Oosterom–Strackee signed-solid-angle sum over a fan from vertex 0.
+    """
+    v = ring_xyz
+    if v.shape[0] < 3:
+        return 0.0
+    a = v[0]
+    b = v[1:-1]
+    c = v[2:]
+    num = np.einsum("j,ij->i", a, np.cross(b, c))
+    den = 1.0 + b @ a + np.einsum("ij,ij->i", b, c) + c @ a
+    return float(np.sum(2.0 * np.arctan2(num, den)))
+
+
+def _boundary_rings_xyz(morton, step):
+    """Edge-cancellation dissolve of a cover → list of boundary rings.
+
+    Each ring is an ``(M, 3)`` array of unit vectors (open — first vertex not
+    repeated).  A mixed-order MOC is densified to its finest order first so every
+    cell carries unit-length edges that cancel against their neighbours.  ``step``
+    samples ``step`` points per cell edge (``step>1`` traces the curved HEALPix
+    boundary); shared sub-edge points coincide between neighbours and cancel too.
+    """
+    from . import _healpix as hp
+    from .coverage import moc_to_order
+    from .tools import _rust_mort2nested
+
+    morton = np.atleast_1d(np.asarray(morton, dtype=np.uint64))
+    if morton.size == 0:
+        return []
+
+    nested, depths = _rust_mort2nested(np.ascontiguousarray(morton))
+    udepths = np.unique(depths)
+    if udepths.size > 1:
+        morton = np.asarray(moc_to_order(morton, int(udepths.max())), dtype=np.uint64)
+        nested, depths = _rust_mort2nested(np.ascontiguousarray(morton))
+    order = int(depths[0])
+    nest = np.ascontiguousarray(nested.astype(np.int64))
+
+    bnd = hp.boundaries(order, nest, step=step)
+    if bnd.ndim == 2:
+        bnd = bnd[np.newaxis, ...]
+    pts = np.transpose(bnd, (0, 2, 1))  # (N, K, 3), K = 4*step in boundary order
+    n_cells, k = pts.shape[0], pts.shape[1]
+    flat = pts.reshape(-1, 3)
+
+    # Integer-snap every boundary point to a vertex id; a shared corner/sub-edge
+    # point collapses to one id, so adjacent cells reference the same vertex.
+    snapped = np.round(flat * _DISSOLVE_SNAP).astype(np.int64)
+    _, first_idx, inv = np.unique(
+        snapped, axis=0, return_index=True, return_inverse=True
+    )
+    id_xyz = flat[first_idx]  # representative unit vector per vertex id
+    inv = inv.reshape(n_cells, k)
+
+    # Directed edges (vertex id → vertex id) around every cell boundary.
+    starts = inv.ravel()
+    ends = np.roll(inv, -1, axis=1).ravel()
+    keep = starts != ends  # drop any degenerate zero-length edge
+    edges = list(zip(starts[keep].tolist(), ends[keep].tolist()))
+
+    # An interior edge appears as (a, b) in one cell and (b, a) in its neighbour;
+    # the surviving boundary is the net direction at each undirected edge.
+    from collections import Counter, defaultdict
+
+    counts = Counter(edges)
+    out = defaultdict(list)
+    for (a, b), c in counts.items():
+        net = c - counts.get((b, a), 0)
+        for _ in range(net):
+            out[a].append(b)
+
+    # Chain the surviving directed edges into closed rings.
+    rings = []
+    for start in list(out.keys()):
+        while out[start]:
+            cur = start
+            chain = [cur]
+            while True:
+                nxt = out[cur].pop()
+                chain.append(nxt)
+                cur = nxt
+                if cur == start:
+                    break
+            rings.append(id_xyz[np.asarray(chain[:-1])])
+    return rings
+
+
+def _count_antimeridian_crossings(lon):
+    """How many ring edges jump >180° in longitude (closed ring of lon degrees)."""
+    closed = np.concatenate([lon, lon[:1]])
+    return int(np.sum(np.abs(np.diff(closed)) > 180.0))
+
+
+def _split_at_antimeridian(coords):
+    """Split a lon/lat ring at the ±180° meridian into clean closed pieces.
+
+    ``coords`` is an open list of ``(lon, lat)`` with an even number of
+    antimeridian crossings (no enclosed pole — that case is rejected upstream).
+    Each crossing edge is cut at the meridian (latitude linearly interpolated),
+    and each resulting segment is closed along its own ±180° side.  Returns a
+    list of closed ``(lon, lat)`` rings, all within a single hemisphere of
+    longitude so the planar polygon is unambiguous.
+    """
+    n = len(coords)
+    segments = []
+    cur = []
+    for i in range(n):
+        lo0, la0 = coords[i]
+        lo1, la1 = coords[(i + 1) % n]
+        cur.append((lo0, la0))
+        if abs(lo1 - lo0) > 180.0:
+            lo1u = lo1 - 360.0 if lo1 > lo0 else lo1 + 360.0
+            boundary = 180.0 if lo1u > lo0 else -180.0
+            frac = (boundary - lo0) / (lo1u - lo0)
+            la_x = la0 + frac * (la1 - la0)
+            cur.append((boundary, la_x))
+            segments.append(cur)
+            cur = [(-boundary, la_x)]
+    if segments:
+        segments[0] = cur + segments[0]  # the wrap-around segment closes the first
+    else:
+        segments = [cur]
+    return [seg + [seg[0]] for seg in segments]
+
+
+def _point_in_ring(x, y, ring):
+    """Even-odd ray-cast point-in-polygon (``ring`` = closed list of (x, y))."""
+    inside = False
+    n = len(ring)
+    j = n - 1
+    for i in range(n):
+        xi, yi = ring[i]
+        xj, yj = ring[j]
+        if (yi > y) != (yj > y):
+            x_cross = xi + (y - yi) / (yj - yi) * (xj - xi)
+            if x < x_cross:
+                inside = not inside
+        j = i
+    return inside
+
+
+def _planar_signed_area(ring):
+    """Shoelace signed area of a closed list of ``(x, y)`` (for size ordering)."""
+    a = np.asarray(ring, dtype=np.float64)
+    x, y = a[:, 0], a[:, 1]
+    return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+
+
+def _dissolved_polygons(mod, morton, step):
+    """Build the dissolved outline of *morton* as a list of backend Polygons.
+
+    Exterior and hole rings come from the edge-cancellation engine; holes are
+    nested into the exterior that contains them.  Covers whose outline encloses a
+    pole, and antimeridian-crossing holes, are rejected with a clear
+    :class:`NotImplementedError` (the spherical→planar pole/hole split is the
+    remaining sub-piece of issue #71 — see the PR thread).
+    """
+    rings_xyz = _boundary_rings_xyz(morton, step)
+    if not rings_xyz:
+        return []
+
+    # Normalise global winding: the cover's net signed area (exteriors minus
+    # holes) is the covered area, always positive.  HEALPix orders boundary
+    # points one way for step==1 and the other for step>1, so key the
+    # exterior/hole sign off this invariant rather than a fixed convention.
+    areas = [_spherical_signed_area(r) for r in rings_xyz]
+    if sum(areas) < 0.0:
+        rings_xyz = [r[::-1] for r in rings_xyz]
+        areas = [-a for a in areas]
+
+    ext_pieces = []
+    holes = []
+    for ring, area in zip(rings_xyz, areas):
+        lat, lon = _xyz_to_latlon(ring)
+        crossings = _count_antimeridian_crossings(lon)
+        if crossings % 2 == 1:
+            raise NotImplementedError(
+                "dissolved emit of a pole-enclosing cover (e.g. a polar cap) is "
+                "not yet supported; pass dissolve=False for the per-cell "
+                "MultiPolygon (issue #71 phase 4 follow-up)"
+            )
+        ll = list(zip(lon.tolist(), lat.tolist()))
+        if area >= 0.0:
+            ext_pieces.extend(_split_at_antimeridian(ll))
+        elif crossings > 0:
+            raise NotImplementedError(
+                "dissolved emit with an antimeridian-crossing hole is not yet "
+                "supported; pass dissolve=False (issue #71 phase 4 follow-up)"
+            )
+        else:
+            holes.append(ll + [ll[0]])
+
+    # Nest each hole into the smallest exterior piece that contains it.
+    hole_groups = [[] for _ in ext_pieces]
+    ext_areas = [abs(_planar_signed_area(p)) for p in ext_pieces]
+    for hole in holes:
+        cx = float(np.mean([p[0] for p in hole]))
+        cy = float(np.mean([p[1] for p in hole]))
+        best = None
+        for idx, piece in enumerate(ext_pieces):
+            if _point_in_ring(cx, cy, piece) and (
+                best is None or ext_areas[idx] < ext_areas[best]
+            ):
+                best = idx
+        hole_groups[best if best is not None else 0].append(hole)
+
+    return [
+        mod.Polygon(ext_pieces[i], hole_groups[i]) for i in range(len(ext_pieces))
+    ]
+
+
 def to_geometry(morton, dissolve=True, step=1):
     """Convert a morton cover to a backend geometry (issue #71).
 
@@ -324,7 +563,8 @@ def to_geometry(morton, dissolve=True, step=1):
         A morton cover (flat or mixed-order MOC; each word self-encodes order).
     dissolve : bool, optional
         ``True`` (default) emits the single dissolved outline of the whole cover
-        (exterior rings, holes, and disjoint components).  ``False`` emits a
+        (exterior rings, holes, and disjoint components), built natively by
+        edge-cancellation — no backend spatial predicate.  ``False`` emits a
         per-cell ``MultiPolygon`` — one quad per cell.
     step : int, optional
         Boundary points per cell edge (default 1 = 4 corners / straight chords).
@@ -337,14 +577,15 @@ def to_geometry(morton, dissolve=True, step=1):
 
     Notes
     -----
-    Emit requires the shapely backend (it constructs geometry objects).
+    Emit requires the shapely backend (it constructs geometry objects).  The
+    dissolved emit (``dissolve=True``) does not yet support covers whose outline
+    encloses a pole or holes that cross the antimeridian — both raise
+    :class:`NotImplementedError`; use ``dissolve=False`` for those (issue #71
+    phase 4 follow-up).
     """
     mod = _require_shapely("geometry emit")
     if dissolve:
-        raise NotImplementedError(
-            "dissolve=True (the dissolved-outline emit) lands in phase 4 of "
-            "issue #71; pass dissolve=False for the per-cell MultiPolygon"
-        )
+        return mod.MultiPolygon(_dissolved_polygons(mod, morton, step))
     return mod.MultiPolygon(_per_cell_polygons(mod, morton, step))
 
 

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -562,6 +562,13 @@ def _stitch_segments(segments, pole):
 def _next_segment(segs, used, ring, pole, seed):
     """Append meridian/pole connectors from the current ring end and return the
     next segment index (``None`` closes the ring).  See :func:`_stitch_segments`.
+
+    Closing back to the *seed* is the right stop: walking always advances toward
+    the next start in one meridian direction, so the seed (the directional
+    extremum on its side) is reached only when the loop has consumed every
+    segment of this ring — it cannot be stepped past.  Same-side starts are
+    matched within a 1e-9° latitude tolerance, which is far below HEALPix corner
+    spacing at any order, so distinct crossing points never alias.
     """
     side, end_lat = ring[-1]
     cands = [(segs[i][0][1], i) for i in range(len(segs))
@@ -637,20 +644,20 @@ def _ring_signed_area_lonlat(ring):
     return _spherical_signed_area(v)
 
 
-def _dissolved_polygons(mod, morton, step):
-    """Build the dissolved outline of *morton* as a list of backend Polygons.
+def _dissolved_rings_py(morton, step):
+    """Reference (pure-Python) dissolve → ``(ext_pieces, holes)`` lon/lat rings.
 
-    Exterior and hole rings come from the edge-cancellation engine; rings that
-    cross the ±180° meridian are cut and reconnected by the GeoJSON-convention
-    splitter (:func:`_cut_at_antimeridian` / :func:`_stitch_segments`), which
-    inserts explicit ±90° pole vertices for a pole-enclosing region.  Holes are
-    then nested into the exterior that contains them.  This handles pole caps
-    (the project's polar data), exteriors crossing the antimeridian any even
-    number of times, and antimeridian-crossing holes.
+    This is the exact-verified reference engine kept as the test oracle for the
+    Rust fast path (:func:`_dissolved_polygons` calls ``_rustie.rust_dissolve``
+    at runtime — §7's Rust-only contract).  Rings that cross the ±180° meridian
+    are cut and reconnected by the GeoJSON-convention splitter
+    (:func:`_cut_at_antimeridian` / :func:`_stitch_segments`), which inserts
+    explicit ±90° pole vertices for a pole-enclosing region.  Each returned ring
+    is a closed list of ``(lon, lat)`` degree pairs.
     """
     rings_xyz = _boundary_rings_xyz(morton, step)
     if not rings_xyz:
-        return []
+        return [], []
 
     # Normalise global winding: the cover's net signed area (exteriors minus
     # holes) is the covered area, always positive.  HEALPix orders boundary
@@ -689,18 +696,24 @@ def _dissolved_polygons(mod, morton, step):
             pole = 90.0 if total_net > 0.0 else -90.0
         for piece in _stitch_segments(segments, pole):
             # Classify by spherical signed area — a pole-spanning ring's planar
-            # shoelace sign is unreliable, but its spherical area is exact.
+            # shoelace sign is unreliable, but its spherical area is exact.  The
+            # sign is meaningful because the global winding was normalised above
+            # (exteriors CCW → positive); a stitched piece always encloses a
+            # finite covered/uncovered region, so its area is never exactly zero.
             (ext_pieces if _ring_signed_area_lonlat(piece) >= 0.0 else holes).append(
                 piece
             )
+    return ext_pieces, holes
 
-    # Nest each hole into the smallest exterior piece that contains it.  A hole
-    # vertex lies strictly inside its surrounding exterior, so test a vertex
-    # (a guaranteed-interior point) rather than the centroid, which a concave or
-    # split ring can push outside the region.
+
+def _nest_and_build(mod, ext_pieces, holes):
+    """Nest each hole into the smallest containing exterior and build Polygons."""
     hole_groups = [[] for _ in ext_pieces]
     ext_areas = [abs(_planar_signed_area(p)) for p in ext_pieces]
     for hole in holes:
+        # A hole vertex lies strictly inside its surrounding exterior, so test a
+        # vertex (a guaranteed-interior point) rather than the centroid, which a
+        # concave or split ring can push outside the region.
         hx, hy = hole[0]
         best = None
         for idx, piece in enumerate(ext_pieces):
@@ -714,10 +727,34 @@ def _dissolved_polygons(mod, morton, step):
                 "unsupported self-touching outline); pass dissolve=False"
             )
         hole_groups[best].append(hole)
-
     return [
         mod.Polygon(ext_pieces[i], hole_groups[i]) for i in range(len(ext_pieces))
     ]
+
+
+def _dissolved_polygons(mod, morton, step):
+    """Build the dissolved outline of *morton* as a list of backend Polygons.
+
+    The exterior/hole rings (edge-cancellation dissolve plus the GeoJSON
+    pole/antimeridian split) are computed by the Rust fast path
+    (``_rustie.rust_dissolve``); this nests holes into the exterior that
+    contains them and constructs the backend Polygons.  Handles pole caps (the
+    project's polar data), exteriors crossing the antimeridian any even number
+    of times, and antimeridian-crossing holes.  The pure-Python
+    :func:`_dissolved_rings_py` is the exact-verified reference oracle for this
+    path in the tests.
+    """
+    from . import _rustie
+
+    morton = np.atleast_1d(np.asarray(morton, dtype=np.uint64))
+    if morton.size == 0:
+        return []
+    shells, holes = _rustie.rust_dissolve(np.ascontiguousarray(morton), int(step))
+    ext_pieces = [[tuple(v) for v in ring] for ring in shells]
+    hole_rings = [[tuple(v) for v in ring] for ring in holes]
+    if not ext_pieces:
+        return []
+    return _nest_and_build(mod, ext_pieces, hole_rings)
 
 
 def to_geometry(morton, dissolve=True, step=1):

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -112,7 +112,8 @@ def test_ewkb_ewkt_srid_optin():
     # EWKB carries the SRID; from_wkb reads it back.
     ewkb = geometry.geometry_to_wkb(g, srid=4326)
     assert int(shapely.get_srid(geometry.geometry_from_wkb(ewkb))) == 4326
-    assert int(shapely.get_srid(geometry.geometry_from_wkb(geometry.geometry_to_wkb(g)))) == 0
+    plain = geometry.geometry_from_wkb(geometry.geometry_to_wkb(g))
+    assert int(shapely.get_srid(plain)) == 0
 
 
 # ── Phase 2: ingest reproduces the array-path coverage ─────────────────────
@@ -242,13 +243,57 @@ def test_emit_wkb_wkt_roundtrip_matches_cell_corners():
     back = shapely.from_wkb(wkb)
     assert shapely.get_num_geometries(back) == cov.size
     # The first emitted cell's exterior matches mort2polygon's lon/lat corners.
+    # (cov is a single-order flat cover, so emit order tracks cov order here.)
     poly0 = shapely.get_geometry(back, 0)
     ring_lonlat = shapely.get_coordinates(shapely.get_exterior_ring(poly0))
     want = np.array([[lon, lat] for lat, lon in mortie.mort2polygon(int(cov[0]))])
-    assert np.allclose(np.sort(ring_lonlat, axis=0), np.sort(want, axis=0))
+    # Compare as ordered (lon, lat) PAIRS (lexsort on rows keeps the pairing, so
+    # a per-vertex lon/lat swap would be caught — column-wise sorting would not).
+    got_rows = ring_lonlat[np.lexsort((ring_lonlat[:, 1], ring_lonlat[:, 0]))]
+    want_rows = want[np.lexsort((want[:, 1], want[:, 0]))]
+    assert got_rows.shape == want_rows.shape
+    assert np.allclose(got_rows, want_rows)
     # WKT path parses too.
     assert shapely.from_wkt(geometry.to_wkt(cov, dissolve=False)).geom_type \
         == "MultiPolygon"
+
+
+def test_emit_single_cell_cover():
+    # The grp.size == 1 scalar branch of _per_cell_polygons.
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)[:1]
+    g = geometry.to_geometry(cov, dissolve=False)
+    assert shapely.get_num_geometries(g) == 1
+    assert g.is_valid
+
+
+def test_emit_step_densifies_edges():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)[:1]
+    g1 = geometry.to_geometry(cov, dissolve=False, step=1)
+    g8 = geometry.to_geometry(cov, dissolve=False, step=8)
+    n1 = shapely.get_coordinates(shapely.get_exterior_ring(
+        shapely.get_geometry(g1, 0))).shape[0]
+    n8 = shapely.get_coordinates(shapely.get_exterior_ring(
+        shapely.get_geometry(g8, 0))).shape[0]
+    # step=1 → 4 corners (+closing); step=8 → 32 boundary points (+closing).
+    assert n1 == 5 and n8 == 33
+
+
+def test_emit_antimeridian_and_polar_cells_are_valid():
+    # A cover straddling the antimeridian and one over the north pole; per-cell
+    # emit (with mort2polygon's antimeridian normalization) must stay valid
+    # (no self-intersection) — the plan's emit acceptance criterion.
+    am = mortie.morton_coverage(
+        [10.0, 20.0, 20.0, 10.0], [179.0, 179.0, -179.0, -179.0], order=5
+    )
+    polar = mortie.morton_coverage(
+        [85.0, 85.0, 89.0, 89.0], [-90.0, 90.0, 90.0, -90.0], order=5
+    )
+    for cov in (am, polar):
+        g = geometry.to_geometry(cov, dissolve=False)
+        assert g.geom_type == "MultiPolygon" and shapely.get_num_geometries(g) > 0
+        # Every emitted cell quad is a valid (non-self-intersecting) polygon.
+        for i in range(shapely.get_num_geometries(g)):
+            assert shapely.get_geometry(g, i).is_valid
 
 
 def test_emit_srid_optin_and_empty_cover():

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -479,3 +479,42 @@ def test_dissolve_wkb_wkt_srid_roundtrip():
 def test_dissolve_empty_cover():
     mp = geometry.to_geometry(np.array([], dtype=np.uint64))
     assert mp.geom_type == "MultiPolygon" and mp.is_empty
+
+
+def _interleave(x, y, order):
+    h = 0
+    for i in range(order):
+        h |= ((x >> i) & 1) << (2 * i)
+        h |= ((y >> i) & 1) << (2 * i + 1)
+    return h
+
+
+def test_dissolve_corner_touch_yields_simple_rings():
+    # Two cells in one base face that touch ONLY at a corner (non-manifold
+    # boundary vertex).  Angular ring-chaining must keep them as two separate
+    # valid polygons rather than crossing into a self-touching bowtie.
+    from mortie import _rustie
+
+    order, face, side = 4, 4, 2 ** 4
+    nested = np.array(
+        [face * side * side + _interleave(5, 5, order),
+         face * side * side + _interleave(6, 6, order)],
+        dtype=np.uint64,
+    )
+    cov = np.unique(np.asarray(
+        _rustie.rust_mi_from_nested(nested, order), dtype=np.uint64))
+    mp = geometry.to_geometry(cov)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 2
+    for i in range(2):
+        assert shapely.get_geometry(mp, i).is_valid
+
+
+def test_dissolve_step_cancels_seams_no_spurious_holes():
+    # With step>1 the shared sub-edge points between neighbours must still cancel,
+    # or failed cancellation would leave sliver interior rings.  A contiguous box
+    # must dissolve to a single hole-free outline at every step.
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    for step in (2, 4, 8):
+        mp = geometry.to_geometry(cov, step=step)
+        assert mp.is_valid and shapely.get_num_geometries(mp) == 1
+        assert shapely.get_num_interior_rings(shapely.get_geometry(mp, 0)) == 0

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -305,10 +305,17 @@ def test_emit_srid_optin_and_empty_cover():
     assert empty.geom_type == "MultiPolygon" and empty.is_empty
 
 
-def test_emit_dissolve_default_pending_phase4():
+def test_emit_dissolve_is_the_default():
+    # dissolve=True is the default: to_wkb(cov) with no flag emits the dissolved
+    # outline (one ring for a contiguous box), not the per-cell quads.
     cov = mortie.morton_coverage(_LATS, _LONS, order=6)
-    with pytest.raises(NotImplementedError, match="phase 4"):
-        geometry.to_wkb(cov)
+    dissolved = shapely.from_wkb(geometry.to_wkb(cov))
+    assert dissolved.geom_type == "MultiPolygon"
+    assert shapely.get_num_geometries(dissolved) == 1
+    # The dissolved outline has far fewer vertices than the per-cell emit.
+    per_cell = geometry.to_geometry(cov, dissolve=False)
+    assert shapely.get_num_coordinates(dissolved) < \
+        shapely.get_num_coordinates(per_cell)
 
 
 def test_backend_gate_message(monkeypatch):
@@ -327,3 +334,148 @@ def test_backend_gate_message(monkeypatch):
     with pytest.raises(ImportError, match="shapely"):
         gm._require_backend()
     # monkeypatch reverts _BACKEND and __import__; the next call re-resolves.
+
+
+# ── dissolved-outline emit (phase 4) ───────────────────────────────────────
+
+
+def _union_oracle(cov):
+    """shapely.unary_union of the per-cell quads — the independent dissolve
+    reference, valid away from the antimeridian / poles (planar union)."""
+    polys = [
+        shapely.Polygon([(lon, lat) for lat, lon in mortie.mort2polygon(int(w))])
+        for w in cov
+    ]
+    return shapely.unary_union(polys)
+
+
+def _ring_spherical_area(coords):
+    """Signed steradian area of a closed lon/lat ring (backend-independent — the
+    one oracle that still works across the antimeridian / poles)."""
+    a = np.asarray(coords[:-1], dtype=np.float64)
+    rlat = np.radians(a[:, 1])
+    rlon = np.radians(a[:, 0])
+    v = np.column_stack(
+        [np.cos(rlat) * np.cos(rlon), np.cos(rlat) * np.sin(rlon), np.sin(rlat)]
+    )
+    p0, b, c = v[0], v[1:-1], v[2:]
+    num = np.einsum("j,ij->i", p0, np.cross(b, c))
+    den = 1.0 + b @ p0 + np.einsum("ij,ij->i", b, c) + c @ p0
+    return float(np.sum(2.0 * np.arctan2(num, den)))
+
+
+def _cover_area(cov):
+    _, depths = mortie.tools._rust_mort2nested(
+        np.ascontiguousarray(np.asarray(cov, dtype=np.uint64))
+    )
+    return float(np.sum(4.0 * np.pi / (12.0 * (4.0 ** depths))))
+
+
+def test_dissolve_matches_union_oracle():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    mp = geometry.to_geometry(cov)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 1
+    # Native edge-cancellation dissolve == shapely's planar union, to precision.
+    assert mp.symmetric_difference(_union_oracle(cov)).area < 1e-9
+
+
+def test_dissolve_polygon_with_hole():
+    big = mortie.morton_coverage(
+        [30.0, 30.0, 60.0, 60.0], [-130.0, -100.0, -100.0, -130.0], order=5
+    )
+    inner = mortie.morton_coverage(
+        [42.0, 42.0, 48.0, 48.0], [-120.0, -110.0, -110.0, -120.0], order=5
+    )
+    cov = np.array(sorted(set(big.tolist()) - set(inner.tolist())), dtype=np.uint64)
+    mp = geometry.to_geometry(cov)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 1
+    # The carved-out interior is emitted as exactly one hole.
+    assert shapely.get_num_interior_rings(shapely.get_geometry(mp, 0)) == 1
+    assert mp.symmetric_difference(_union_oracle(cov)).area < 1e-9
+
+
+def test_dissolve_disjoint_components():
+    a = mortie.morton_coverage(
+        [40.0, 40.0, 45.0, 45.0], [-120.0, -115.0, -115.0, -120.0], order=6
+    )
+    b = mortie.morton_coverage(
+        [40.0, 40.0, 45.0, 45.0], [-100.0, -95.0, -95.0, -100.0], order=6
+    )
+    cov = np.unique(np.concatenate([a, b]))
+    mp = geometry.to_geometry(cov)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 2
+    assert mp.symmetric_difference(_union_oracle(cov)).area < 1e-9
+
+
+def test_dissolve_step_densifies_and_matches():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    g1 = geometry.to_geometry(cov, step=1)
+    g4 = geometry.to_geometry(cov, step=4)
+    # step traces the curved HEALPix edge: more boundary vertices, still valid.
+    # (The curved outline differs from the straight-chord union by the chord
+    # error, so area conservation — not planar symdiff — is the right oracle.)
+    assert g4.is_valid
+    assert shapely.get_num_coordinates(g4) > shapely.get_num_coordinates(g1)
+    ring = list(shapely.get_coordinates(
+        shapely.get_exterior_ring(shapely.get_geometry(g4, 0))))
+    assert abs(_ring_spherical_area(ring) - _cover_area(cov)) < 1e-3
+
+
+def test_dissolve_mixed_order_moc():
+    moc = mortie.morton_coverage_moc(_LATS, _LONS, order=8)
+    mp = geometry.to_geometry(moc)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 1
+    # The MOC is densified to its finest order, so the dissolved outline encloses
+    # the same area as the MOC's cells (independent of the planar union, which a
+    # coarse-vs-fine chord mismatch would perturb).
+    assert abs(_ring_spherical_area(
+        list(shapely.get_coordinates(shapely.get_exterior_ring(
+            shapely.get_geometry(mp, 0))))
+    ) - _cover_area(mortie.coverage.moc_to_order(moc, 8))) < 1e-3
+
+
+def test_dissolve_antimeridian_split():
+    # A box straddling +/-180: the outline crosses the antimeridian (an even
+    # number of times, no pole) and must split into valid pieces.
+    cov = mortie.morton_coverage(
+        [10.0, 10.0, 20.0, 20.0], [170.0, -170.0, -170.0, 170.0], order=5
+    )
+    mp = geometry.to_geometry(cov)
+    assert mp.is_valid and shapely.get_num_geometries(mp) >= 2
+    # No emitted piece spans more than a hemisphere of longitude (the hallmark of
+    # a correctly split antimeridian polygon).
+    out_area = 0.0
+    for i in range(shapely.get_num_geometries(mp)):
+        ring = list(shapely.get_coordinates(
+            shapely.get_exterior_ring(shapely.get_geometry(mp, i))))
+        lons = np.asarray(ring)[:, 0]
+        assert lons.max() - lons.min() <= 180.0 + 1e-9
+        out_area += _ring_spherical_area(ring)
+    # The split conserves the covered area exactly (no sliver lost at the seam).
+    assert abs(out_area - _cover_area(cov)) < 1e-3
+
+
+def test_dissolve_pole_enclosing_raises():
+    # A ring of cells around the north pole encloses it (odd antimeridian
+    # crossings) — not yet supported; must raise a clear, specific error.
+    lats, lons = [], []
+    for lo in range(-180, 180, 20):
+        lats += [82.0, 82.0, 89.9, 89.9]
+        lons += [lo, lo + 20, lo + 20, lo]
+    cap = np.unique(mortie.morton_coverage(lats, lons, order=4))
+    with pytest.raises(NotImplementedError, match="pole-enclosing"):
+        geometry.to_geometry(cap)
+
+
+def test_dissolve_wkb_wkt_srid_roundtrip():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    assert shapely.from_wkb(geometry.to_wkb(cov)).geom_type == "MultiPolygon"
+    assert shapely.from_wkt(geometry.to_wkt(cov)).geom_type == "MultiPolygon"
+    assert int(shapely.get_srid(
+        shapely.from_wkb(geometry.to_wkb(cov, srid=4326)))) == 4326
+    assert geometry.to_wkt(cov, srid=4326).startswith("SRID=4326;")
+
+
+def test_dissolve_empty_cover():
+    mp = geometry.to_geometry(np.array([], dtype=np.uint64))
+    assert mp.geom_type == "MultiPolygon" and mp.is_empty

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -455,16 +455,119 @@ def test_dissolve_antimeridian_split():
     assert abs(out_area - _cover_area(cov)) < 1e-3
 
 
-def test_dissolve_pole_enclosing_raises():
-    # A ring of cells around the north pole encloses it (odd antimeridian
-    # crossings) — not yet supported; must raise a clear, specific error.
+def _polar_cap(latlo, lathi, order=4):
+    """A ring of cells encircling a pole (the project's polar-data case)."""
     lats, lons = [], []
     for lo in range(-180, 180, 20):
-        lats += [82.0, 82.0, 89.9, 89.9]
+        lats += [latlo, latlo, lathi, lathi]
         lons += [lo, lo + 20, lo + 20, lo]
-    cap = np.unique(mortie.morton_coverage(lats, lons, order=4))
-    with pytest.raises(NotImplementedError, match="pole-enclosing"):
-        geometry.to_geometry(cap)
+    return np.unique(mortie.morton_coverage(lats, lons, order=order))
+
+
+@pytest.mark.parametrize("latlo,lathi,pole", [(82.0, 89.9, 90.0),
+                                              (-89.9, -82.0, -90.0)])
+def test_dissolve_polar_cap(latlo, lathi, pole):
+    # A pole-enclosing cap dissolves to the GeoJSON convention: a single polygon
+    # with explicit +/-90 pole vertices stitched down the antimeridian.
+    cap = _polar_cap(latlo, lathi)
+    mp = geometry.to_geometry(cap)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 1
+    coords = np.asarray(shapely.get_coordinates(
+        shapely.get_exterior_ring(shapely.get_geometry(mp, 0))))
+    # The frozen representation carries an explicit pole vertex at +/-90 and the
+    # seam runs down +/-180.
+    assert np.any(np.isclose(coords[:, 1], pole))
+    assert np.any(np.isclose(np.abs(coords[:, 0]), 180.0))
+    # Spherical-area conservation (the planar union oracle breaks at the pole).
+    assert abs(_ring_spherical_area(list(map(tuple, coords))) -
+               _cover_area(cap)) < 1e-2
+
+
+def test_dissolve_polar_cap_matches_spherely():
+    # Independent sphere-truth cross-check: spherely (s2geometry) is geodesic and
+    # has no pole singularity, so the union of the per-cell quads gives the exact
+    # spherical area of the dissolved cap.  (Test-only oracle; runtime is
+    # numpy-only and never imports spherely.)
+    spherely = pytest.importorskip("spherely")
+    cap = _polar_cap(-89.9, -82.0)
+    quads = [
+        spherely.create_polygon(
+            shell=[(lon, lat) for lat, lon in mortie.mort2polygon(int(w))])
+        for w in cap
+    ]
+    acc = quads[0]
+    for q in quads[1:]:
+        acc = spherely.union(acc, q)
+    oracle = spherely.area(acc) / (spherely.EARTH_RADIUS_METERS ** 2)
+    mp = geometry.to_geometry(cap)
+    ring = list(map(tuple, shapely.get_coordinates(
+        shapely.get_exterior_ring(shapely.get_geometry(mp, 0)))))
+    assert mp.is_valid
+    assert abs(abs(_ring_spherical_area(ring)) - oracle) < 1e-9
+
+
+def test_dissolve_polar_annulus():
+    # A band around the south pole: a pole-enclosing exterior AND a pole-enclosing
+    # hole.  Their net longitude windings cancel, so the FILLED region does NOT
+    # enclose the pole — the splitter must reconnect ext-to-hole along the seam
+    # (no pole vertex) into one valid polygon, not route each through the pole.
+    big = _polar_cap(-89.9, -75.0, order=4)
+    inner = _polar_cap(-89.9, -85.0, order=4)
+    ann = np.array(sorted(set(big.tolist()) - set(inner.tolist())), dtype=np.uint64)
+    mp = geometry.to_geometry(ann)
+    assert mp.is_valid and shapely.get_num_geometries(mp) >= 1
+    out = 0.0
+    for i in range(shapely.get_num_geometries(mp)):
+        g = shapely.get_geometry(mp, i)
+        out += _ring_spherical_area(list(map(tuple, shapely.get_coordinates(
+            shapely.get_exterior_ring(g)))))
+        for j in range(shapely.get_num_interior_rings(g)):
+            out -= abs(_ring_spherical_area(list(map(tuple, shapely.get_coordinates(
+                shapely.get_interior_ring(g, j))))))
+    assert abs(abs(out) - _cover_area(ann)) < 1e-2
+
+
+def test_dissolve_antimeridian_multi_crossing():
+    # Two disjoint antimeridian-straddling boxes: the exterior set crosses +/-180
+    # four times.  Each closes on its own side into a valid hemisphere piece.
+    a = mortie.morton_coverage(
+        [10.0, 10.0, 20.0, 20.0], [170.0, -170.0, -170.0, 170.0], order=5)
+    b = mortie.morton_coverage(
+        [40.0, 40.0, 50.0, 50.0], [170.0, -170.0, -170.0, 170.0], order=5)
+    cov = np.unique(np.concatenate([a, b]))
+    mp = geometry.to_geometry(cov)
+    assert mp.is_valid
+    out = 0.0
+    for i in range(shapely.get_num_geometries(mp)):
+        ring = list(map(tuple, shapely.get_coordinates(
+            shapely.get_exterior_ring(shapely.get_geometry(mp, i)))))
+        assert np.ptp(np.asarray(ring)[:, 0]) <= 180.0 + 1e-9
+        out += _ring_spherical_area(ring)
+    assert abs(out - _cover_area(cov)) < 1e-2
+
+
+def test_dissolve_antimeridian_crossing_hole():
+    # An antimeridian-straddling box with an inner antimeridian-straddling box
+    # removed: the hole itself crosses +/-180 (no pole).  Splitting an annulus at
+    # the antimeridian opens the hole into a seam-side concavity, so each half is
+    # a valid C-shaped piece (the GeoJSON convention) — area must still conserve.
+    big = mortie.morton_coverage(
+        [10.0, 10.0, 40.0, 40.0], [160.0, -160.0, -160.0, 160.0], order=4)
+    inner = mortie.morton_coverage(
+        [20.0, 20.0, 30.0, 30.0], [170.0, -170.0, -170.0, 170.0], order=4)
+    cov = np.array(sorted(set(big.tolist()) - set(inner.tolist())), dtype=np.uint64)
+    mp = geometry.to_geometry(cov)
+    assert mp.is_valid
+    out = 0.0
+    for i in range(shapely.get_num_geometries(mp)):
+        g = shapely.get_geometry(mp, i)
+        ring = np.asarray(shapely.get_coordinates(shapely.get_exterior_ring(g)))
+        assert np.ptp(ring[:, 0]) <= 180.0 + 1e-9  # no piece spans a hemisphere+
+        out += _ring_spherical_area(list(map(tuple, ring)))
+        for j in range(shapely.get_num_interior_rings(g)):
+            out -= abs(_ring_spherical_area(list(map(tuple, shapely.get_coordinates(
+                shapely.get_interior_ring(g, j))))))
+    assert abs(out - _cover_area(cov)) < 1e-2
 
 
 def test_dissolve_wkb_wkt_srid_roundtrip():

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -205,6 +205,67 @@ def test_ingest_linear_rejects_polygon_only_args():
         mortie.from_wkt(wkt, order=6, moc=True)
 
 
+def test_ingest_moc_via_wkb_and_clockwise_spelling():
+    # moc ingest works through WKB (not just WKT)...
+    want = mortie.morton_coverage_moc(_LATS, _LONS, order=8)
+    wkb = geometry.geometry_to_wkb(shapely.from_wkt(_poly_wkt(_LATS, _LONS)))
+    assert np.array_equal(mortie.from_wkb(wkb, order=8, moc=True), want)
+    # ...and a clockwise ring gives the same sub-hemisphere cover as CCW
+    # (normalize=True default makes ordinary polygons orientation-insensitive).
+    ccw = _poly_wkt(list(reversed(_LATS)), list(reversed(_LONS)))
+    cw = _poly_wkt(_LATS, _LONS)
+    assert np.array_equal(
+        mortie.from_wkt(cw, order=6), mortie.from_wkt(ccw, order=6)
+    )
+
+
+# ── Phase 3: per-cell emit (dissolve=False) ────────────────────────────────
+
+
+def test_emit_per_cell_one_polygon_per_cell():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    g = geometry.to_geometry(cov, dissolve=False)
+    assert g.geom_type == "MultiPolygon"
+    assert shapely.get_num_geometries(g) == cov.size
+
+
+def test_emit_per_cell_mixed_order_moc():
+    moc = mortie.morton_coverage_moc(_LATS, _LONS, order=8)
+    g = geometry.to_geometry(moc, dissolve=False)
+    # Each MOC cell (any order) emits exactly one quad.
+    assert shapely.get_num_geometries(g) == moc.size
+
+
+def test_emit_wkb_wkt_roundtrip_matches_cell_corners():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    wkb = geometry.to_wkb(cov, dissolve=False)
+    back = shapely.from_wkb(wkb)
+    assert shapely.get_num_geometries(back) == cov.size
+    # The first emitted cell's exterior matches mort2polygon's lon/lat corners.
+    poly0 = shapely.get_geometry(back, 0)
+    ring_lonlat = shapely.get_coordinates(shapely.get_exterior_ring(poly0))
+    want = np.array([[lon, lat] for lat, lon in mortie.mort2polygon(int(cov[0]))])
+    assert np.allclose(np.sort(ring_lonlat, axis=0), np.sort(want, axis=0))
+    # WKT path parses too.
+    assert shapely.from_wkt(geometry.to_wkt(cov, dissolve=False)).geom_type \
+        == "MultiPolygon"
+
+
+def test_emit_srid_optin_and_empty_cover():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    assert geometry.to_wkt(cov, dissolve=False, srid=4326).startswith("SRID=4326;")
+    assert int(shapely.get_srid(shapely.from_wkb(
+        geometry.to_wkb(cov, dissolve=False, srid=4326)))) == 4326
+    empty = geometry.to_geometry(np.array([], dtype=np.uint64), dissolve=False)
+    assert empty.geom_type == "MultiPolygon" and empty.is_empty
+
+
+def test_emit_dissolve_default_pending_phase4():
+    cov = mortie.morton_coverage(_LATS, _LONS, order=6)
+    with pytest.raises(NotImplementedError, match="phase 4"):
+        geometry.to_wkb(cov)
+
+
 def test_backend_gate_message(monkeypatch):
     # With no backend importable, a clear ImportError naming shapely/spherely.
     import mortie.geometry as gm

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -516,14 +516,12 @@ def test_dissolve_polar_annulus():
     ann = np.array(sorted(set(big.tolist()) - set(inner.tolist())), dtype=np.uint64)
     mp = geometry.to_geometry(ann)
     assert mp.is_valid and shapely.get_num_geometries(mp) >= 1
-    out = 0.0
-    for i in range(shapely.get_num_geometries(mp)):
-        g = shapely.get_geometry(mp, i)
-        out += _ring_spherical_area(list(map(tuple, shapely.get_coordinates(
-            shapely.get_exterior_ring(g)))))
-        for j in range(shapely.get_num_interior_rings(g)):
-            out -= abs(_ring_spherical_area(list(map(tuple, shapely.get_coordinates(
-                shapely.get_interior_ring(g, j))))))
+    # The pole seam opens the band's inner hole into a concavity, so the piece is
+    # a hole-free C-shape whose signed exterior area already nets out the cavity.
+    out = sum(
+        _ring_spherical_area(list(map(tuple, shapely.get_coordinates(
+            shapely.get_exterior_ring(shapely.get_geometry(mp, i))))))
+        for i in range(shapely.get_num_geometries(mp)))
     assert abs(abs(out) - _cover_area(ann)) < 1e-2
 
 
@@ -563,10 +561,9 @@ def test_dissolve_antimeridian_crossing_hole():
         g = shapely.get_geometry(mp, i)
         ring = np.asarray(shapely.get_coordinates(shapely.get_exterior_ring(g)))
         assert np.ptp(ring[:, 0]) <= 180.0 + 1e-9  # no piece spans a hemisphere+
+        # The seam opens the hole into a concavity, so each piece is hole-free
+        # and its signed exterior area already accounts for the carved interior.
         out += _ring_spherical_area(list(map(tuple, ring)))
-        for j in range(shapely.get_num_interior_rings(g)):
-            out -= abs(_ring_spherical_area(list(map(tuple, shapely.get_coordinates(
-                shapely.get_interior_ring(g, j))))))
     assert abs(out - _cover_area(cov)) < 1e-2
 
 
@@ -621,3 +618,43 @@ def test_dissolve_step_cancels_seams_no_spurious_holes():
         mp = geometry.to_geometry(cov, step=step)
         assert mp.is_valid and shapely.get_num_geometries(mp) == 1
         assert shapely.get_num_interior_rings(shapely.get_geometry(mp, 0)) == 0
+
+
+# ── Phase 6: Rust dissolve fast path == the Python reference engine ─────────
+
+
+def _structure(mp):
+    """(#polygons, sorted #interior-rings, total #coords) of a MultiPolygon — a
+    rotation-invariant structural fingerprint (the ring vertex order/start may
+    differ between two correct engines, but the topology must match)."""
+    n = shapely.get_num_geometries(mp)
+    holes = sorted(
+        shapely.get_num_interior_rings(shapely.get_geometry(mp, i)) for i in range(n))
+    return n, holes, int(shapely.get_num_coordinates(mp))
+
+
+@pytest.mark.parametrize("step", [1, 4])
+def test_dissolve_rust_matches_python_reference(step):
+    # The runtime dissolve is Rust (geometry._dissolved_polygons -> rust_dissolve);
+    # _dissolved_rings_py is the exact-verified Python reference oracle.  They must
+    # agree to machine precision across contiguous, holed, antimeridian, and
+    # polar-cap covers.
+    box = mortie.morton_coverage(_LATS, _LONS, order=6)
+    big = mortie.morton_coverage(
+        [30.0, 30.0, 60.0, 60.0], [-130.0, -100.0, -100.0, -130.0], order=5)
+    inner = mortie.morton_coverage(
+        [42.0, 42.0, 48.0, 48.0], [-120.0, -110.0, -110.0, -120.0], order=5)
+    holed = np.array(sorted(set(big.tolist()) - set(inner.tolist())), dtype=np.uint64)
+    am = mortie.morton_coverage(
+        [10.0, 10.0, 20.0, 20.0], [170.0, -170.0, -170.0, 170.0], order=5)
+    cap = _polar_cap(-89.9, -82.0)
+    for cov in (box, holed, am, cap):
+        ext_py, holes_py = geometry._dissolved_rings_py(cov, step)
+        mp_py = shapely.MultiPolygon(
+            geometry._nest_and_build(shapely, ext_py, holes_py))
+        mp_rust = geometry.to_geometry(cov, step=step)
+        assert mp_rust.is_valid
+        # Identical geometry to a machine-precision symmetric difference, and the
+        # same topology (polygon / hole / vertex counts) — not just equal area.
+        assert mp_rust.symmetric_difference(mp_py).area < 1e-9
+        assert _structure(mp_rust) == _structure(mp_py)

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -1,0 +1,117 @@
+"""Tests for the WKB/WKT geometry codec adapter (issue #71, phase 1).
+
+These pin :mod:`mortie.geometry`: the lazy backend gate, the WKB/WKT (and
+EWKB/EWKT) codec, and the decomposition of polygons / multipolygons / holes /
+linestrings into ``(lat, lon)`` ring arrays — the input shape the ingest path
+(phase 2) feeds to the existing coverage entry points.  The backend is used
+only as a codec; spherical correctness is mortie's own job and not exercised
+here.
+"""
+
+import numpy as np
+import pytest
+
+from mortie import geometry
+
+shapely = pytest.importorskip("shapely")
+
+
+def test_decompose_polygon_with_hole():
+    # A unit square with a square hole: exterior + one interior ring.
+    g = shapely.from_wkt(
+        "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0),"
+        "(0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, 0.5 0.5))"
+    )
+    kind, rings = geometry.decompose(g)
+    assert kind == "polygonal"
+    assert len(rings) == 2  # exterior + hole
+    ext_lat, ext_lon = rings[0]
+    # (x, y) = (lon, lat): the exterior spans lon/lat 0..2.
+    assert np.isclose(ext_lon.max(), 2.0) and np.isclose(ext_lat.max(), 2.0)
+    hole_lat, hole_lon = rings[1]
+    assert np.isclose(hole_lon.min(), 0.5) and np.isclose(hole_lat.min(), 0.5)
+
+
+def test_decompose_multipolygon_flattens_all_rings():
+    g = shapely.from_wkt(
+        "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)),"
+        "((5 5, 6 5, 6 6, 5 6, 5 5),(5.2 5.2, 5.8 5.2, 5.8 5.8, 5.2 5.8, 5.2 5.2)))"
+    )
+    kind, rings = geometry.decompose(g)
+    assert kind == "polygonal"
+    # poly1 (1 ring) + poly2 (exterior + 1 hole) = 3 rings, flattened.
+    assert len(rings) == 3
+
+
+def test_decompose_linestring_and_multilinestring():
+    ls = shapely.from_wkt("LINESTRING (0 0, 1 1, 2 0)")
+    kind, lines = geometry.decompose(ls)
+    assert kind == "linear"
+    assert len(lines) == 1
+    lat, lon = lines[0]
+    assert lat.shape == (3,) and lon.shape == (3,)
+
+    mls = shapely.from_wkt("MULTILINESTRING ((0 0, 1 1), (2 2, 3 3, 4 4))")
+    kind, lines = geometry.decompose(mls)
+    assert kind == "linear"
+    assert [ln[0].size for ln in lines] == [2, 3]
+
+
+def test_decompose_rejects_points_and_collections():
+    with pytest.raises(ValueError, match="unsupported geometry type"):
+        geometry.decompose(shapely.from_wkt("POINT (1 2)"))
+    with pytest.raises(ValueError, match="unsupported geometry type"):
+        geometry.decompose(
+            shapely.from_wkt("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (0 0, 1 1))")
+        )
+
+
+def test_wkb_wkt_codec_roundtrip():
+    wkt = "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"
+    g = geometry.geometry_from_wkt(wkt)
+    # WKB round-trip preserves the rings.
+    wkb = geometry.geometry_to_wkb(g)
+    assert isinstance(wkb, (bytes, bytearray))
+    g2 = geometry.geometry_from_wkb(wkb)
+    k1, r1 = geometry.decompose(g)
+    k2, r2 = geometry.decompose(g2)
+    assert k1 == k2
+    assert np.allclose(r1[0][0], r2[0][0]) and np.allclose(r1[0][1], r2[0][1])
+    # WKT round-trip.
+    g3 = geometry.geometry_from_wkt(geometry.geometry_to_wkt(g))
+    assert int(shapely.get_type_id(g3)) == int(shapely.get_type_id(g))
+
+
+def test_ewkb_ewkt_srid_optin():
+    g = geometry.geometry_from_wkt("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))")
+
+    # EWKT carries the SRID prefix; plain WKT does not.
+    ewkt = geometry.geometry_to_wkt(g, srid=4326)
+    assert ewkt.startswith("SRID=4326;")
+    assert not geometry.geometry_to_wkt(g).startswith("SRID=")
+    # The EWKT prefix is tolerated on ingest (advisory; contract is EPSG:4326).
+    g_back = geometry.geometry_from_wkt(ewkt)
+    assert int(shapely.get_type_id(g_back)) == int(shapely.get_type_id(g))
+
+    # EWKB carries the SRID; from_wkb reads it back.
+    ewkb = geometry.geometry_to_wkb(g, srid=4326)
+    assert int(shapely.get_srid(geometry.geometry_from_wkb(ewkb))) == 4326
+    assert int(shapely.get_srid(geometry.geometry_from_wkb(geometry.geometry_to_wkb(g)))) == 0
+
+
+def test_backend_gate_message(monkeypatch):
+    # With no backend importable, a clear ImportError naming shapely/spherely.
+    import mortie.geometry as gm
+
+    monkeypatch.setattr(gm, "_BACKEND", None)
+    real_import = __import__
+
+    def _block(name, *args, **kwargs):
+        if name in ("shapely", "spherely"):
+            raise ImportError(f"blocked {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _block)
+    with pytest.raises(ImportError, match="shapely"):
+        gm._require_backend()
+    # monkeypatch reverts _BACKEND and __import__; the next call re-resolves.

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -11,6 +11,7 @@ here.
 import numpy as np
 import pytest
 
+import mortie
 from mortie import geometry
 
 shapely = pytest.importorskip("shapely")
@@ -66,6 +67,21 @@ def test_decompose_rejects_points_and_collections():
         )
 
 
+def test_decompose_rejects_empty_geometry():
+    for wkt in ("POLYGON EMPTY", "LINESTRING EMPTY", "MULTIPOLYGON EMPTY"):
+        with pytest.raises(ValueError, match="empty geometry"):
+            geometry.decompose(shapely.from_wkt(wkt))
+
+
+def test_decompose_drops_z_coordinate():
+    # A 3-D polygon ingests as its 2-D lon/lat footprint (Z is dropped).
+    g = shapely.from_wkt("POLYGON Z ((0 0 5, 1 0 5, 1 1 5, 0 1 5, 0 0 5))")
+    kind, rings = geometry.decompose(g)
+    assert kind == "polygonal"
+    lat, lon = rings[0]
+    assert lat.ndim == 1 and lon.ndim == 1  # no third column leaked through
+
+
 def test_wkb_wkt_codec_roundtrip():
     wkt = "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"
     g = geometry.geometry_from_wkt(wkt)
@@ -97,6 +113,96 @@ def test_ewkb_ewkt_srid_optin():
     ewkb = geometry.geometry_to_wkb(g, srid=4326)
     assert int(shapely.get_srid(geometry.geometry_from_wkb(ewkb))) == 4326
     assert int(shapely.get_srid(geometry.geometry_from_wkb(geometry.geometry_to_wkb(g)))) == 0
+
+
+# ── Phase 2: ingest reproduces the array-path coverage ─────────────────────
+
+# A small polygon well away from the poles / antimeridian.
+_LATS = [40.0, 50.0, 50.0, 40.0]
+_LONS = [-120.0, -120.0, -110.0, -110.0]
+
+
+def _poly_wkt(lats, lons):
+    pts = ", ".join(f"{lo} {la}" for la, lo in zip(lats, lons))
+    first = f"{lons[0]} {lats[0]}"
+    return f"POLYGON (({pts}, {first}))"
+
+
+def test_ingest_polygon_matches_array_path():
+    want = mortie.morton_coverage(_LATS, _LONS, order=6)
+    wkt = _poly_wkt(_LATS, _LONS)
+    got_wkt = mortie.from_wkt(wkt, order=6)
+    got_wkb = mortie.from_wkb(geometry.geometry_to_wkb(shapely.from_wkt(wkt)), order=6)
+    assert np.array_equal(got_wkt, want)
+    assert np.array_equal(got_wkb, want)
+
+
+def test_ingest_polygon_with_hole_matches_array_path():
+    outer_lat, outer_lon = _LATS, _LONS
+    hole_lat = [43.0, 47.0, 47.0, 43.0]
+    hole_lon = [-117.0, -117.0, -113.0, -113.0]
+    want = mortie.morton_coverage(
+        [outer_lat, hole_lat], [outer_lon, hole_lon], order=6
+    )
+    wkt = (
+        "POLYGON (("
+        + ", ".join(f"{lo} {la}" for la, lo in zip(outer_lat, outer_lon))
+        + f", {outer_lon[0]} {outer_lat[0]}),("
+        + ", ".join(f"{lo} {la}" for la, lo in zip(hole_lat, hole_lon))
+        + f", {hole_lon[0]} {hole_lat[0]}))"
+    )
+    assert np.array_equal(mortie.from_wkt(wkt, order=6), want)
+
+
+def test_ingest_multipolygon_matches_array_path():
+    lats2 = [10.0, 20.0, 20.0, 10.0]
+    lons2 = [-80.0, -80.0, -70.0, -70.0]
+    want = mortie.morton_coverage([_LATS, lats2], [_LONS, lons2], order=6)
+    wkt = (
+        "MULTIPOLYGON ((("
+        + ", ".join(f"{lo} {la}" for la, lo in zip(_LATS, _LONS))
+        + f", {_LONS[0]} {_LATS[0]})),(("
+        + ", ".join(f"{lo} {la}" for la, lo in zip(lats2, lons2))
+        + f", {lons2[0]} {lats2[0]})))"
+    )
+    assert np.array_equal(mortie.from_wkt(wkt, order=6), want)
+
+
+def test_ingest_polygon_moc_matches_array_path():
+    want = mortie.morton_coverage_moc(_LATS, _LONS, order=8)
+    wkt = _poly_wkt(_LATS, _LONS)
+    assert np.array_equal(mortie.from_wkt(wkt, order=8, moc=True), want)
+
+
+def test_ingest_linestring_matches_array_path():
+    lats = [40.0, 50.0, 45.0]
+    lons = [-120.0, -110.0, -100.0]
+    want = mortie.linestring_coverage(lats, lons, order=6)
+    wkt = "LINESTRING (" + ", ".join(f"{lo} {la}" for la, lo in zip(lats, lons)) + ")"
+    got = mortie.from_wkt(wkt, order=6)
+    assert np.array_equal(got, want)
+
+
+def test_ingest_multilinestring_matches_array_path():
+    lats = [[40.0, 50.0], [10.0, 20.0, 15.0]]
+    lons = [[-120.0, -110.0], [-80.0, -70.0, -60.0]]
+    want = mortie.linestring_coverage(lats, lons, order=6)
+    wkt = (
+        "MULTILINESTRING (("
+        + ", ".join(f"{lo} {la}" for la, lo in zip(lats[0], lons[0]))
+        + "),("
+        + ", ".join(f"{lo} {la}" for la, lo in zip(lats[1], lons[1]))
+        + "))"
+    )
+    got = mortie.from_wkt(wkt, order=6)
+    assert isinstance(got, list) and len(got) == 2
+    assert all(np.array_equal(g, w) for g, w in zip(got, want))
+
+
+def test_ingest_linear_rejects_polygon_only_args():
+    wkt = "LINESTRING (0 0, 1 1, 2 0)"
+    with pytest.raises(ValueError, match="only to polygonal"):
+        mortie.from_wkt(wkt, order=6, moc=True)
 
 
 def test_backend_gate_message(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
   "cdshealpix>=0.7",  # independent HEALPix oracle for the hemisphere/#11 tests
   "pandas>=2.0",      # exercise the morton_index ExtensionArray in CI
   "pyarrow>=14.0",    # exercise the morton_index Arrow ExtensionType in CI
+  "shapely>=2.0",     # WKB/WKT geometry codec for the issue #71 I/O (test-only)
 ]
 bench = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
   "pandas>=2.0",      # exercise the morton_index ExtensionArray in CI
   "pyarrow>=14.0",    # exercise the morton_index Arrow ExtensionType in CI
   "shapely>=2.0",     # WKB/WKT geometry codec for the issue #71 I/O (test-only)
+  "spherely>=0.1",    # geodesic (s2) sphere-truth oracle for polar/AM dissolve (test-only)
 ]
 bench = [
   "pytest",

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -312,6 +312,11 @@ fn next_segment(
 ) -> Option<usize> {
     let &(side, end_lat) = ring.last().unwrap();
     // candidate starts on the same +/-180 side (the seed is allowed, to close).
+    // The Python oracle keys min/max on the full (lat, index) tuple; here we
+    // compare on lat only, but iterate `0..segs.len()` in index order, so
+    // `min_by`/`max_by` (first-/last-of-equal) reproduce the same tie-break.
+    // Distinct crossing points never share a latitude within 1e-9°, so the tie
+    // is unreachable in practice anyway.
     let same_side = |i: usize| (segs[i][0].0 - side).abs() < 1e-9 && (!used[i] || i == seed);
     let pick: Option<(f64, usize)> = if side > 0.0 {
         (0..segs.len())

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -1,0 +1,499 @@
+//! Native dissolved-outline emit for a morton cover (issue #71, phase 6).
+//!
+//! This is the Rust port of `mortie/geometry.py`'s edge-cancellation dissolve
+//! (the Python remains the reference/oracle in the tests).  The pipeline:
+//!
+//! 1. Each cell's boundary is `step` points per edge of unit vectors; every
+//!    boundary point is integer-snapped to a vertex id, so a corner/sub-edge
+//!    point shared by two neighbours collapses to one id and their shared edge
+//!    cancels exactly (no floating tolerance search).
+//! 2. The surviving directed edges chain into rings; at a non-manifold
+//!    corner-touch vertex the next edge is the smallest anticlockwise turn from
+//!    the reversed arrival (right-hand rule), keeping rings simple.
+//! 3. Rings are classified exterior/hole by spherical signed area (global
+//!    winding normalised so the covered area is positive), then crossing rings
+//!    are cut at +/-180 and reconnected by the GeoJSON convention — explicit
+//!    +/-90 pole vertices stitched down the antimeridian for a pole-enclosing
+//!    region.
+//!
+//! The entry point returns classified planar rings (shells and holes) as
+//! `(lon, lat)` degree pairs; the Python side builds the backend Polygons and
+//! nests holes (both need the shapely codec anyway).
+
+use std::collections::HashMap;
+
+use crate::geo2mort::{boundaries_scalar, boundaries_step_scalar};
+use crate::moc;
+use crate::morton::mort2nested;
+use crate::sphere::{cross, dot, Vec3};
+
+// Snap scale for vertex identity (mirrors `_DISSOLVE_SNAP` in geometry.py): a
+// shared HEALPix corner that both adjacent cells compute identically collapses
+// to one integer-keyed vertex, so their shared edge cancels exactly.
+const SNAP: f64 = 1e10;
+
+/// A closed lon/lat ring (degrees): a list of `(lon, lat)` vertices.
+type Ring = Vec<(f64, f64)>;
+
+/// Classified planar (lon, lat) rings: exterior shells and hole rings.
+pub struct ClassifiedRings {
+    pub shells: Vec<Ring>,
+    pub holes: Vec<Ring>,
+}
+
+/// Dissolve a morton cover into classified planar (lon, lat) rings.
+pub fn dissolve(morton: &[u64], step: u32) -> ClassifiedRings {
+    let rings = boundary_rings_xyz(morton, step);
+    classify_and_split(rings)
+}
+
+// ── edge-cancellation: cover → boundary rings (unit vectors) ───────────────
+
+fn boundary_rings_xyz(morton: &[u64], step: u32) -> Vec<Vec<Vec3>> {
+    if morton.is_empty() {
+        return Vec::new();
+    }
+    // Decode depth per word; densify a mixed-order MOC to its finest order so
+    // every cell carries unit-length edges that cancel against their neighbours.
+    let depths: Vec<u8> = morton.iter().map(|&w| mort2nested(w).1).collect();
+    let max_depth = *depths.iter().max().unwrap();
+    let min_depth = *depths.iter().min().unwrap();
+    let flat: Vec<u64> = if min_depth != max_depth {
+        moc::to_order(morton, max_depth)
+    } else {
+        morton.to_vec()
+    };
+    let order = max_depth;
+
+    // Boundary points per cell, in boundary order, as unit vectors.
+    let mut all_pts: Vec<Vec<Vec3>> = Vec::with_capacity(flat.len());
+    for &w in &flat {
+        let nest = mort2nested(w).0;
+        if step == 1 {
+            let xyz = boundaries_scalar(order, nest); // [[x;4],[y;4],[z;4]]
+            let cell: Vec<Vec3> = (0..4).map(|c| [xyz[0][c], xyz[1][c], xyz[2][c]]).collect();
+            all_pts.push(cell);
+        } else {
+            all_pts.push(boundaries_step_scalar(order, nest, step)); // Vec<[f64;3]>
+        }
+    }
+
+    // Integer-snap every boundary point to a vertex id.
+    let mut id_of: HashMap<[i64; 3], u32> = HashMap::new();
+    let mut id_xyz: Vec<Vec3> = Vec::new();
+    let mut cell_ids: Vec<Vec<u32>> = Vec::with_capacity(all_pts.len());
+    for cell in &all_pts {
+        let mut ids = Vec::with_capacity(cell.len());
+        for p in cell {
+            let key = [
+                (p[0] * SNAP).round() as i64,
+                (p[1] * SNAP).round() as i64,
+                (p[2] * SNAP).round() as i64,
+            ];
+            let id = *id_of.entry(key).or_insert_with(|| {
+                id_xyz.push(*p);
+                (id_xyz.len() - 1) as u32
+            });
+            ids.push(id);
+        }
+        cell_ids.push(ids);
+    }
+
+    // Directed edges around every cell boundary; the net direction per
+    // undirected edge survives (an interior edge appears as (a,b) in one cell
+    // and (b,a) in its neighbour and cancels).
+    let mut counts: HashMap<(u32, u32), i64> = HashMap::new();
+    for ids in &cell_ids {
+        let n = ids.len();
+        for i in 0..n {
+            let a = ids[i];
+            let b = ids[(i + 1) % n];
+            if a != b {
+                *counts.entry((a, b)).or_insert(0) += 1;
+            }
+        }
+    }
+    let mut survivors: Vec<(u32, u32)> = Vec::new();
+    for (&(a, b), &c) in &counts {
+        let net = c - counts.get(&(b, a)).copied().unwrap_or(0);
+        for _ in 0..net.max(0) {
+            survivors.push((a, b));
+        }
+    }
+    chain_rings(&survivors, &id_xyz)
+}
+
+// ── ring chaining (angular / right-hand rule at non-manifold vertices) ─────
+
+fn tangent_azimuth(p: &Vec3, q: &Vec3) -> f64 {
+    let qp = dot(q, p);
+    let d = [q[0] - qp * p[0], q[1] - qp * p[1], q[2] - qp * p[2]];
+    let nd = (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt();
+    if nd < 1e-15 {
+        return 0.0;
+    }
+    let d = [d[0] / nd, d[1] / nd, d[2] / nd];
+    let mut east = cross(&[0.0, 0.0, 1.0], p);
+    let ne = (east[0] * east[0] + east[1] * east[1] + east[2] * east[2]).sqrt();
+    if ne < 1e-9 {
+        east = [1.0, 0.0, 0.0];
+    } else {
+        east = [east[0] / ne, east[1] / ne, east[2] / ne];
+    }
+    let north = cross(p, &east);
+    dot(&d, &east).atan2(dot(&d, &north))
+}
+
+fn chain_rings(survivors: &[(u32, u32)], id_xyz: &[Vec3]) -> Vec<Vec<Vec3>> {
+    let two_pi = std::f64::consts::TAU;
+    let az: Vec<f64> = survivors
+        .iter()
+        .map(|&(a, b)| tangent_azimuth(&id_xyz[a as usize], &id_xyz[b as usize]))
+        .collect();
+    let mut alive: Vec<bool> = vec![true; survivors.len()];
+    let mut by_start: HashMap<u32, Vec<usize>> = HashMap::new();
+    for (i, &(a, _)) in survivors.iter().enumerate() {
+        by_start.entry(a).or_default().push(i);
+    }
+
+    let mut rings = Vec::new();
+    for seed in 0..survivors.len() {
+        if !alive[seed] {
+            continue;
+        }
+        let seed_start = survivors[seed].0;
+        let mut cur = seed;
+        let mut chain: Vec<u32> = Vec::new();
+        loop {
+            if !alive[cur] {
+                break;
+            }
+            alive[cur] = false;
+            chain.push(survivors[cur].0);
+            let v = survivors[cur].1;
+            if v == seed_start {
+                break; // ring closed
+            }
+            let cands: Vec<usize> = by_start
+                .get(&v)
+                .map(|ix| ix.iter().copied().filter(|&i| alive[i]).collect())
+                .unwrap_or_default();
+            if cands.is_empty() {
+                break;
+            }
+            cur = if cands.len() == 1 {
+                cands[0]
+            } else {
+                // smallest turn anticlockwise from the reversed arrival.
+                let back = tangent_azimuth(&id_xyz[v as usize], &id_xyz[survivors[cur].0 as usize]);
+                *cands
+                    .iter()
+                    .min_by(|&&i, &&j| {
+                        let ti = (az[i] - back).rem_euclid(two_pi);
+                        let tj = (az[j] - back).rem_euclid(two_pi);
+                        ti.partial_cmp(&tj).unwrap()
+                    })
+                    .unwrap()
+            };
+        }
+        rings.push(chain.iter().map(|&i| id_xyz[i as usize]).collect());
+    }
+    rings
+}
+
+// ── classification + pole/antimeridian split (GeoJSON convention) ──────────
+
+fn spherical_signed_area(ring: &[Vec3]) -> f64 {
+    if ring.len() < 3 {
+        return 0.0;
+    }
+    let a = ring[0];
+    let mut total = 0.0;
+    for i in 1..ring.len() - 1 {
+        let b = ring[i];
+        let c = ring[i + 1];
+        let num = dot(&a, &cross(&b, &c));
+        let den = 1.0 + dot(&b, &a) + dot(&b, &c) + dot(&c, &a);
+        total += 2.0 * num.atan2(den);
+    }
+    total
+}
+
+fn xyz_to_lonlat(v: &Vec3) -> (f64, f64) {
+    let z = v[2].clamp(-1.0, 1.0);
+    let lat = z.asin().to_degrees();
+    let lon = v[1].atan2(v[0]).to_degrees();
+    (lon, lat)
+}
+
+fn net_winding(coords: &[(f64, f64)]) -> f64 {
+    let n = coords.len();
+    let mut net = 0.0;
+    for i in 0..n {
+        let lo0 = coords[i].0;
+        let lo1 = coords[(i + 1) % n].0;
+        let d = lo1 - lo0;
+        net += (d + 180.0).rem_euclid(360.0) - 180.0;
+    }
+    net
+}
+
+/// Cut an open lon/lat ring at +/-180.  `Ok(whole)` when the ring never
+/// crosses; `Err(segments)` with each segment an open polyline whose free ends
+/// sit on +/-180.
+fn cut_at_antimeridian(coords: &[(f64, f64)]) -> Result<Ring, Vec<Ring>> {
+    let n = coords.len();
+    let mut segments: Vec<Vec<(f64, f64)>> = Vec::new();
+    let mut cur: Vec<(f64, f64)> = Vec::new();
+    for i in 0..n {
+        let (lo0, la0) = coords[i];
+        let (lo1, la1) = coords[(i + 1) % n];
+        cur.push((lo0, la0));
+        if (lo1 - lo0).abs() > 180.0 {
+            let lo1u = if lo1 > lo0 { lo1 - 360.0 } else { lo1 + 360.0 };
+            let boundary = if lo1u > lo0 { 180.0 } else { -180.0 };
+            let frac = (boundary - lo0) / (lo1u - lo0);
+            let la_x = la0 + frac * (la1 - la0);
+            cur.push((boundary, la_x));
+            segments.push(std::mem::take(&mut cur));
+            cur = vec![(-boundary, la_x)];
+        }
+    }
+    if segments.is_empty() {
+        let mut whole = coords.to_vec();
+        whole.push(coords[0]);
+        return Ok(whole);
+    }
+    // the wrap-around segment closes the first.
+    let mut first = std::mem::take(&mut cur);
+    first.append(&mut segments[0]);
+    segments[0] = first;
+    Err(segments)
+}
+
+/// Reconnect antimeridian-cut `segments` into closed lon/lat rings.  `pole` is
+/// the pole (+/-90) the filled region encloses (0.0 = none).
+fn stitch_segments(segments: Vec<Vec<(f64, f64)>>, pole: f64) -> Vec<Vec<(f64, f64)>> {
+    let segs = segments;
+    let n = segs.len();
+    let mut used = vec![false; n];
+    let mut rings: Vec<Vec<(f64, f64)>> = Vec::new();
+    for seed in 0..n {
+        if used[seed] {
+            continue;
+        }
+        let mut ring: Vec<(f64, f64)> = Vec::new();
+        let mut idx = Some(seed);
+        let mut guard = 0usize;
+        while let Some(i) = idx {
+            if used[i] {
+                break;
+            }
+            guard += 1;
+            assert!(guard <= 8 * n + 16, "antimeridian stitch did not converge");
+            used[i] = true;
+            ring.extend_from_slice(&segs[i]);
+            idx = next_segment(&segs, &used, &mut ring, pole, seed);
+        }
+        if let Some(&first) = ring.first() {
+            ring.push(first);
+        }
+        rings.push(ring);
+    }
+    rings
+}
+
+fn next_segment(
+    segs: &[Vec<(f64, f64)>],
+    used: &[bool],
+    ring: &mut Vec<(f64, f64)>,
+    pole: f64,
+    seed: usize,
+) -> Option<usize> {
+    let &(side, end_lat) = ring.last().unwrap();
+    // candidate starts on the same +/-180 side (the seed is allowed, to close).
+    let same_side = |i: usize| (segs[i][0].0 - side).abs() < 1e-9 && (!used[i] || i == seed);
+    let pick: Option<(f64, usize)> = if side > 0.0 {
+        (0..segs.len())
+            .filter(|&i| same_side(i) && segs[i][0].1 >= end_lat - 1e-9)
+            .map(|i| (segs[i][0].1, i))
+            .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+    } else {
+        (0..segs.len())
+            .filter(|&i| same_side(i) && segs[i][0].1 <= end_lat + 1e-9)
+            .map(|i| (segs[i][0].1, i))
+            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+    };
+    if let Some((la, i)) = pick {
+        ring.push((side, la));
+        return if i == seed && used[seed] {
+            None
+        } else {
+            Some(i)
+        };
+    }
+
+    // No same-side start in that direction: the region wraps `pole`.
+    assert!(
+        pole != 0.0,
+        "unbalanced antimeridian segments but no pole enclosed"
+    );
+    let other = -side;
+    ring.push((side, pole));
+    ring.push((other, pole));
+    let ocands: Vec<(f64, usize)> = (0..segs.len())
+        .filter(|&i| (segs[i][0].0 - other).abs() < 1e-9 && (!used[i] || i == seed))
+        .map(|i| (segs[i][0].1, i))
+        .collect();
+    if ocands.is_empty() {
+        return None;
+    }
+    let want_min = (other > 0.0) == (pole < 0.0);
+    let (la, i) = if want_min {
+        *ocands
+            .iter()
+            .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+            .unwrap()
+    } else {
+        *ocands
+            .iter()
+            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+            .unwrap()
+    };
+    ring.push((other, la));
+    if i == seed && used[seed] {
+        None
+    } else {
+        Some(i)
+    }
+}
+
+fn ring_signed_area_lonlat(ring: &[(f64, f64)]) -> f64 {
+    // ring is closed (first == last); drop the repeat for the area fan.
+    let open = &ring[..ring.len() - 1];
+    let v: Vec<Vec3> = open
+        .iter()
+        .map(|&(lon, lat)| {
+            let rlat = lat.to_radians();
+            let rlon = lon.to_radians();
+            [rlat.cos() * rlon.cos(), rlat.cos() * rlon.sin(), rlat.sin()]
+        })
+        .collect();
+    spherical_signed_area(&v)
+}
+
+fn classify_and_split(mut rings_xyz: Vec<Vec<Vec3>>) -> ClassifiedRings {
+    let mut out = ClassifiedRings {
+        shells: Vec::new(),
+        holes: Vec::new(),
+    };
+    if rings_xyz.is_empty() {
+        return out;
+    }
+    // Normalise global winding so the covered area (exteriors minus holes) is
+    // positive — the boundary point order differs between step==1 and step>1.
+    let mut areas: Vec<f64> = rings_xyz.iter().map(|r| spherical_signed_area(r)).collect();
+    if areas.iter().sum::<f64>() < 0.0 {
+        for r in rings_xyz.iter_mut() {
+            r.reverse();
+        }
+        for a in areas.iter_mut() {
+            *a = -*a;
+        }
+    }
+
+    let mut segments: Vec<Vec<(f64, f64)>> = Vec::new();
+    let mut total_net = 0.0;
+    for (ring, &area) in rings_xyz.iter().zip(areas.iter()) {
+        let ll: Vec<(f64, f64)> = ring.iter().map(xyz_to_lonlat).collect();
+        total_net += net_winding(&ll);
+        match cut_at_antimeridian(&ll) {
+            Ok(whole) => {
+                if area < 0.0 {
+                    out.holes.push(whole);
+                } else {
+                    out.shells.push(whole);
+                }
+            }
+            Err(segs) => segments.extend(segs),
+        }
+    }
+
+    if !segments.is_empty() {
+        let pole = if total_net.abs() > 180.0 {
+            if total_net > 0.0 {
+                90.0
+            } else {
+                -90.0
+            }
+        } else {
+            0.0
+        };
+        for piece in stitch_segments(segments, pole) {
+            if ring_signed_area_lonlat(&piece) >= 0.0 {
+                out.shells.push(piece);
+            } else {
+                out.holes.push(piece);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cut_no_crossing_returns_whole() {
+        let ring = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)];
+        let got = cut_at_antimeridian(&ring).unwrap();
+        assert_eq!(got.len(), ring.len() + 1); // closed
+        assert_eq!(got[0], got[got.len() - 1]);
+    }
+
+    #[test]
+    fn cut_two_crossings_splits_each_side() {
+        // box straddling +/-180: two segments, one per hemisphere side.
+        let ring = [(170.0, 0.0), (-170.0, 0.0), (-170.0, 10.0), (170.0, 10.0)];
+        let segs = cut_at_antimeridian(&ring).unwrap_err();
+        assert_eq!(segs.len(), 2);
+        for s in &segs {
+            assert!((s[0].0.abs() - 180.0).abs() < 1e-9);
+            assert!((s[s.len() - 1].0.abs() - 180.0).abs() < 1e-9);
+        }
+        // no pole enclosed -> each segment closes on its own side.
+        let rings = stitch_segments(segs, 0.0);
+        assert_eq!(rings.len(), 2);
+        for r in &rings {
+            let span = r.iter().map(|p| p.0).fold(f64::MIN, f64::max)
+                - r.iter().map(|p| p.0).fold(f64::MAX, f64::min);
+            assert!(span <= 180.0 + 1e-9);
+        }
+    }
+
+    #[test]
+    fn net_winding_detects_pole_wrap() {
+        // a ring marching once around the globe wraps a pole (net ~ +/-360).
+        let ring: Vec<(f64, f64)> = (-180..180)
+            .step_by(30)
+            .map(|lo| (lo as f64, -80.0))
+            .collect();
+        assert!(net_winding(&ring).abs() > 180.0);
+    }
+
+    #[test]
+    fn pole_cap_stitches_to_one_ring_with_pole_vertex() {
+        // one segment running +180 -> -180 around the pole, stitched through -90.
+        let segs = vec![vec![
+            (180.0, -80.0),
+            (90.0, -80.0),
+            (0.0, -80.0),
+            (-90.0, -80.0),
+            (-180.0, -80.0),
+        ]];
+        let rings = stitch_segments(segs, -90.0);
+        assert_eq!(rings.len(), 1);
+        assert!(rings[0].iter().any(|p| (p.1 + 90.0).abs() < 1e-9)); // pole vertex
+    }
+}

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -7,6 +7,7 @@ pub mod buffer;
 pub mod cell_geom;
 pub mod coverage;
 pub mod decimal_morton;
+pub mod dissolve;
 pub mod geo2mort;
 pub mod linestring;
 pub mod moc;
@@ -1073,6 +1074,42 @@ fn rust_mi_decimal_repr(py: Python<'_>, morton_array: PyReadonlyArray1<u64>) -> 
     }
 }
 
+/// Dissolve a morton cover into the classified planar rings of its outline.
+///
+/// Returns `(shells, holes)`: two Python lists of `(N, 2)` f64 arrays of
+/// `(lon, lat)` degrees.  Crossing rings are cut at +/-180 and reconnected by
+/// the GeoJSON convention (explicit +/-90 pole vertices stitched down the
+/// antimeridian for a pole-enclosing region).  The Python side builds the
+/// backend Polygons and nests holes — see `mortie/geometry.py`.
+#[pyfunction]
+#[pyo3(signature = (morton, step=1))]
+fn rust_dissolve(py: Python<'_>, morton: PyReadonlyArray1<u64>, step: u32) -> PyResult<PyObject> {
+    let data = morton.to_vec()?;
+    let result = py.allow_threads(|| std::panic::catch_unwind(|| dissolve::dissolve(&data, step)));
+    let classified = match result {
+        Ok(c) => c,
+        Err(e) => return Err(PyValueError::new_err(panic_msg(e, "dissolve panicked"))),
+    };
+    let to_list = |rings: Vec<Vec<(f64, f64)>>| {
+        let lst = pyo3::types::PyList::empty_bound(py);
+        for ring in rings {
+            let mut flat = Vec::with_capacity(ring.len() * 2);
+            for (lon, lat) in ring {
+                flat.push(lon);
+                flat.push(lat);
+            }
+            let n = flat.len() / 2;
+            let arr = numpy::ndarray::Array2::from_shape_vec((n, 2), flat).unwrap();
+            lst.append(PyArray2::from_owned_array_bound(py, arr))
+                .unwrap();
+        }
+        lst.into_any().unbind()
+    };
+    let shells = to_list(classified.shells);
+    let holes = to_list(classified.holes);
+    Ok(pyo3::types::PyTuple::new_bound(py, &[shells, holes]).to_object(py))
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -1083,6 +1120,7 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_ang2pix, m)?)?;
     m.add_function(wrap_pyfunction!(rust_pix2ang, m)?)?;
     m.add_function(wrap_pyfunction!(rust_boundaries, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_dissolve, m)?)?;
     m.add_function(wrap_pyfunction!(rust_vec2ang, m)?)?;
     m.add_function(wrap_pyfunction!(rust_morton_buffer, m)?)?;
     m.add_function(wrap_pyfunction!(rust_polygon_coverage, m)?)?;


### PR DESCRIPTION
Closes #71

Adds WKB/WKT geometry **ingest** and **emit** to mortie, per the design locked in the issue thread (see the [05:23 sign-off](https://github.com/espg/mortie/issues/71#issuecomment-4815380013) and the [edge-handling sign-off](https://github.com/espg/mortie/issues/71#issuecomment-4818992322)).

## Design (settled on the issue thread)

- **Runtime stays numpy-only.** All WKB/WKT I/O routes through one lazy backend adapter (`mortie/geometry.py`), gated like `mortie/arrow.py` gates pyarrow — `shapely>=2` primary, `spherely` accepted as a raw codec. `shapely>=2` (and now `spherely`, the test-only dissolve oracle) are added to the **`test` extra only**, never `[project].dependencies`. The dissolve engine itself is **Rust** (`src_rust/src/dissolve.rs`), the fast path.
- **Emit default is the dissolved outline** (single (Multi)Polygon of the whole cover); per-cell `MultiPolygon` is the opt-in `dissolve=False` granularity. Dissolve uses **native edge-cancellation / boundary-trace** (approach (i)) — no backend spatial predicate.
- **Plain WKB/WKT by default**; EWKB/EWKT with `SRID=4326` opt-in. EPSG:4326 lon/lat degrees is the documented contract. No PROJ registration.

## Phases

- [x] **Phase 1 — `mortie/geometry.py` codec adapter.** Lazy `shapely`/`spherely` backend gate; WKB/WKT decode/encode with EWKB/EWKT(SRID) opt-in; `decompose()` of Polygon / MultiPolygon / holes / LineString / MultiLineString into `(lat, lon)` ring arrays (empty geometries rejected, Z dropped). Backend-gated tests.
- [x] **Phase 2 — Ingest.** `from_wkb` / `from_wkt` / `from_geometry` → `decompose` → existing entry points (`morton_coverage`, `morton_coverage_moc`, `linestring_coverage`). Round-trip tests: WKB **and** WKT ingest reproduce the array-path cover.
- [x] **Phase 3 — Per-cell emit (`dissolve=False`).** `to_wkb` / `to_wkt` / `to_geometry`: morton word → cell corners (reusing `mort2polygon`, grouped by order so mixed-order MOC works) → per-cell `MultiPolygon`; EWKB/EWKT SRID opt-in; empty cover → empty `MultiPolygon`.
- [x] **Phase 4 — Dissolved-boundary emit (the DEFAULT).** Native edge-cancellation: every cell's boundary becomes directed edges; interior edges shared by adjacent cells cancel; survivors chain (angular / right-hand-rule, so non-manifold corner-touch vertices stay simple) into rings; rings classified exterior/hole by spherical signed area; antimeridian-crossing exteriors split at ±180; holes nested by ray-cast point-in-polygon. Verified exactly against `shapely.unary_union` (machine-precision symmetric difference over 250 randomized covers).
- [x] **Phase 5 — Pole / antimeridian splitter (the deferred sub-piece).** Completes `dissolve=True` for the three cases that previously raised `NotImplementedError`: a **pole-enclosing** cover (polar cap — this project's polar data), an exterior crossing the antimeridian **more than twice**, and an **antimeridian-crossing hole**. Crossing rings are cut at ±180 and reconnected by the **GeoJSON convention** — a single split `MultiPolygon` with **explicit ±90° pole vertices** stitched down the antimeridian for a pole-enclosing region. The pole the *filled* region encloses is keyed off the cover's **total** net longitude winding (an exterior + a hole that both wrap the pole cancel to net 0 — a band that does not enclose it). `spherely` (s2geometry, geodesic, no pole/AM singularity) is wired into the **`test` extra only** as the independent sphere-truth oracle, since `shapely.unary_union` breaks exactly at the pole.
- [x] **Phase 6 — Rust port of the dissolve engine (the fast path).** The edge-cancellation, angular ring-chaining, classification, and the Phase-5 pole/AM splitter are ported to `src_rust/src/dissolve.rs` (PyO3 binding `rust_dissolve(morton, step) -> (shells, holes)` in `lib.rs`, mirroring the existing binding style). `geometry._dissolved_polygons` calls Rust at runtime (§7 Rust-only path — no `MORTIE_FORCE_PYTHON` gate); the pure-Python engine is retained as `_dissolved_rings_py`, the exact-verified reference **oracle** the tests check the Rust path against.

## How it was tested

Local, isolated venv, `maturin develop --release`:
- `pytest mortie/tests/test_geometry.py` → **43 passed** (codec round-trips, ingest parity, per-cell emit, the dissolve suite, the new polar-cap (both poles) / polar-annulus / >2-crossing / AM-crossing-hole / spherely-oracle tests, and the Rust-vs-Python-reference parity test at step 1 and 4).
- Full suite `pytest -q` → **487 passed, 7 skipped**; `flake8 mortie --select=E9,F63,F7,F82` clean; `--max-line-length=88` clean on the touched files. `geometry.py` is 811 lines (under the ~1000 soft limit).
- Rust: `cargo test` → **177 passed** (incl. 4 new `dissolve` unit tests); `cargo fmt --check` clean; `cargo clippy --release --tests` clean (no new warnings).
- **Splitter verification (Phase 5):** the dissolved polar cap / annulus / AM cases match `spherely`'s geodesic s2 union to **≤8e-16 steradians** of spherical area (60 randomized polar/AM/box covers: all `is_valid`, worst area error 1.8e-15), alongside the spherical-area-conservation / `is_valid` / ≤180°-lon-span invariants. **spherely installed and ran in this environment** (0.1.1).
- **Rust port verification (Phase 6):** `rust_dissolve` matches the exact-verified Python reference engine to **≤3e-13** planar symmetric difference across contiguous / holed / disjoint / antimeridian / polar-cap covers at step 1 and 4, with identical polygon/hole/vertex topology (pinned by `test_dissolve_rust_matches_python_reference`).
- Runtime stays **numpy-only** — confirmed `spherely` is never imported on the dissolve path; the engine is Rust + numpy.

## Resolution of the earlier "Questions for review"

All four are now settled (thanks for the calls):

1. **Rust vs Python** — done in Rust (the [fast path you greenlit](https://github.com/espg/mortie/pull/89#issuecomment-4833369835)); Python kept as the test oracle.
2. **Backend + polar-cap representation** — [Option (C)](https://github.com/espg/mortie/pull/89#issuecomment-4845637126): we build the splitter ourselves; `spherely` is a **test-only** oracle (not a runtime dep); the polar cap is frozen as the **GeoJSON antimeridian convention** — a single split `MultiPolygon` with explicit ±90° pole vertices down the antimeridian.
3. **spherely depth** — codec-only at runtime; spherely used only as the test oracle (no full ring-walk shim needed, since the pole/AM split is on the emit side and stays mortie's job regardless of backend).
4. **Emit naming** — top-level `from_wkb` / `from_wkt` / `to_wkb` / `to_wkt`, as built.

All phases complete and self-reviewed (per-phase fresh-context adversarial reviews; Phase 5's diff-scoped findings were folded into the Phase 6 commit — classification/seed-condition comments, and the dead hole-subtraction loops in the split-annulus / AM-hole tests removed since those cases correctly emit hole-free C-shapes).