### PR TITLE
Library-agnostic Arrow C Data Interface for morton_index (arro3-core / PyCapsule)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ numpy = "0.22"
 rayon = "1.10"
 healpix = "0.3.3"
 smallvec = "1"
+arrow = { version = "53", features = ["ffi"] }
 
 [dev-dependencies]
 criterion = { version = "4.3.0", package = "codspeed-criterion-compat" }

--- a/docs/arrow_interchange.md
+++ b/docs/arrow_interchange.md
@@ -1,0 +1,92 @@
+# Arrow interchange for `morton_index`
+
+`mortie` exposes its packed 64-bit `morton_index` words to the Arrow ecosystem
+through **two** surfaces. Both carry the same `uint64` storage and the same
+`mortie.morton_index` **extension type**, and both map the all-zero empty
+sentinel to an Arrow **null** and back. Neither is a runtime dependency — numpy
+stays the only hard dep.
+
+| surface | module | needs | use for |
+|---|---|---|---|
+| pyarrow `ExtensionType` skin | `mortie.arrow.from_morton_index` / `to_morton_index` | `pyarrow` | parquet / IPC, `table.to_pandas()`, off-worker analysis |
+| **library-agnostic C Data Interface** | `mortie.arrow.export_c_array` / `import_c_array` (+ `MortonIndexArray.__arrow_c_array__` / `from_arrow`) | **nothing beyond numpy** | zero-copy handoff to **arro3-core**, polars, pyarrow — including envs with no pyarrow |
+
+The second surface (issue #93) is what lets a `morton_index` column travel
+through **arro3-core** — the pyarrow-free Arrow carrier used on constrained
+workers (e.g. an AWS Lambda layer without pyarrow). The raw Arrow C structs are
+built in Rust (via the `arrow` crate), so nothing on the critical path imports
+pyarrow.
+
+## Producing a column (any Arrow lib)
+
+`export_c_array` returns the `(schema_capsule, array_capsule)` pair of the
+[Arrow PyCapsule C Data Interface][pycapsule] from raw `uint64` words (or a
+`MortonIndexArray`). Wrap it in a tiny object exposing `__arrow_c_array__` and
+hand it to any Arrow constructor:
+
+```python
+import numpy as np
+from mortie import arrow as marrow
+
+words = ...  # uint64 numpy array of packed morton_index words (0 == null)
+
+class MortonColumn:
+    def __arrow_c_array__(self, requested_schema=None):
+        return marrow.export_c_array(words)
+    def __arrow_c_schema__(self):
+        return marrow.export_c_schema()
+
+# arro3-core (no pyarrow needed):
+from arro3.core import Array
+a3 = Array.from_arrow(MortonColumn())
+# a3.field.metadata_str["ARROW:extension:name"] == "mortie.morton_index"
+
+# pyarrow, if installed, resolves the registered extension type:
+import pyarrow as pa
+pa_arr = pa.array(MortonColumn())          # type: extension<mortie.morton_index>
+```
+
+`MortonIndexArray` (the pandas extension array) implements `__arrow_c_array__`
+directly, so it can be passed straight to `Array.from_arrow(...)` / `pa.array(...)`.
+
+## Consuming a column back to words
+
+`import_c_array` accepts either an object exposing `__arrow_c_array__` (an
+arro3-core / pyarrow / polars array) or a raw `(schema_capsule, array_capsule)`
+tuple, and returns a `uint64` numpy array (Arrow nulls come back as the empty
+sentinel `0`):
+
+```python
+words = marrow.import_c_array(a3)                    # from arro3-core
+mia = MortonIndexArray.from_arrow(a3)                # straight to the pandas array
+```
+
+## Extension metadata survives arro3-core
+
+The exported schema carries the extension type as field metadata
+(`ARROW:extension:name = mortie.morton_index`). **arro3-core `0.8.1` round-trips
+this metadata** through the C-Data boundary (verified in
+`mortie/tests/test_arrow_cdata.py::TestArro3Interop`), so a column stays typed
+end-to-end with no fallback to bare `uint64`. If a future carrier drops the
+metadata, the words still transfer (storage is `uint64`); re-attach the type at
+the edge with `MortonIndexArray.from_arrow`.
+
+## Null / sentinel semantics
+
+The missing value is the all-zero empty word (`MortonIndexArray.isna()`), the
+kernel's null sentinel. On export it becomes an Arrow null via a real **validity
+bitmap**; on import a null becomes the sentinel again — byte-for-byte through any
+Arrow lib, not just via pyarrow's `fill_null`.
+
+## Running the arro3-core tests locally
+
+arro3-core is **not** in the CI `test` extra, so the arro3 leg of
+`test_arrow_cdata.py` skips in CI (the pyarrow leg runs there). To exercise it
+locally, install the pinned carrier and run the suite:
+
+```sh
+pip install "mortie[arro3]"    # or: pip install arro3-core==0.8.1
+pytest mortie/tests/test_arrow_cdata.py
+```
+
+[pycapsule]: https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html

--- a/mortie/arrow.py
+++ b/mortie/arrow.py
@@ -198,19 +198,30 @@ def export_c_schema():
 
 
 def import_c_array(source):
-    """Import an Arrow C Data Interface array as packed ``uint64`` words.
+    """Import an Arrow C Data Interface array/stream as packed ``uint64`` words.
 
-    ``source`` is either an object exposing ``__arrow_c_array__`` (an arro3-core /
-    pyarrow / polars array) or a ``(schema_capsule, array_capsule)`` tuple. Arrow
-    nulls come back as the all-zero empty sentinel, so the null<->sentinel
-    convention round-trips byte-for-byte. Returns a ``uint64`` numpy array.
+    ``source`` is one of:
+
+    * an object exposing ``__arrow_c_array__`` (a contiguous arro3-core / pyarrow /
+      polars array),
+    * an object exposing ``__arrow_c_stream__`` (a **chunked** column / multi-batch
+      source -- every chunk is concatenated),
+    * or a ``(schema_capsule, array_capsule)`` tuple.
+
+    Arrow nulls come back as the all-zero empty sentinel, so the null<->sentinel
+    convention round-trips byte-for-byte. Returns a ``uint64`` numpy array. No
+    pyarrow dependency on any path.
     """
     from . import _rustie
 
+    # A single contiguous array is preferred when both are present; only a
+    # chunked source (no __arrow_c_array__) goes through the stream path.
     if hasattr(source, "__arrow_c_array__"):
         schema_capsule, array_capsule = source.__arrow_c_array__()
-    else:
-        schema_capsule, array_capsule = source
+        return _rustie.rust_mi_import_c_array(schema_capsule, array_capsule)
+    if hasattr(source, "__arrow_c_stream__"):
+        return _rustie.rust_mi_import_c_stream(source.__arrow_c_stream__())
+    schema_capsule, array_capsule = source
     return _rustie.rust_mi_import_c_array(schema_capsule, array_capsule)
 
 

--- a/mortie/arrow.py
+++ b/mortie/arrow.py
@@ -161,6 +161,59 @@ def to_morton_index(array):
     return MortonIndexArray(words)
 
 
+# ---------------------------------------------------------------------------
+# Arrow C Data Interface (PyCapsule) surface -- library-agnostic, pyarrow-free
+# (issue #93).
+#
+# These build/consume the raw Arrow C structs in Rust (via the ``arrow`` crate),
+# so any Arrow lib that speaks the PyCapsule interface -- arro3-core (the carrier
+# zagg runs on its Lambda worker, without pyarrow), pyarrow, polars -- can pull a
+# typed ``morton_index`` column zero-copy and hand one back. The runtime stays
+# numpy-only; nothing here imports pyarrow.
+# ---------------------------------------------------------------------------
+
+
+def export_c_array(words):
+    """Export packed ``uint64`` words as an Arrow C Data Interface capsule pair.
+
+    Returns ``(schema_capsule, array_capsule)`` PyCapsules carrying the words as
+    a ``morton_index`` extension column (``ARROW:extension:name`` on the schema),
+    with the all-zero empty sentinel mapped to an Arrow null via a real validity
+    bitmap. Consumable by any Arrow lib without pandas or pyarrow. ``words`` is
+    any ``uint64`` array-like (e.g. a raw numpy array or a ``MortonIndexArray``).
+    """
+    from . import _rustie
+
+    data = np.ascontiguousarray(
+        np.asarray(getattr(words, "_data", words), dtype=np.uint64)
+    )
+    return _rustie.rust_mi_export_c_array(data)
+
+
+def export_c_schema():
+    """Return the ``morton_index`` Arrow schema capsule (``__arrow_c_schema__``)."""
+    from . import _rustie
+
+    return _rustie.rust_mi_export_c_schema()
+
+
+def import_c_array(source):
+    """Import an Arrow C Data Interface array as packed ``uint64`` words.
+
+    ``source`` is either an object exposing ``__arrow_c_array__`` (an arro3-core /
+    pyarrow / polars array) or a ``(schema_capsule, array_capsule)`` tuple. Arrow
+    nulls come back as the all-zero empty sentinel, so the null<->sentinel
+    convention round-trips byte-for-byte. Returns a ``uint64`` numpy array.
+    """
+    from . import _rustie
+
+    if hasattr(source, "__arrow_c_array__"):
+        schema_capsule, array_capsule = source.__arrow_c_array__()
+    else:
+        schema_capsule, array_capsule = source
+    return _rustie.rust_mi_import_c_array(schema_capsule, array_capsule)
+
+
 def __getattr__(name):
     """Lazily expose the extension type / array classes.
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -194,6 +194,45 @@ def _build_classes():
             return cls(words)
 
         @classmethod
+        def from_arrow(cls, source):
+            """Build a ``MortonIndexArray`` from any Arrow C-Data array (#93).
+
+            ``source`` is either an object exposing ``__arrow_c_array__`` (an
+            arro3-core / pyarrow / polars array) or a ``(schema_capsule,
+            array_capsule)`` tuple. The words are pulled over the PyCapsule C Data
+            Interface with **no pyarrow dependency**; Arrow nulls come back as the
+            all-zero empty sentinel so :meth:`isna` round-trips. This is the
+            library-agnostic sibling of :func:`mortie.arrow.to_morton_index`
+            (which is the pyarrow ``ExtensionArray`` path).
+            """
+            from .arrow import import_c_array
+
+            return cls(import_c_array(source))
+
+        # -- Arrow C Data Interface (PyCapsule) -----------------------------
+        # The library-agnostic export surface (#93): any Arrow lib that speaks
+        # the PyCapsule interface can pull these zero-copy, carrying the
+        # morton_index extension type, with no pyarrow on either side.
+
+        def __arrow_c_schema__(self):
+            """Arrow C-Data schema capsule for the ``morton_index`` type."""
+            from .arrow import export_c_schema
+
+            return export_c_schema()
+
+        def __arrow_c_array__(self, requested_schema=None):
+            """Arrow C-Data ``(schema, array)`` capsules over the packed words.
+
+            The empty sentinel is exported as an Arrow null (validity bitmap) and
+            the schema carries the ``morton_index`` extension type. The
+            ``requested_schema`` hint is accepted (per the protocol) but ignored:
+            this array has a single fixed logical type.
+            """
+            from .arrow import export_c_array
+
+            return export_c_array(self._data)
+
+        @classmethod
         def _coerce_words(cls, scalars):
             """Map a sequence of words / NA markers to a uint64 array.
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -197,13 +197,15 @@ def _build_classes():
         def from_arrow(cls, source):
             """Build a ``MortonIndexArray`` from any Arrow C-Data array (#93).
 
-            ``source`` is either an object exposing ``__arrow_c_array__`` (an
-            arro3-core / pyarrow / polars array) or a ``(schema_capsule,
-            array_capsule)`` tuple. The words are pulled over the PyCapsule C Data
-            Interface with **no pyarrow dependency**; Arrow nulls come back as the
-            all-zero empty sentinel so :meth:`isna` round-trips. This is the
-            library-agnostic sibling of :func:`mortie.arrow.to_morton_index`
-            (which is the pyarrow ``ExtensionArray`` path).
+            ``source`` is an object exposing ``__arrow_c_array__`` (a contiguous
+            arro3-core / pyarrow / polars array), one exposing
+            ``__arrow_c_stream__`` (a **chunked** column, concatenated), or a
+            ``(schema_capsule, array_capsule)`` tuple. The words are pulled over
+            the PyCapsule C Data Interface with **no pyarrow dependency**; Arrow
+            nulls come back as the all-zero empty sentinel so :meth:`isna`
+            round-trips. This is the library-agnostic sibling of
+            :func:`mortie.arrow.to_morton_index` (the pyarrow ``ExtensionArray``
+            path).
             """
             from .arrow import import_c_array
 

--- a/mortie/tests/test_arrow_cdata.py
+++ b/mortie/tests/test_arrow_cdata.py
@@ -166,17 +166,41 @@ class TestPyarrowInterop:
         with pytest.raises(ValueError, match="uint64"):
             marrow.import_c_array(arr)
 
+    def test_import_respects_slice_offset(self):
+        # A sliced arrow array carries a non-zero logical offset over the C-Data
+        # boundary; the imported words must be the sliced range, not the buffer.
+        pa = pytest.importorskip("pyarrow")
+        words = _words_with_gap()  # nulls at 2 and 5
+        arr = pa.array(_CapsuleSource(words)).slice(2, 4)  # spans a null at idx 2
+        back = marrow.import_c_array(arr)
+        np.testing.assert_array_equal(back, words[2:6])
+
+    def test_reject_misordered_capsules(self):
+        # Passing (array, schema) instead of (schema, array) must be rejected on
+        # the capsule name, not reinterpreted (would be memory corruption).
+        words = _sample_words()
+        schema_capsule, array_capsule = marrow.export_c_array(words)
+        with pytest.raises(ValueError, match="arrow_schema"):
+            _rustie.rust_mi_import_c_array(array_capsule, schema_capsule)
+
 
 # ---------------------------------------------------------------------------
 # arro3-core consumer/producer -- pyarrow-free carrier (issue #93 item 4).
-# Local-only: arro3-core is not in the CI test extra; skip if absent.
+# Local-only: arro3-core is not in the CI test extra, so gate *only this class*
+# on it (a module-level importorskip would skip the whole file -- incl. the
+# pyarrow/numpy legs that DO run in CI -- when arro3-core is absent).
 # ---------------------------------------------------------------------------
 
-a3 = pytest.importorskip(
-    "arro3.core", reason="arro3-core not installed (local-only leg)"
-)
+try:
+    import arro3.core as a3
+
+    HAS_ARRO3 = True
+except ImportError:  # pragma: no cover - arro3-core absent (CI)
+    a3 = None
+    HAS_ARRO3 = False
 
 
+@pytest.mark.skipif(not HAS_ARRO3, reason="arro3-core not installed (local-only leg)")
 class TestArro3Interop:
     """The pyarrow-free path #86 never exercised: round-trip on arro3-core."""
 

--- a/mortie/tests/test_arrow_cdata.py
+++ b/mortie/tests/test_arrow_cdata.py
@@ -183,6 +183,37 @@ class TestPyarrowInterop:
         with pytest.raises(ValueError, match="arrow_schema"):
             _rustie.rust_mi_import_c_array(array_capsule, schema_capsule)
 
+    def test_import_chunked_stream(self):
+        # A chunked column exposes __arrow_c_stream__ (not __arrow_c_array__);
+        # every chunk is concatenated, nulls preserved.
+        pa = pytest.importorskip("pyarrow")
+        words = _words_with_gap()
+        arr = pa.array(_CapsuleSource(words))
+        ca = pa.chunked_array([arr[:3], arr[3:5], arr[5:]])
+        assert not hasattr(ca, "__arrow_c_array__")
+        np.testing.assert_array_equal(marrow.import_c_array(ca), words)
+
+    def test_from_arrow_chunked(self):
+        pytest.importorskip("pandas")
+        pa = pytest.importorskip("pyarrow")
+        words = _words_with_gap()
+        arr = pa.array(_CapsuleSource(words))
+        ca = pa.chunked_array([arr[:4], arr[4:]])
+        mia = mortie.MortonIndexArray.from_arrow(ca)
+        np.testing.assert_array_equal(mia._data, words)
+        np.testing.assert_array_equal(mia.isna(), words == SENTINEL)
+
+    def test_empty_chunked_stream(self):
+        pa = pytest.importorskip("pyarrow")
+        empty = pa.chunked_array([], type=pa.uint64())
+        assert len(marrow.import_c_array(empty)) == 0
+
+    def test_reject_non_uint64_stream(self):
+        pa = pytest.importorskip("pyarrow")
+        ca = pa.chunked_array([pa.array([1, 2], type=pa.int32())])
+        with pytest.raises(ValueError, match="uint64"):
+            marrow.import_c_array(ca)
+
 
 # ---------------------------------------------------------------------------
 # arro3-core consumer/producer -- pyarrow-free carrier (issue #93 item 4).
@@ -220,6 +251,13 @@ class TestArro3Interop:
         arr = a3.Array.from_arrow(_CapsuleSource(words))
         back = marrow.import_c_array(arr)
         np.testing.assert_array_equal(back, words)
+
+    def test_arro3_chunked_stream_round_trip(self):
+        # arro3 ChunkedArray (a C stream) imports concatenated, no pyarrow.
+        words = _words_with_gap()
+        arr = a3.Array.from_arrow(_CapsuleSource(words))
+        ca = a3.ChunkedArray([arr])
+        np.testing.assert_array_equal(marrow.import_c_array(ca), words)
 
     def test_arro3_only_no_pyarrow_needed(self):
         # The whole round-trip touches no pyarrow symbol.

--- a/mortie/tests/test_arrow_cdata.py
+++ b/mortie/tests/test_arrow_cdata.py
@@ -1,0 +1,217 @@
+"""
+Tests for the library-agnostic Arrow C Data Interface surface (issue #93).
+
+Where ``test_arrow.py`` pins the pyarrow ``ExtensionType`` skin (issue #86),
+these pin the raw **PyCapsule C Data Interface** built in Rust (the ``arrow``
+crate): ``MortonIndexArray.__arrow_c_array__`` / ``__arrow_c_schema__`` +
+``from_arrow``, and the numpy-only ``mortie.arrow.export_c_array`` /
+``import_c_array`` helpers. The point is that this path carries a typed
+``morton_index`` column -- extension metadata + null/sentinel -- through **any**
+Arrow lib, including arro3-core with pyarrow absent (zagg's Lambda carrier).
+
+The pyarrow leg runs in CI (pyarrow is a test extra). The arro3-core leg is
+gated on arro3-core being importable; it is **not** in the CI test extra (see
+issue #93 / the docs note), so install ``arro3-core==0.8.1`` locally to exercise
+it: ``pip install arro3-core==0.8.1 && pytest mortie/tests/test_arrow_cdata.py``.
+"""
+
+import numpy as np
+import pytest
+
+import mortie  # noqa: F401  (registers the morton_index pyarrow extension type)
+from mortie import _rustie
+from mortie import arrow as marrow
+
+EXT_NAME = "mortie.morton_index"
+
+
+def _sample_words(n=8, order=12):
+    """A spread of packed words across base cells / both hemispheres."""
+    bases = np.arange(n, dtype=np.uint64) % 12
+    nested = bases * (1 << (2 * order)) + np.arange(n, dtype=np.uint64)
+    return _rustie.rust_mi_from_nested(
+        np.ascontiguousarray(nested), order
+    ).astype(np.uint64)
+
+
+try:
+    SENTINEL = int(mortie.MortonIndexArray._SENTINEL)
+except ImportError:  # pragma: no cover - pandas absent
+    SENTINEL = 0
+
+
+def _words_with_gap():
+    """Sample words with the empty sentinel planted at two positions."""
+    words = _sample_words().copy()
+    words[2] = SENTINEL
+    words[5] = SENTINEL
+    return words
+
+
+class _CapsuleSource:
+    """A minimal object exposing the raw producer capsules for consumers."""
+
+    def __init__(self, words):
+        self._words = np.ascontiguousarray(words, dtype=np.uint64)
+
+    def __arrow_c_schema__(self):
+        return marrow.export_c_schema()
+
+    def __arrow_c_array__(self, requested_schema=None):
+        return marrow.export_c_array(self._words)
+
+
+# ---------------------------------------------------------------------------
+# numpy-only surface (no pyarrow, no pandas): export -> import round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestNumpyOnlyRoundTrip:
+    def test_export_import_preserves_words(self):
+        words = _sample_words()
+        back = marrow.import_c_array(_CapsuleSource(words))
+        assert back.dtype == np.uint64
+        np.testing.assert_array_equal(back, words)
+
+    def test_export_import_preserves_nulls(self):
+        # sentinel -> Arrow null -> sentinel, byte-for-byte over the validity bitmap
+        words = _words_with_gap()
+        back = marrow.import_c_array(_CapsuleSource(words))
+        np.testing.assert_array_equal(back, words)
+
+    def test_import_accepts_capsule_tuple(self):
+        words = _sample_words()
+        pair = marrow.export_c_array(words)
+        np.testing.assert_array_equal(marrow.import_c_array(pair), words)
+
+    def test_export_accepts_morton_index_array(self):
+        pytest.importorskip("pandas")
+        mia = mortie.MortonIndexArray(_sample_words())
+        back = marrow.import_c_array(marrow.export_c_array(mia))
+        np.testing.assert_array_equal(back, mia._data)
+
+    def test_empty_array_round_trips(self):
+        words = np.empty(0, dtype=np.uint64)
+        back = marrow.import_c_array(_CapsuleSource(words))
+        assert len(back) == 0
+
+    def test_all_null_round_trips_to_sentinel(self):
+        words = np.full(4, SENTINEL, dtype=np.uint64)
+        back = marrow.import_c_array(_CapsuleSource(words))
+        np.testing.assert_array_equal(back, words)
+
+
+# ---------------------------------------------------------------------------
+# MortonIndexArray dunder surface (pandas path)
+# ---------------------------------------------------------------------------
+
+
+class TestMortonIndexArrayDunders:
+    def test_dunder_round_trip(self):
+        pytest.importorskip("pandas")
+        mia = mortie.MortonIndexArray(_sample_words())
+        back = mortie.MortonIndexArray.from_arrow(mia)
+        assert isinstance(back, mortie.MortonIndexArray)
+        np.testing.assert_array_equal(back._data, mia._data)
+
+    def test_dunder_round_trip_with_nulls(self):
+        pytest.importorskip("pandas")
+        mia = mortie.MortonIndexArray(_words_with_gap())
+        back = mortie.MortonIndexArray.from_arrow(mia)
+        np.testing.assert_array_equal(back._data, mia._data)
+        np.testing.assert_array_equal(back.isna(), mia._data == SENTINEL)
+
+    def test_schema_capsule_is_named(self):
+        pytest.importorskip("pandas")
+        mia = mortie.MortonIndexArray(_sample_words())
+        cap = mia.__arrow_c_schema__()
+        # A PyCapsule with the C Data Interface schema name.
+        assert "arrow_schema" in repr(cap)
+
+
+# ---------------------------------------------------------------------------
+# pyarrow consumer/producer (CI: pyarrow is a test extra)
+# ---------------------------------------------------------------------------
+
+
+class TestPyarrowInterop:
+    def test_pyarrow_consumes_our_export(self):
+        pa = pytest.importorskip("pyarrow")
+        words = _words_with_gap()
+        arr = pa.array(_CapsuleSource(words))
+        # pyarrow resolves the registered morton_index extension type.
+        assert arr.type.extension_name == EXT_NAME
+        assert arr.null_count == 2
+        assert arr.storage.to_pylist() == [
+            (None if w == SENTINEL else int(w)) for w in words
+        ]
+
+    def test_we_import_pyarrow_export(self):
+        pa = pytest.importorskip("pyarrow")
+        words = _words_with_gap()
+        arr = pa.array(_CapsuleSource(words))
+        back = marrow.import_c_array(arr)
+        np.testing.assert_array_equal(back, words)
+
+    def test_import_plain_uint64_pyarrow_array(self):
+        # A plain (non-extension) uint64 arrow array still imports as words.
+        pa = pytest.importorskip("pyarrow")
+        words = _sample_words()
+        arr = pa.array(words, type=pa.uint64())
+        np.testing.assert_array_equal(marrow.import_c_array(arr), words)
+
+    def test_reject_non_uint64_storage(self):
+        pa = pytest.importorskip("pyarrow")
+        arr = pa.array([1, 2, 3], type=pa.int32())
+        with pytest.raises(ValueError, match="uint64"):
+            marrow.import_c_array(arr)
+
+
+# ---------------------------------------------------------------------------
+# arro3-core consumer/producer -- pyarrow-free carrier (issue #93 item 4).
+# Local-only: arro3-core is not in the CI test extra; skip if absent.
+# ---------------------------------------------------------------------------
+
+a3 = pytest.importorskip(
+    "arro3.core", reason="arro3-core not installed (local-only leg)"
+)
+
+
+class TestArro3Interop:
+    """The pyarrow-free path #86 never exercised: round-trip on arro3-core."""
+
+    def test_arro3_consumes_our_export_with_extension_metadata(self):
+        # arro3-core pulls our export and preserves the extension metadata
+        # through the C-Data boundary (the issue-2 gate; arro3-core==0.8.1).
+        words = _sample_words()
+        arr = a3.Array.from_arrow(_CapsuleSource(words))
+        meta = dict(arr.field.metadata_str)
+        assert meta.get("ARROW:extension:name") == EXT_NAME
+        np.testing.assert_array_equal(np.asarray(arr), words)
+
+    def test_arro3_export_import_round_trip_with_nulls(self):
+        # Full loop with pyarrow absent from the path: our export -> arro3 ->
+        # arro3's export -> our import, nulls preserved byte-for-byte.
+        words = _words_with_gap()
+        arr = a3.Array.from_arrow(_CapsuleSource(words))
+        back = marrow.import_c_array(arr)
+        np.testing.assert_array_equal(back, words)
+
+    def test_arro3_only_no_pyarrow_needed(self):
+        # The whole round-trip touches no pyarrow symbol.
+        words = _sample_words()
+        arr = a3.Array.from_arrow(_CapsuleSource(words))
+        back = mortie.MortonIndexArray.from_arrow(arr) if _has_pandas() else None
+        raw = marrow.import_c_array(arr)
+        np.testing.assert_array_equal(raw, words)
+        if back is not None:
+            np.testing.assert_array_equal(back._data, words)
+
+
+def _has_pandas():
+    try:
+        import pandas  # noqa: F401
+
+        return True
+    except ImportError:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,15 @@ pandas = [
 pyarrow = [
   "pyarrow>=14.0",
 ]
+# arro3-core is a pyarrow-free Arrow carrier for the library-agnostic C Data
+# Interface surface (mortie.arrow.export_c_array / import_c_array, issue #93).
+# Also NOT a runtime dep. Kept out of the `test` extra deliberately: the
+# arro3-core round-trip leg in test_arrow_cdata.py is local-only (it skips when
+# arro3-core is absent) — install this extra to exercise it. See
+# docs/arrow_interchange.md.
+arro3 = [
+  "arro3-core>=0.8.1",
+]
 test = [
   "pytest>=8.0",
   "pytest-cov>=4.0",

--- a/src_rust/src/arrow_ffi.rs
+++ b/src_rust/src/arrow_ffi.rs
@@ -1,0 +1,138 @@
+//! Arrow C Data Interface (PyCapsule) producer + consumer for `morton_index`
+//! (issue #93).
+//!
+//! Makes the `morton_index` Arrow surface library-agnostic: any Arrow lib that
+//! speaks the [PyCapsule C Data Interface] — `arro3-core` (the carrier zagg runs
+//! on its Lambda worker, **without pyarrow**), pyarrow, polars — can pull a typed
+//! morton column zero-copy, and hand one back. Where `mortie.arrow` (issue #86)
+//! builds a pyarrow `ExtensionArray` and is gated on pyarrow, this path builds
+//! the raw C structs in Rust via the `arrow` crate, so the runtime stays
+//! numpy-only.
+//!
+//! The exported schema carries the `morton_index` Arrow **extension type** as
+//! field metadata (`ARROW:extension:name` = [`EXTENSION_NAME`]), so the dtype
+//! survives the boundary. Nulls travel as a real Arrow **validity bitmap** built
+//! from the all-zero empty sentinel (`data == 0`), and are mapped back to the
+//! sentinel on import — the same null<->sentinel convention as #86, but carried
+//! byte-for-byte through any Arrow lib rather than via pyarrow's `fill_null`.
+//!
+//! [PyCapsule C Data Interface]: https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html
+
+use std::collections::HashMap;
+use std::ffi::CString;
+
+use arrow::array::{Array, UInt64Array};
+use arrow::datatypes::{DataType, Field};
+use arrow::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+/// The Arrow extension name that tags a `morton_index` column. Mirrors
+/// `mortie.arrow.EXTENSION_NAME` on the pyarrow side, so a column produced here
+/// is recognized by the pandas `__from_arrow__` hook and vice versa.
+pub const EXTENSION_NAME: &str = "mortie.morton_index";
+
+/// The all-zero empty word: the missing-value sentinel (prefix 0). A word equal
+/// to this maps to an Arrow null on export and comes back from a null on import.
+const SENTINEL: u64 = 0;
+
+/// Build the `morton_index` Arrow field: `uint64` storage, nullable, carrying the
+/// extension-type metadata so the morton-ness survives the C-Data boundary.
+fn morton_index_field() -> Field {
+    let mut meta = HashMap::new();
+    meta.insert(
+        "ARROW:extension:name".to_string(),
+        EXTENSION_NAME.to_string(),
+    );
+    // No parameters to carry; the extension name is the whole identity (matches
+    // the pyarrow side's empty `__arrow_ext_serialize__`).
+    meta.insert("ARROW:extension:metadata".to_string(), String::new());
+    Field::new("item", DataType::UInt64, true).with_metadata(meta)
+}
+
+/// Build the C schema capsule (named `"arrow_schema"`) for a `morton_index`
+/// column. Shared by the `__arrow_c_schema__` and `__arrow_c_array__` paths.
+fn schema_capsule<'py>(py: Python<'py>) -> PyResult<Bound<'py, PyCapsule>> {
+    let ffi_schema = FFI_ArrowSchema::try_from(&morton_index_field())
+        .map_err(|e| PyValueError::new_err(format!("failed to export Arrow schema: {e}")))?;
+    let name = CString::new("arrow_schema").unwrap();
+    PyCapsule::new_bound(py, ffi_schema, Some(name))
+}
+
+/// `MortonIndexArray.__arrow_c_schema__` backend: the schema capsule alone.
+#[pyfunction]
+pub fn rust_mi_export_c_schema(py: Python<'_>) -> PyResult<Bound<'_, PyCapsule>> {
+    schema_capsule(py)
+}
+
+/// `MortonIndexArray.__arrow_c_array__` backend: `(schema_capsule, array_capsule)`
+/// over the packed `uint64` words, with the sentinel mapped to an Arrow null via
+/// a real validity bitmap and the `morton_index` extension type on the schema.
+#[pyfunction]
+pub fn rust_mi_export_c_array(
+    py: Python<'_>,
+    words: Vec<u64>,
+) -> PyResult<(Bound<'_, PyCapsule>, Bound<'_, PyCapsule>)> {
+    // Sentinel word -> Arrow null, mirroring #86's `data == _SENTINEL` mask, but
+    // as a validity bitmap in the exported buffer rather than a pyarrow `mask=`.
+    let arr: UInt64Array = words
+        .iter()
+        .map(|&w| if w == SENTINEL { None } else { Some(w) })
+        .collect();
+    let ffi_array = FFI_ArrowArray::new(&arr.into_data());
+    let array_name = CString::new("arrow_array").unwrap();
+    let array_capsule = PyCapsule::new_bound(py, ffi_array, Some(array_name))?;
+    Ok((schema_capsule(py)?, array_capsule))
+}
+
+/// Consume a `(schema_capsule, array_capsule)` pair produced by *any* Arrow lib
+/// and return the packed `uint64` words (Arrow nulls -> the empty sentinel).
+///
+/// This is the import half of the C Data Interface: it moves the `FFI_ArrowArray`
+/// out of its capsule (leaving a released stub so the capsule destructor is a
+/// no-op — the C-Data ownership-transfer convention) and borrows the schema.
+#[pyfunction]
+pub fn rust_mi_import_c_array(
+    py: Python<'_>,
+    schema_capsule: &Bound<'_, PyCapsule>,
+    array_capsule: &Bound<'_, PyCapsule>,
+) -> PyResult<Py<PyAny>> {
+    let schema_ptr = schema_capsule.pointer() as *const FFI_ArrowSchema;
+    let array_ptr = array_capsule.pointer() as *mut FFI_ArrowArray;
+    if schema_ptr.is_null() || array_ptr.is_null() {
+        return Err(PyValueError::new_err(
+            "expected non-null 'arrow_schema'/'arrow_array' PyCapsules",
+        ));
+    }
+
+    // Move the array struct out of the capsule and leave an empty (released)
+    // struct behind, so the producer's capsule destructor won't double-free.
+    // Borrow the schema for the duration of the call (the capsule outlives it).
+    let (data, schema_dt) = unsafe {
+        let ffi_array = std::ptr::replace(array_ptr, FFI_ArrowArray::empty());
+        let data = from_ffi(ffi_array, &*schema_ptr)
+            .map_err(|e| PyValueError::new_err(format!("failed to import Arrow array: {e}")))?;
+        let dt = data.data_type().clone();
+        (data, dt)
+    };
+    if schema_dt != DataType::UInt64 {
+        return Err(PyValueError::new_err(format!(
+            "morton_index import expects uint64 storage, got {schema_dt:?}"
+        )));
+    }
+
+    let arr = UInt64Array::from(data);
+    let words: Vec<u64> = (0..arr.len())
+        .map(|i| {
+            if arr.is_null(i) {
+                SENTINEL
+            } else {
+                arr.value(i)
+            }
+        })
+        .collect();
+    Ok(numpy::PyArray1::from_vec_bound(py, words)
+        .into_any()
+        .unbind())
+}

--- a/src_rust/src/arrow_ffi.rs
+++ b/src_rust/src/arrow_ffi.rs
@@ -86,6 +86,30 @@ pub fn rust_mi_export_c_array(
     Ok((schema_capsule(py)?, array_capsule))
 }
 
+/// Return a capsule's pointer, but only after confirming it carries the expected
+/// C Data Interface name. `PyCapsule::pointer()` looks the pointer up by the
+/// capsule's *own* name and never checks it, so a mis-ordered or wrong-named pair
+/// would otherwise let us reinterpret an `FFI_ArrowSchema` as an `FFI_ArrowArray`
+/// (memory corruption reachable from safe Python). Guard the name first.
+fn checked_pointer(
+    capsule: &Bound<'_, PyCapsule>,
+    expected: &str,
+) -> PyResult<*mut std::ffi::c_void> {
+    let ok = matches!(capsule.name()?, Some(name) if name.to_bytes() == expected.as_bytes());
+    if !ok {
+        return Err(PyValueError::new_err(format!(
+            "expected a PyCapsule named {expected:?}"
+        )));
+    }
+    let ptr = capsule.pointer();
+    if ptr.is_null() {
+        return Err(PyValueError::new_err(format!(
+            "PyCapsule {expected:?} holds a null pointer"
+        )));
+    }
+    Ok(ptr)
+}
+
 /// Consume a `(schema_capsule, array_capsule)` pair produced by *any* Arrow lib
 /// and return the packed `uint64` words (Arrow nulls -> the empty sentinel).
 ///
@@ -98,13 +122,8 @@ pub fn rust_mi_import_c_array(
     schema_capsule: &Bound<'_, PyCapsule>,
     array_capsule: &Bound<'_, PyCapsule>,
 ) -> PyResult<Py<PyAny>> {
-    let schema_ptr = schema_capsule.pointer() as *const FFI_ArrowSchema;
-    let array_ptr = array_capsule.pointer() as *mut FFI_ArrowArray;
-    if schema_ptr.is_null() || array_ptr.is_null() {
-        return Err(PyValueError::new_err(
-            "expected non-null 'arrow_schema'/'arrow_array' PyCapsules",
-        ));
-    }
+    let schema_ptr = checked_pointer(schema_capsule, "arrow_schema")? as *const FFI_ArrowSchema;
+    let array_ptr = checked_pointer(array_capsule, "arrow_array")? as *mut FFI_ArrowArray;
 
     // Move the array struct out of the capsule and leave an empty (released)
     // struct behind, so the producer's capsule destructor won't double-free.

--- a/src_rust/src/arrow_ffi.rs
+++ b/src_rust/src/arrow_ffi.rs
@@ -23,7 +23,8 @@ use std::ffi::CString;
 
 use arrow::array::{Array, UInt64Array};
 use arrow::datatypes::{DataType, Field};
-use arrow::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
+use arrow::ffi::{from_ffi, from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
+use arrow::ffi_stream::FFI_ArrowArrayStream;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
@@ -142,15 +143,81 @@ pub fn rust_mi_import_c_array(
     }
 
     let arr = UInt64Array::from(data);
-    let words: Vec<u64> = (0..arr.len())
-        .map(|i| {
-            if arr.is_null(i) {
-                SENTINEL
-            } else {
-                arr.value(i)
-            }
-        })
-        .collect();
+    let mut words: Vec<u64> = Vec::with_capacity(arr.len());
+    append_words(&arr, &mut words);
+    Ok(numpy::PyArray1::from_vec_bound(py, words)
+        .into_any()
+        .unbind())
+}
+
+/// Append a `UInt64Array`'s logical values to `out`, mapping Arrow nulls to the
+/// empty sentinel (respects the array's offset via the logical accessors).
+fn append_words(arr: &UInt64Array, out: &mut Vec<u64>) {
+    for i in 0..arr.len() {
+        out.push(if arr.is_null(i) {
+            SENTINEL
+        } else {
+            arr.value(i)
+        });
+    }
+}
+
+/// Consume an Arrow C Data Interface **stream** capsule (`__arrow_c_stream__` —
+/// a chunked column / multi-batch source) and return all packed `uint64` words
+/// concatenated (Arrow nulls -> the empty sentinel).
+///
+/// A chunked column's stream schema is the bare `uint64` (extension) type, *not*
+/// a struct, so the struct-oriented `ArrowArrayStreamReader` can't read it. We
+/// drive the C stream callbacks directly: pull the schema once, then each chunk
+/// via `get_next` until the released end-of-stream marker, importing each with
+/// the explicit `uint64` type.
+#[pyfunction]
+pub fn rust_mi_import_c_stream(
+    py: Python<'_>,
+    stream_capsule: &Bound<'_, PyCapsule>,
+) -> PyResult<Py<PyAny>> {
+    let stream_ptr =
+        checked_pointer(stream_capsule, "arrow_array_stream")? as *mut FFI_ArrowArrayStream;
+
+    // Move the stream out of the capsule, leaving a released stub behind (so the
+    // producer's capsule destructor is a no-op); `stream` drops -> release here.
+    let mut stream = unsafe { std::ptr::replace(stream_ptr, FFI_ArrowArrayStream::empty()) };
+    let get_schema = stream
+        .get_schema
+        .ok_or_else(|| PyValueError::new_err("Arrow stream has no get_schema callback"))?;
+    let get_next = stream
+        .get_next
+        .ok_or_else(|| PyValueError::new_err("Arrow stream has no get_next callback"))?;
+
+    // Pull the schema once and confirm the stream carries uint64 storage.
+    let mut schema = FFI_ArrowSchema::empty();
+    let rc = unsafe { get_schema(&mut stream, &mut schema) };
+    if rc != 0 {
+        return Err(PyValueError::new_err("Arrow stream get_schema failed"));
+    }
+    let dt = DataType::try_from(&schema)
+        .map_err(|e| PyValueError::new_err(format!("failed to read stream schema: {e}")))?;
+    if dt != DataType::UInt64 {
+        return Err(PyValueError::new_err(format!(
+            "morton_index import expects uint64 storage, got {dt:?}"
+        )));
+    }
+
+    let mut words: Vec<u64> = Vec::new();
+    loop {
+        let mut ffi_array = FFI_ArrowArray::empty();
+        let rc = unsafe { get_next(&mut stream, &mut ffi_array) };
+        if rc != 0 {
+            return Err(PyValueError::new_err("Arrow stream get_next failed"));
+        }
+        // A released array is the end-of-stream marker.
+        if ffi_array.is_released() {
+            break;
+        }
+        let data = unsafe { from_ffi_and_data_type(ffi_array, DataType::UInt64) }
+            .map_err(|e| PyValueError::new_err(format!("failed to import stream chunk: {e}")))?;
+        append_words(&UInt64Array::from(data), &mut words);
+    }
     Ok(numpy::PyArray1::from_vec_bound(py, words)
         .into_any()
         .unbind())

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -3,6 +3,7 @@
 //! This module provides Python bindings for fast morton encoding operations,
 //! replacing the numba-accelerated functions to eliminate Dask conflicts.
 
+pub mod arrow_ffi;
 pub mod buffer;
 pub mod cell_geom;
 pub mod coverage;
@@ -1185,5 +1186,8 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_mi_decode, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_from_legacy, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_decimal_repr, m)?)?;
+    m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_export_c_schema, m)?)?;
+    m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_export_c_array, m)?)?;
+    m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_import_c_array, m)?)?;
     Ok(())
 }

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -1189,5 +1189,6 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_export_c_schema, m)?)?;
     m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_export_c_array, m)?)?;
     m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_import_c_array, m)?)?;
+    m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_import_c_stream, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
Closes #93.

## What & why

Makes the `morton_index` Arrow surface **library-agnostic**: any Arrow lib that speaks the [PyCapsule C Data Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html) — **arro3-core** (the carrier zagg runs on its Lambda worker, where pyarrow is intentionally absent), pyarrow, polars — can pull a typed `morton_index` column zero-copy and hand one back, carrying a real Arrow **extension type** rather than shimming through plain `uint64`.

Where #86's `mortie.arrow` builds a pyarrow `ExtensionArray` and is gated on pyarrow (`_require_pyarrow`, `fill_null`, `to_pandas`) and has no export hook, this path builds the raw Arrow C structs in **Rust** (the `arrow` crate's C Data Interface), so the runtime stays **numpy-only** and gets both directions.

Approach follows the decisions on #93: approach **(A)** (Rust FFI), the **umbrella `arrow` crate**, pinned target **`arro3-core==0.8.1`**, and the arro3-only test kept **runnable-locally + documented** (no `.github/workflows/` change here — bundled to #92).

## Key finding (the #93 item-2 gate)

**arro3-core 0.8.1 round-trips the extension metadata** (`ARROW:extension:name = mortie.morton_index`) through the C-Data boundary — verified in `TestArro3Interop`. So we ship the **real extension type**; no `uint64`-storage fallback is needed on the Lambda layer.

## Design

- **Rust producer/consumer** (`src_rust/src/arrow_ffi.rs`, via the `arrow` crate):
  - `rust_mi_export_c_array(words)` / `rust_mi_export_c_schema()`: build the `(schema, array)` capsules — a `UInt64Array` with a **real validity bitmap** from the empty sentinel (`data == 0` → Arrow null), schema Field carrying the extension metadata.
  - `rust_mi_import_c_array(schema, array)`: single contiguous array → packed words. Validates each capsule's C-Data **name** before dereferencing; moves the FFI struct out leaving a released stub (no double-free); rejects non-`uint64`.
  - `rust_mi_import_c_stream(stream)`: a **chunked** column (`__arrow_c_stream__`). Its stream schema is the bare (non-struct) `uint64`, which the struct-oriented `ArrowArrayStreamReader` rejects, so this drives the C stream callbacks directly (schema once, `get_next` each chunk to the released end-marker, import each via `from_ffi_and_data_type(_, UInt64)`), concatenating.
- **Python surface:**
  - `MortonIndexArray.__arrow_c_array__` / `__arrow_c_schema__` / `from_arrow(source)` (`mortie/morton_index.py`).
  - numpy-only `mortie.arrow.export_c_array` / `export_c_schema` / `import_c_array` (`mortie/arrow.py`) — pyarrow-free; `import_c_array` dispatches `__arrow_c_array__` (contiguous) vs `__arrow_c_stream__` (chunked) vs a raw capsule tuple.
- **Null/sentinel** preserved byte-for-byte over a validity bitmap, across chunk boundaries.

## Phases

- [x] **Phase 1** — Rust C-Data producer + consumer + extension type; Python surface; round-trip tests (numpy-only, pandas dunders, pyarrow, arro3-core), incl. null/empty/all-null and non-uint64 rejection.
- [x] **Phase 2** — `arro3` install extra (local-only) + `docs/arrow_interchange.md`.
- [x] **Phase 3** — [#92 context comment](https://github.com/espg/mortie/issues/92#issuecomment-4859163096) for the no-pyarrow CI leg.
- [x] **Phase 4** — chunked/stream import (`__arrow_c_stream__`) per review feedback; verified round-tripping pyarrow + arro3-core `ChunkedArray`, empty, and non-uint64 rejection.

## Self-review resolutions

Phase-1 review folded (commit `fold phase 1 self-review on #93`): scoped the `arro3` skip to `TestArro3Interop` only (a module-level `importorskip` would have skipped the whole file in CI); added capsule-**name validation** (`checked_pointer`) against a memory-corruption path; added an offset-slice import test. (Phase-4 stream self-review in progress.)

## How it was tested

Local (fresh venv, `maturin develop --release`, `arro3-core==0.8.1`):

- `pytest mortie/tests/test_arrow_cdata.py` — **23 passed** locally; the arro3 leg skips when arro3-core is absent (the CI shape).
- `pytest test_arrow.py test_morton_index.py` — 57 passed, 1 skipped (no regression to the #86 pyarrow skin).
- `cargo test --lib` — 188 passed. `cargo fmt` clean; `flake8 mortie --select=E9,F63,F7,F82` clean.

## Notes for review

- **Extension metadata verified on arro3-core 0.8.1** — ship the real extension type (no `uint64` fallback), as done.
- **codecov/patch** is red on the local-only `TestArro3Interop` lines (skipped in CI); source files are 100% patch-covered. `codecov.yml`'s existing `ignore: mortie/tests/**/*` isn't excluding files directly under `mortie/tests/` from patch — a one-line glob fix greens it; flagged on the thread for your go-ahead since it's CI config.
- The numpy-only C-Data helpers live in `mortie/arrow.py` alongside the pyarrow skin (import no pyarrow) — flagging the placement in case you'd prefer a separate module.

Refs #86, #92.