### PR TITLE
Tag-driven Cargo.toml version sync

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -181,6 +181,13 @@ jobs:
         tmp=$(mktemp)
         sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
         mv "$tmp" Cargo.toml
+        # Fail loudly if the version line never matched (sed no-op), so a stale
+        # version can't silently ship to PyPI — restores the fail-fast that the
+        # removed "Verify release tag" step provided.
+        grep -qF "version = \"$VERSION\"" Cargo.toml || {
+          echo "::error::Cargo.toml version sync did not apply (expected version = \"$VERSION\")."
+          exit 1
+        }
         echo "Cargo.toml version set to $VERSION"
         grep -m1 '^version = ' Cargo.toml
 
@@ -240,6 +247,13 @@ jobs:
         tmp=$(mktemp)
         sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
         mv "$tmp" Cargo.toml
+        # Fail loudly if the version line never matched (sed no-op), so a stale
+        # version can't silently ship to PyPI — restores the fail-fast that the
+        # removed "Verify release tag" step provided.
+        grep -qF "version = \"$VERSION\"" Cargo.toml || {
+          echo "::error::Cargo.toml version sync did not apply (expected version = \"$VERSION\")."
+          exit 1
+        }
         echo "Cargo.toml version set to $VERSION"
 
     - name: Build wheels
@@ -283,6 +297,13 @@ jobs:
         tmp=$(mktemp)
         sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
         mv "$tmp" Cargo.toml
+        # Fail loudly if the version line never matched (sed no-op), so a stale
+        # version can't silently ship to PyPI — restores the fail-fast that the
+        # removed "Verify release tag" step provided.
+        grep -qF "version = \"$VERSION\"" Cargo.toml || {
+          echo "::error::Cargo.toml version sync did not apply (expected version = \"$VERSION\")."
+          exit 1
+        }
         echo "Cargo.toml version set to $VERSION"
 
     - name: Build wheels
@@ -329,6 +350,13 @@ jobs:
         tmp=$(mktemp)
         sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
         mv "$tmp" Cargo.toml
+        # Fail loudly if the version line never matched (sed no-op), so a stale
+        # version can't silently ship to PyPI — restores the fail-fast that the
+        # removed "Verify release tag" step provided.
+        grep -qF "version = \"$VERSION\"" Cargo.toml || {
+          echo "::error::Cargo.toml version sync did not apply (expected version = \"$VERSION\")."
+          exit 1
+        }
         echo "Cargo.toml version set to $VERSION"
 
     - name: Build sdist

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -28,7 +28,10 @@ jobs:
     - name: Get tag name
       id: get_tag
       run: |
-        echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        TAG=${GITHUB_REF#refs/tags/}
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        # Cargo.toml's version line is bare semver (no leading "v").
+        echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
     - name: Get previous tag
       id: get_previous_tag
@@ -170,25 +173,37 @@ jobs:
           rm -f $NEW_ENTRY_FILE
         fi
 
-    - name: Commit changelog updates
+    - name: Sync Cargo.toml version to tag
+      env:
+        VERSION: ${{ steps.get_tag.outputs.version }}
+      run: |
+        # mktemp + mv (not sed -i) so this works on both GNU and BSD/macOS sed.
+        tmp=$(mktemp)
+        sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
+        mv "$tmp" Cargo.toml
+        echo "Cargo.toml version set to $VERSION"
+        grep -m1 '^version = ' Cargo.toml
+
+    - name: Commit changelog and version updates
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config --local user.name "github-actions[bot]"
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
-        # Switch to main branch and pull latest changes
+        # Switch to main branch and pull latest changes (uncommitted
+        # CHANGELOG.md/Cargo.toml edits carry over since they share main's base).
         git checkout main
         git pull origin main
 
         # Check if there are any changes to commit
-        if git diff --quiet CHANGELOG.md; then
-          echo "No changes to CHANGELOG.md"
+        if git diff --quiet CHANGELOG.md Cargo.toml; then
+          echo "No changes to CHANGELOG.md or Cargo.toml"
         else
-          git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG.md for ${{ steps.get_tag.outputs.tag }}"
+          git add CHANGELOG.md Cargo.toml
+          git commit -m "docs: update CHANGELOG.md and sync Cargo.toml version for ${{ steps.get_tag.outputs.tag }}"
           git push origin main
-          echo "✅ CHANGELOG.md updated and pushed to main branch"
+          echo "✅ CHANGELOG.md and Cargo.toml updated and pushed to main branch"
         fi
 
   # Build wheels for Linux, Windows, and macOS
@@ -213,17 +228,19 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Verify release tag matches Cargo.toml version
+    - name: Sync Cargo.toml version to tag
       if: startsWith(github.ref, 'refs/tags/')
       shell: bash
       run: |
-        TAG=${GITHUB_REF#refs/tags/}
-        CARGO_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
-        if [ "$TAG" != "$CARGO_VERSION" ]; then
-          echo "::error::Release tag '$TAG' != Cargo.toml version '$CARGO_VERSION'. Cargo.toml is the single version source (the Python wheel reads it via maturin's dynamic version); bump it to match the tag before releasing."
-          exit 1
-        fi
-        echo "Release tag matches Cargo.toml version: $TAG"
+        # Build jobs check out the tag ref, which predates the changelog job's
+        # version-bump commit; re-apply the same sed so the wheel version matches.
+        VERSION=${GITHUB_REF#refs/tags/}
+        VERSION=${VERSION#v}
+        # mktemp + mv (not sed -i) so this works on both GNU and BSD/macOS sed.
+        tmp=$(mktemp)
+        sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
+        mv "$tmp" Cargo.toml
+        echo "Cargo.toml version set to $VERSION"
 
     - name: Build wheels
       uses: PyO3/maturin-action@v1
@@ -254,17 +271,19 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Verify release tag matches Cargo.toml version
+    - name: Sync Cargo.toml version to tag
       if: startsWith(github.ref, 'refs/tags/')
       shell: bash
       run: |
-        TAG=${GITHUB_REF#refs/tags/}
-        CARGO_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
-        if [ "$TAG" != "$CARGO_VERSION" ]; then
-          echo "::error::Release tag '$TAG' != Cargo.toml version '$CARGO_VERSION'. Cargo.toml is the single version source (the Python wheel reads it via maturin's dynamic version); bump it to match the tag before releasing."
-          exit 1
-        fi
-        echo "Release tag matches Cargo.toml version: $TAG"
+        # Build jobs check out the tag ref, which predates the changelog job's
+        # version-bump commit; re-apply the same sed so the wheel version matches.
+        VERSION=${GITHUB_REF#refs/tags/}
+        VERSION=${VERSION#v}
+        # mktemp + mv (not sed -i) so this works on both GNU and BSD/macOS sed.
+        tmp=$(mktemp)
+        sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
+        mv "$tmp" Cargo.toml
+        echo "Cargo.toml version set to $VERSION"
 
     - name: Build wheels
       uses: PyO3/maturin-action@v1
@@ -298,17 +317,19 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Verify release tag matches Cargo.toml version
+    - name: Sync Cargo.toml version to tag
       if: startsWith(github.ref, 'refs/tags/')
       shell: bash
       run: |
-        TAG=${GITHUB_REF#refs/tags/}
-        CARGO_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
-        if [ "$TAG" != "$CARGO_VERSION" ]; then
-          echo "::error::Release tag '$TAG' != Cargo.toml version '$CARGO_VERSION'. Cargo.toml is the single version source (the Python wheel reads it via maturin's dynamic version); bump it to match the tag before releasing."
-          exit 1
-        fi
-        echo "Release tag matches Cargo.toml version: $TAG"
+        # Build jobs check out the tag ref, which predates the changelog job's
+        # version-bump commit; re-apply the same sed so the sdist version matches.
+        VERSION=${GITHUB_REF#refs/tags/}
+        VERSION=${VERSION#v}
+        # mktemp + mv (not sed -i) so this works on both GNU and BSD/macOS sed.
+        tmp=$(mktemp)
+        sed -E 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml > "$tmp"
+        mv "$tmp" Cargo.toml
+        echo "Cargo.toml version set to $VERSION"
 
     - name: Build sdist
       uses: PyO3/maturin-action@v1


### PR DESCRIPTION
Closes #67.

## What

Makes the `Cargo.toml` version **tag-driven** instead of hand-bumped, so cutting a release is just pushing a `*.*.*` tag — no more manual `version =` edit, and no more "tag != Cargo.toml" release failures (the failure that blocked the `0.8.3` run).

## Approach

Mirrors the existing changelog-update job rather than asserting the version:

- **`update-changelog` job (runs on the tag, pushes to `main`):**
  - `Get tag name` now also emits `version=${TAG#v}` (Cargo.toml's line is bare semver, no leading `v`).
  - New **Sync Cargo.toml version to tag** step rewrites the `version =` line from the tag.
  - The commit step now `git add CHANGELOG.md Cargo.toml` and pushes both back to `main` — so the committed `Cargo.toml` tracks the released version, exactly as the changelog already does.
- **Three build jobs (wheels ×2 + sdist):** the old *Verify release tag matches Cargo.toml version* fail-steps are **removed** and replaced with an **ephemeral** same-sed sync. These jobs `checkout` the *tag* ref, which predates the changelog job's bump commit, so they re-apply the bump in-place (not committed) to guarantee the wheel/sdist version matches regardless of checkout timing — belt-and-suspenders with the `main` commit.

Plain `sed`, no new tooling (per the issue's greenlit choices: plain sed, commit `Cargo.toml` back to `main`).

**One deviation from the diff in the issue, flagged for review:** the issue's diff used `sed -E -i`. GitHub's macOS runners use **BSD sed**, where `-i` consumes the next arg as a backup suffix and the in-place edit breaks — this would fail the `macos-15-intel` / `macos-latest` wheel jobs at the sync step. I used the file's existing portable idiom (`mktemp` + redirect + `mv`, same as the changelog job at lines 133/149) so it works on both GNU and BSD sed.

## Phases

- [x] Phase 1 — version-sync in `build-wheels.yml` (changelog-job commit + 3 ephemeral build-job syncs; verify-and-fail steps removed)

## Testing

- `python -c "import yaml; yaml.safe_load(...)"` → parses clean.
- Grep audit: 0 `Verify release tag` steps remain, 4 `Sync Cargo.toml version to tag` steps, 0 `sed -E -i`.
- `sed` rewrite exercised against both `v1.2.3` → `1.2.3` and bare `2.0.0` → `2.0.0` (BSD sed, no `-i`), correct in both.

End-to-end can only be verified by an actual tag push (production publish), which I won't do.

## Questions for review

- Confirm you're OK with the **portability deviation** (`mktemp`+`mv` instead of `sed -i`) — it's the one place this differs from the diff you saw in the issue.
