### PR TITLE
Harden release changelog/version commit against non-tip tags

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -127,6 +127,18 @@ jobs:
         # Store the new entry file path
         echo "new_entry_file=$NEW_ENTRY_FILE" >> $GITHUB_OUTPUT
 
+    - name: Switch to main before editing tracked files
+      run: |
+        # Edit CHANGELOG.md/Cargo.toml on main directly instead of in the tag
+        # checkout and carrying uncommitted edits across the branch switch.
+        # The carry-over only works when the tag's copies of those files equal
+        # main's; tagging a non-tip/older commit makes them differ, so
+        # `git checkout main` would abort ("local changes would be overwritten").
+        # Changelog generation above reads tags by name, so it is unaffected by
+        # the current branch.
+        git checkout main
+        git pull origin main
+
     - name: Update CHANGELOG.md
       run: |
         NEW_ENTRY_FILE="${{ steps.generate_changelog.outputs.new_entry_file }}"
@@ -198,11 +210,8 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
-        # Switch to main branch and pull latest changes (uncommitted
-        # CHANGELOG.md/Cargo.toml edits carry over since they share main's base).
-        git checkout main
-        git pull origin main
-
+        # Already on main (switched before the file edits above), so the
+        # CHANGELOG.md/Cargo.toml changes are staged and committed on main.
         # Check if there are any changes to commit
         if git diff --quiet CHANGELOG.md Cargo.toml; then
           echo "No changes to CHANGELOG.md or Cargo.toml"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
         threshold: 1%
 
 ignore:
-  - "mortie/tests/**/*"
+  - "mortie/tests"
   - "setup.py"
   - "setup.cfg"
 


### PR DESCRIPTION
Closes #92.

## What this does

Two CI-config fixes, both explicitly requested by @espg (issue #92 by name, and the one-line `codecov.yml` change referenced in the PR #94 comment permalink).

### 1. Harden the release changelog/version commit against non-tip tags (#92)

`build-wheels.yml`'s `update-changelog` job edited tracked files **in the detached tag checkout** and then switched to `main` to commit them, relying on the uncommitted edits carrying over:

- `Update CHANGELOG.md` rewrote `CHANGELOG.md` in place.
- `Sync Cargo.toml version to tag` rewrote `Cargo.toml` in place.
- `Commit changelog and version updates` then ran `git checkout main` / `git pull origin main` and committed the carried-over edits.

That carry-over only works when the tag's committed copies of those files equal `main`'s. For the normal flow (tagging the **tip of `main`**) that holds. But tagging a **non-tip / older commit** (a hotfix, or re-tagging) makes `CHANGELOG.md`/`Cargo.toml` differ, so `git checkout main` aborts with *"Your local changes … would be overwritten by checkout."* Because the build jobs gate on `needs: [update-changelog]` being `success`/`skipped`, that failure can **silently skip the whole release**.

**Fix (per the issue's suggested approach):** switch to `main` and `git pull` *before* the file edits, so the changelog + version edits are applied on `main` directly rather than edited in the tag checkout and carried across. Concretely:

- Added a `Switch to main before editing tracked files` step immediately after `Generate changelog entry` (which writes to a `mktemp` temp file, independent of the working tree) and before `Update CHANGELOG.md`.
- Removed the now-redundant `git checkout main` / `git pull origin main` from `Commit changelog and version updates`.

Changelog generation is unaffected by the current branch: `Get tag name`, `Get previous tag`, and `Generate changelog entry` reference tags **by name** (`git log … $CURRENT_TAG`, `git describe --tags … ${tag}^`), which resolve from any branch (the job checks out with `fetch-depth: 0`). The per-job ephemeral `sed` in each build job still re-derives the wheel/sdist version from the tag independently, so the committed-to-`main` edits only need to be correct on `main`.

### 2. Make `codecov.yml`'s test-file ignore actually exclude patch coverage (folded in)

The referenced comment on PR #94 (`pull/94#issuecomment-4859353255`) noted that `ignore: ["mortie/tests/**/*", …]` fails to exclude files sitting *directly* under `mortie/tests/` from patch coverage, which drags the codecov/patch check down for intentionally-CI-skipped test files. Changed `"mortie/tests/**/*"` → `"mortie/tests"` so the directory (and everything under it) is excluded, making the existing intent work.

## How it was tested

- Both YAML files validated with `yaml.safe_load` (parse clean).
- This is a CI-config-only change with **no Rust/Python source touched**, so `maturin develop` / `pytest` / `flake8` have nothing to exercise here; the release-workflow path can only be exercised by pushing a `*.*.*` tag, which is forbidden (§1, §7). The change is a mechanical reordering of existing, already-working steps plus one glob edit — reviewed by tracing the step order and git semantics rather than by execution.

## Questions for review

- **`codecov.yml` glob form:** the comment offered `"mortie/tests"` **or** adding `"mortie/tests/*"`. I used `"mortie/tests"` (directory form) since it's the single-line change the comment led with and matches the sibling `setup.py` / `setup.cfg` path-style entries. Happy to switch to `"mortie/tests/*"` if you prefer the glob form.
- The `Switch to main` step assumes `main` is fetchable at that point (it is — the job checks out `fetch-depth: 0` with the default token, same as the original commit step's `git pull origin main`).
