### PR TITLE
numpy-level point-kind geo2mort: geo2mort(..., points=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- numpy-level point-kind `geo2mort(..., points=True)` encoder; lat/lon now default to order-29 point words (issue #96). **Breaking:** a bare `geo2mort(lat, lon)` returns order-29 `Kind::Point` words (was order-18 area cells) — pass an explicit `order` for an area cell. Non-finite lat/lon encode to the reserved `0`. ([#100](https://github.com/espg/mortie/pull/100)) by @espg
+
 ## [0.8.4] - 2026-07-01
 
 - Harden release changelog/version commit against non-tip tags ([#95](https://github.com/espg/mortie/pull/95)) by @espg

--- a/mortie/tests/test_geo2mort_points.py
+++ b/mortie/tests/test_geo2mort_points.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from mortie import _rustie, common_ancestor, geo2mort
-from mortie.tools import clip2order
+from mortie.tools import clip2order, infer_order_from_morton
 
 # A spread of locations across hemispheres and near the poles/prime meridian.
 _LATS = np.array([45.0, -80.0, 0.0, 12.3, 89.9, -89.9])
@@ -103,10 +103,13 @@ def test_point_matches_morton_index_from_latlon():
 def test_area_default_backward_compatible_at_explicit_order():
     """points=False is byte-identical to the pre-#96 area encode at a given order."""
     for order in (0, 6, 12, 18, 29):
+        area = geo2mort(_LATS, _LONS, order=order)
         np.testing.assert_array_equal(
-            geo2mort(_LATS, _LONS, order=order),
-            geo2mort(_LATS, _LONS, order=order, points=False),
+            area, geo2mort(_LATS, _LONS, order=order, points=False)
         )
+        # Pin the resolved order — order=0 is falsy, so this catches a regression
+        # to a truthiness `order or MAX_ORDER` resolution that would coerce 0->29.
+        assert infer_order_from_morton(int(area[0])) == order
 
 
 def test_nonfinite_encodes_reserved_zero():

--- a/mortie/tests/test_geo2mort_points.py
+++ b/mortie/tests/test_geo2mort_points.py
@@ -1,0 +1,128 @@
+"""Tests for the numpy-level point-kind encoder ``geo2mort(..., points=True)``.
+
+Covers the contract from issue #96: a vectorized, numpy-in/numpy-out point
+encoder on the ``geo2mort`` surface that routes through the kernel's order-29
+point path (``Kind::Point``) and returns a plain contiguous ``uint64`` ndarray.
+"""
+
+import numpy as np
+import pytest
+
+from mortie import _rustie, common_ancestor, geo2mort
+from mortie.tools import clip2order
+
+# A spread of locations across hemispheres and near the poles/prime meridian.
+_LATS = np.array([45.0, -80.0, 0.0, 12.3, 89.9, -89.9])
+_LONS = np.array([-122.0, 120.0, 0.0, 45.6, 179.9, -179.9])
+
+
+def _area(order=29):
+    return geo2mort(_LATS, _LONS, order=order)
+
+
+def _point():
+    return geo2mort(_LATS, _LONS, order=29, points=True)
+
+
+def test_point_differs_from_area_but_coarsens_identically():
+    """(a) point != area at order 29, but coarsening is bit-identical below 29.
+
+    This is the property zagg's grouping relies on: point and area words for the
+    same location share the entire order-<29 prefix, so grouping by a coarsened
+    word is independent of whether the words started as points or areas.
+    """
+    area = _area(29)
+    point = _point()
+    assert not np.array_equal(area, point), "point and area words must differ at 29"
+    # At every coarser order the two collapse to the same area cell.
+    for order in range(0, 29):
+        np.testing.assert_array_equal(
+            clip2order(order, point),
+            clip2order(order, area),
+            err_msg=f"point/area coarsening diverged at order {order}",
+        )
+
+
+def test_lone_point_survives_common_ancestor_unchanged():
+    """(b) a single point word passes through common_ancestor unchanged (kind kept)."""
+    for word in _point():
+        got = common_ancestor(np.array([word], dtype=np.uint64))
+        assert int(got) == int(word), "lone point word must be returned unchanged"
+
+
+def test_points_true_wrong_order_raises():
+    """(c) points=True with an explicit order != 29 raises ValueError."""
+    for bad_order in (0, 18, 28):
+        with pytest.raises(ValueError):
+            geo2mort(1.0, 2.0, order=bad_order, points=True)
+    # order=29 (or the default / None) is fine.
+    geo2mort(1.0, 2.0, order=29, points=True)
+    geo2mort(1.0, 2.0, points=True)
+    geo2mort(1.0, 2.0, order=None, points=True)
+
+
+def test_point_output_dtype_shape_contiguity():
+    """(d) result is uint64, C-contiguous, same shape as the input."""
+    out = _point()
+    assert out.dtype == np.uint64
+    assert out.flags["C_CONTIGUOUS"]
+    assert out.shape == _LATS.shape
+    # scalar in -> length-1 ndarray, matching the area path's always-ndarray return.
+    scalar = geo2mort(45.0, -122.0, points=True)
+    assert isinstance(scalar, np.ndarray)
+    assert scalar.shape == (1,)
+    assert scalar.dtype == np.uint64
+
+
+def test_point_matches_from_latlon_kernel_path():
+    """geo2mort(points=True) is bit-identical to the from_latlon internal path.
+
+    This is the equivalence zagg needs to swap ``from_latlon(points=True)`` +
+    unwrap for ``geo2mort(..., points=True)``. Cross-checked against the raw
+    kernel bindings (ang2pix(29) -> from_nested_point) that from_latlon composes,
+    so it holds without the optional pandas dependency.
+    """
+    via_geo = _point()
+    nested = _rustie.rust_ang2pix(29, _LONS, _LATS)
+    nested = np.ascontiguousarray(nested, dtype=np.uint64)
+    via_kernel = _rustie.rust_mi_from_nested_point(nested)
+    np.testing.assert_array_equal(via_geo, via_kernel)
+
+
+def test_point_matches_morton_index_from_latlon():
+    """Same equivalence, but against the public MortonIndexArray.from_latlon."""
+    pytest.importorskip("pandas")
+    from mortie.morton_index import MortonIndexArray
+
+    via_geo = _point()
+    arr = MortonIndexArray.from_latlon(_LATS, _LONS, points=True)
+    via_arr = np.asarray(arr).astype(np.uint64)
+    np.testing.assert_array_equal(via_geo, via_arr)
+
+
+def test_area_default_backward_compatible_at_explicit_order():
+    """points=False is byte-identical to the pre-#96 area encode at a given order."""
+    for order in (0, 6, 12, 18, 29):
+        np.testing.assert_array_equal(
+            geo2mort(_LATS, _LONS, order=order),
+            geo2mort(_LATS, _LONS, order=order, points=False),
+        )
+
+
+def test_nonfinite_handling_agrees_between_paths():
+    """Non-finite lat/lon resolve identically on the area and point paths.
+
+    The two share the order-29 hash step, so whatever the area path does with a
+    non-finite input (raise vs. produce a word), the point path must do too.
+    """
+    for bad in (np.nan, np.inf, -np.inf):
+        area_err = point_err = None
+        try:
+            geo2mort(bad, 0.0, order=29, points=False)
+        except Exception as exc:  # noqa: BLE001 - we compare the failure mode
+            area_err = type(exc)
+        try:
+            geo2mort(bad, 0.0, order=29, points=True)
+        except Exception as exc:  # noqa: BLE001
+            point_err = type(exc)
+        assert area_err == point_err, f"non-finite path mismatch for {bad}"

--- a/mortie/tests/test_geo2mort_points.py
+++ b/mortie/tests/test_geo2mort_points.py
@@ -109,36 +109,40 @@ def test_area_default_backward_compatible_at_explicit_order():
         )
 
 
-def test_nonfinite_handling_agrees_between_paths():
-    """Non-finite lat/lon resolve identically on the area and point paths.
+def test_nonfinite_encodes_reserved_zero():
+    """Non-finite lat/lon encode to the reserved empty word 0 on both paths.
 
-    The two share the order-29 hash step, so a non-finite input must land on the
-    same HEALPix nested cell (they differ only in Kind), and must fail — or not —
-    the same way. Today neither path raises (the hash maps non-finite inputs to a
-    definite cell rather than the reserved ``0``); see the PR's "Questions for
-    review" on whether the area path should instead reject non-finite input.
-    ``BaseException`` is used so a would-be PyO3 panic is caught, not just
-    ``Exception``.
+    Base cell 0 is the null sentinel, so 0 never collides with a real encode;
+    a NaN/inf lat or lon yields it on the area and point routes alike.
     """
-    from mortie.tools import mort2healpix
-
     for bad in (np.nan, np.inf, -np.inf):
-        area_err = point_err = None
-        area_word = point_word = None
-        try:
-            area_word = int(geo2mort(bad, 0.0, order=29, points=False)[0])
-        except BaseException as exc:
-            area_err = type(exc)
-        try:
-            point_word = int(geo2mort(bad, 0.0, order=29, points=True)[0])
-        except BaseException as exc:
-            point_err = type(exc)
-        assert area_err == point_err, f"non-finite failure mode mismatch for {bad}"
-        if area_err is None:
-            # Both produced a word: they must share the underlying nested cell.
-            assert mort2healpix(area_word)[0] == mort2healpix(point_word)[0], (
-                f"non-finite nested cell mismatch for {bad}"
-            )
+        assert int(geo2mort(bad, 0.0, order=29, points=False)[0]) == 0
+        assert int(geo2mort(bad, 0.0, points=True)[0]) == 0
+        assert int(geo2mort(0.0, bad, points=True)[0]) == 0
+    # In an array, only the non-finite rows are zeroed; finite rows encode normally.
+    lats = np.array([45.0, np.nan, -80.0])
+    lons = np.array([-122.0, 0.0, np.inf])
+    out = geo2mort(lats, lons, points=True)
+    assert int(out[0]) != 0
+    assert int(out[1]) == 0
+    assert int(out[2]) == 0
+
+
+def test_bare_call_defaults_to_point():
+    """A bare geo2mort(lat, lon) encodes max-precision point words (issue #96).
+
+    An explicit order instead asks for an area cell at that resolution, with
+    ``points`` inferred ``False`` (so no ValueError for a non-29 order).
+    """
+    bare = geo2mort(_LATS, _LONS)
+    np.testing.assert_array_equal(bare, _point())  # bare == points=True
+    # ... and differs from the order-29 area cell.
+    assert not np.array_equal(bare, geo2mort(_LATS, _LONS, order=29, points=False))
+    # An explicit order implies area (points inferred False), no raise.
+    np.testing.assert_array_equal(
+        geo2mort(_LATS, _LONS, order=12),
+        geo2mort(_LATS, _LONS, order=12, points=False),
+    )
 
 
 def test_point_broadcast_matches_elementwise():

--- a/mortie/tests/test_geo2mort_points.py
+++ b/mortie/tests/test_geo2mort_points.py
@@ -112,17 +112,39 @@ def test_area_default_backward_compatible_at_explicit_order():
 def test_nonfinite_handling_agrees_between_paths():
     """Non-finite lat/lon resolve identically on the area and point paths.
 
-    The two share the order-29 hash step, so whatever the area path does with a
-    non-finite input (raise vs. produce a word), the point path must do too.
+    The two share the order-29 hash step, so a non-finite input must land on the
+    same HEALPix nested cell (they differ only in Kind), and must fail — or not —
+    the same way. Today neither path raises (the hash maps non-finite inputs to a
+    definite cell rather than the reserved ``0``); see the PR's "Questions for
+    review" on whether the area path should instead reject non-finite input.
+    ``BaseException`` is used so a would-be PyO3 panic is caught, not just
+    ``Exception``.
     """
+    from mortie.tools import mort2healpix
+
     for bad in (np.nan, np.inf, -np.inf):
         area_err = point_err = None
+        area_word = point_word = None
         try:
-            geo2mort(bad, 0.0, order=29, points=False)
-        except Exception as exc:  # noqa: BLE001 - we compare the failure mode
+            area_word = int(geo2mort(bad, 0.0, order=29, points=False)[0])
+        except BaseException as exc:
             area_err = type(exc)
         try:
-            geo2mort(bad, 0.0, order=29, points=True)
-        except Exception as exc:  # noqa: BLE001
+            point_word = int(geo2mort(bad, 0.0, order=29, points=True)[0])
+        except BaseException as exc:
             point_err = type(exc)
-        assert area_err == point_err, f"non-finite path mismatch for {bad}"
+        assert area_err == point_err, f"non-finite failure mode mismatch for {bad}"
+        if area_err is None:
+            # Both produced a word: they must share the underlying nested cell.
+            assert mort2healpix(area_word)[0] == mort2healpix(point_word)[0], (
+                f"non-finite nested cell mismatch for {bad}"
+            )
+
+
+def test_point_broadcast_matches_elementwise():
+    """The points=True broadcast branch (scalar lat + array lon) is correct."""
+    lons = np.array([-122.0, -121.0, -120.0])
+    out = geo2mort(45.0, lons, order=29, points=True)
+    assert out.dtype == np.uint64 and out.shape == (3,)
+    for i, lon in enumerate(lons):
+        assert int(out[i]) == int(geo2mort(45.0, lon, order=29, points=True)[0])

--- a/mortie/tests/test_main_api.py
+++ b/mortie/tests/test_main_api.py
@@ -37,14 +37,23 @@ class TestMainAPI:
         assert len(result) == len(lats)
 
     def test_geo2mort_default_order(self):
-        """Test that geo2mort uses order=18 by default"""
+        """Test that geo2mort uses order=29 by default (issue #96)"""
         from mortie import geo2mort
+        from mortie.tools import infer_order_from_morton
 
         lat, lon = 45.0, -122.0
 
-        # Should work without specifying order
+        # Should work without specifying order, and default to order 29.
         result = geo2mort(lat, lon)
         assert isinstance(result, (int, np.integer, np.ndarray))
+        assert infer_order_from_morton(int(result[0])) == 29
+        # order=None resolves to the same default.
+        assert int(geo2mort(lat, lon, order=None)[0]) == int(result[0])
+        # An explicit lower order still works and is byte-identical to the area
+        # encode at that order.
+        assert int(geo2mort(lat, lon, order=18)[0]) == int(
+            geo2mort(lat, lon, order=18, points=False)[0]
+        )
 
     def test_all_main_imports(self):
         """Test that all expected functions can be imported from main package"""

--- a/mortie/tests/test_main_api.py
+++ b/mortie/tests/test_main_api.py
@@ -37,20 +37,21 @@ class TestMainAPI:
         assert len(result) == len(lats)
 
     def test_geo2mort_default_order(self):
-        """Test that geo2mort uses order=29 by default (issue #96)"""
+        """Test that a bare geo2mort defaults to order-29 points (issue #96)"""
         from mortie import geo2mort
         from mortie.tools import infer_order_from_morton
 
         lat, lon = 45.0, -122.0
 
-        # Should work without specifying order, and default to order 29.
+        # A bare call defaults to order-29 point words.
         result = geo2mort(lat, lon)
         assert isinstance(result, (int, np.integer, np.ndarray))
         assert infer_order_from_morton(int(result[0])) == 29
-        # order=None resolves to the same default.
-        assert int(geo2mort(lat, lon, order=None)[0]) == int(result[0])
-        # An explicit lower order still works and is byte-identical to the area
-        # encode at that order.
+        # Bare call == points=True, and differs from the order-29 area cell.
+        assert int(result[0]) == int(geo2mort(lat, lon, points=True)[0])
+        assert int(result[0]) != int(geo2mort(lat, lon, order=29, points=False)[0])
+        # An explicit order implies an area cell (points inferred False) and is
+        # byte-identical to the explicit area encode at that order.
         assert int(geo2mort(lat, lon, order=18)[0]) == int(
             geo2mort(lat, lon, order=18, points=False)[0]
         )

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -103,23 +103,55 @@ def geo2uniq(lats, lons, order=18):
     return uniq
 
 
-def geo2mort(lats, lons, order=18):
+def geo2mort(lats, lons, order=29, points=False):
     """Calculates morton indices from geographic coordinates
 
     The entire pipeline runs in Rust via the ``healpix`` crate — no
     Python HEALPix backend is needed.
 
-    lats: array-like
-    lons: array-like
-    order: int"""
+    Defaults to order 29 (the kernel's ``MAX_ORDER``); ``order=None`` resolves
+    to the same. Pass an explicit lower ``order`` for coarser area cells.
 
+    Parameters
+    ----------
+    lats : array-like
+        Latitude(s) in degrees.
+    lons : array-like
+        Longitude(s) in degrees.
+    order : int, optional
+        HEALPix order (0-29). Defaults to 29.
+    points : bool, optional
+        With ``points=False`` (the default) the result is an order-``order``
+        **area** cell (``Kind::Area``), byte-identical to the area encode at
+        that order. With ``points=True`` the location is encoded as a
+        max-resolution **point** (``Kind::Point``) and a plain contiguous
+        ``uint64`` ndarray is returned. Point encoding is order-29-only, so
+        ``points=True`` with an explicit ``order != 29`` raises ``ValueError``
+        (matching :meth:`MortonIndexArray.from_latlon`). Non-finite lat/lon are
+        handled identically to the area path — the two share the hash step.
+
+    Returns
+    -------
+    ndarray
+        Packed ``uint64`` morton word(s), same shape family as the input
+        (scalar in -> length-1 ndarray)."""
+
+    if order is None:
+        order = 29
+    if points and int(order) != 29:
+        raise ValueError(
+            "points=True encodes an order-29 point; pass order=29 "
+            "(the default) or omit it"
+        )
     # Ensure contiguous arrays for Rust FFI
     if not np.isscalar(lats):
         lats = np.ascontiguousarray(lats, dtype=np.float64)
         lons = np.ascontiguousarray(lons, dtype=np.float64)
-    result = _rust_geo2mort(lats, lons, order)
-    # Always return ndarray
-    return np.atleast_1d(result)
+    result = _rust_geo2mort(lats, lons, int(order), points)
+    # Always return a contiguous uint64 ndarray. The scalar Rust path hands back
+    # a Python int (which np would otherwise infer as int64), so coerce to keep
+    # the dtype uint64 regardless of scalar-vs-array input or hemisphere.
+    return np.ascontiguousarray(np.atleast_1d(result), dtype=np.uint64)
 
 
 def infer_order_from_morton(morton):

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -108,14 +108,27 @@ def geo2uniq(lats, lons, order=18):
     return uniq
 
 
-def geo2mort(lats, lons, order=29, points=False):
+def geo2mort(lats, lons, order=None, points=None):
     """Calculates morton indices from geographic coordinates
 
     The entire pipeline runs in Rust via the ``healpix`` crate — no
     Python HEALPix backend is needed.
 
-    Defaults to order 29 (the kernel's ``MAX_ORDER``); ``order=None`` resolves
-    to the same. Pass an explicit lower ``order`` for coarser area cells.
+    lat/lon inputs are treated as **points** by default (indeterminate
+    resolution, encoded at max precision), so a bare ``geo2mort(lats, lons)``
+    returns order-29 ``Kind::Point`` words. Passing an explicit ``order`` asks
+    for an **area** cell at that resolution instead (``points`` inferred
+    ``False``). The two flags resolve as:
+
+    * ``order=None, points=None`` (bare call) -> order-29 **point** words;
+    * an explicit ``order`` with ``points`` unset -> **area** cell at ``order``;
+    * ``points=True`` -> order-29 point words (order-29-only; an explicit
+      ``order != 29`` raises ``ValueError``, matching
+      :meth:`MortonIndexArray.from_latlon`);
+    * ``points=False`` -> area cell at ``order`` (``order=None`` -> 29).
+
+    Non-finite ``lat``/``lon`` encode to the reserved empty word ``0`` (base
+    cell 0 is the null sentinel) on both the area and point routes.
 
     Parameters
     ----------
@@ -124,16 +137,11 @@ def geo2mort(lats, lons, order=29, points=False):
     lons : array-like
         Longitude(s) in degrees.
     order : int, optional
-        HEALPix order (0-29). Defaults to 29.
+        HEALPix order (0-29). Defaults to 29. An explicit value implies an area
+        cell unless ``points=True`` is also given.
     points : bool, optional
-        With ``points=False`` (the default) the result is an order-``order``
-        **area** cell (``Kind::Area``), byte-identical to the area encode at
-        that order. With ``points=True`` the location is encoded as a
-        max-resolution **point** (``Kind::Point``) and a plain contiguous
-        ``uint64`` ndarray is returned. Point encoding is order-29-only, so
-        ``points=True`` with an explicit ``order != 29`` raises ``ValueError``
-        (matching :meth:`MortonIndexArray.from_latlon`). Non-finite lat/lon are
-        handled identically to the area path — the two share the hash step.
+        Encode ``Kind::Point`` (order-29) vs ``Kind::Area`` words. Defaults to
+        ``True`` for a bare call and ``False`` when an ``order`` is given.
 
     Returns
     -------
@@ -141,6 +149,10 @@ def geo2mort(lats, lons, order=29, points=False):
         Packed ``uint64`` morton word(s), same shape family as the input
         (scalar in -> length-1 ndarray)."""
 
+    # Resolve the point/area mode: a bare call encodes points; an explicit order
+    # implies an area cell at that resolution unless the caller forces points.
+    if points is None:
+        points = order is None
     if order is None:
         order = MAX_ORDER
     if points and int(order) != MAX_ORDER:

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -13,6 +13,11 @@ _rust_geo2mort = _rustie.rust_geo2mort
 _rust_mort2nested = _rustie.rust_mort2nested
 _rust_nested2mort = _rustie.rust_nested2mort
 
+# HEALPix orders the packed-u64 kernel reaches (mirrors decimal_morton::MAX_ORDER
+# and morton_index.MAX_ORDER): 0 = base cell, 29 = max resolution and the only
+# order that carries point words.
+MAX_ORDER = 29
+
 
 def order2res(order):
     res = 111 * 58.6323 * .5**order
@@ -137,8 +142,8 @@ def geo2mort(lats, lons, order=29, points=False):
         (scalar in -> length-1 ndarray)."""
 
     if order is None:
-        order = 29
-    if points and int(order) != 29:
+        order = MAX_ORDER
+    if points and int(order) != MAX_ORDER:
         raise ValueError(
             "points=True encodes an order-29 point; pass order=29 "
             "(the default) or omit it"

--- a/src_rust/src/geo2mort.rs
+++ b/src_rust/src/geo2mort.rs
@@ -42,6 +42,25 @@ pub fn geo2mort_point_scalar(lat: f64, lon: f64) -> u64 {
     from_nested_point(nest)
 }
 
+/// Encode one (lat, lon) to a packed word for the public `geo2mort` surface.
+///
+/// Non-finite `lat`/`lon` map to the reserved empty word `0` (base cell 0 is the
+/// null sentinel, so `0` never collides with a real encode); otherwise routes to
+/// the order-29 point scalar (`points`) or the area scalar at `order`. The guard
+/// lives here rather than in [`geo2mort_scalar`] so it is scoped to the public
+/// surface and does not change `linestring`'s internal hashing.
+#[inline]
+pub fn geo2mort_word(lat: f64, lon: f64, order: u8, points: bool) -> u64 {
+    if !lat.is_finite() || !lon.is_finite() {
+        return 0;
+    }
+    if points {
+        geo2mort_point_scalar(lat, lon)
+    } else {
+        geo2mort_scalar(lat, lon, order)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ang2pix: (lon, lat) in degrees → NESTED pixel index
 // ---------------------------------------------------------------------------
@@ -193,6 +212,25 @@ mod tests {
                 "fused point path != compose at {lat},{lon}"
             );
         }
+    }
+
+    #[test]
+    fn test_geo2mort_word_nonfinite_is_zero() {
+        // Non-finite lat/lon map to the reserved empty word 0 on both the area
+        // and point routes; finite inputs match the underlying scalars.
+        for &pts in &[false, true] {
+            assert_eq!(geo2mort_word(f64::NAN, 0.0, MAX_ORDER, pts), 0);
+            assert_eq!(geo2mort_word(0.0, f64::INFINITY, MAX_ORDER, pts), 0);
+            assert_eq!(geo2mort_word(f64::NEG_INFINITY, 10.0, MAX_ORDER, pts), 0);
+        }
+        assert_eq!(
+            geo2mort_word(45.0, -122.0, MAX_ORDER, false),
+            geo2mort_scalar(45.0, -122.0, MAX_ORDER)
+        );
+        assert_eq!(
+            geo2mort_word(45.0, -122.0, MAX_ORDER, true),
+            geo2mort_point_scalar(45.0, -122.0)
+        );
     }
 
     #[test]

--- a/src_rust/src/geo2mort.rs
+++ b/src_rust/src/geo2mort.rs
@@ -9,7 +9,7 @@ use healpix::dir::Cardinal;
 use healpix::get;
 use std::f64::consts::TAU;
 
-use crate::decimal_morton::from_nested;
+use crate::decimal_morton::{from_nested, from_nested_point, MAX_ORDER};
 
 // ---------------------------------------------------------------------------
 // geo2mort
@@ -25,6 +25,21 @@ pub fn geo2mort_scalar(lat: f64, lon: f64, order: u8) -> u64 {
     let layer = get(order);
     let nest = layer.hash(Degrees(lon, lat));
     from_nested(nest, order)
+}
+
+/// Convert a single (lat, lon) pair to a packed morton **point** word at order 29.
+///
+/// The point twin of [`geo2mort_scalar`]: hash to an order-29 HEALPix NESTED id
+/// with the `healpix` crate, then pack it through the point kernel
+/// ([`from_nested_point`]) so the result decodes with `kind == Kind::Point`.
+/// Point encoding is order-29-only, so this takes no `order` argument. The nest
+/// step is identical to the area path at order 29, so non-finite `lat`/`lon`
+/// resolve exactly as they do there.
+#[inline]
+pub fn geo2mort_point_scalar(lat: f64, lon: f64) -> u64 {
+    let layer = get(MAX_ORDER);
+    let nest = layer.hash(Degrees(lon, lat));
+    from_nested_point(nest)
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +163,35 @@ mod tests {
         for order in 1..=crate::decimal_morton::MAX_ORDER {
             let m = geo2mort_scalar(45.0, -122.0, order);
             assert!(m != 0, "Order {} should produce non-zero morton", order);
+        }
+    }
+
+    #[test]
+    fn test_geo2mort_point_differs_from_area() {
+        // At order 29 the point word and the area word for the same lat/lon are
+        // distinct (different Kind), but both decode to the same nested cell.
+        let area = geo2mort_scalar(45.0, -122.0, MAX_ORDER);
+        let point = geo2mort_point_scalar(45.0, -122.0);
+        assert_ne!(area, point, "point and area words must differ at order 29");
+        assert_eq!(
+            crate::decimal_morton::to_nested(area),
+            crate::decimal_morton::to_nested(point),
+            "point and area words must share the order-29 nested cell"
+        );
+    }
+
+    #[test]
+    fn test_geo2mort_point_matches_compose() {
+        // The fused path must be bit-identical to composing the existing
+        // ang2pix(29) + from_nested_point bindings.
+        for &(lat, lon) in &[(45.0, -122.0), (-80.0, 120.0), (0.0, 0.0), (89.9, 179.9)] {
+            let fused = geo2mort_point_scalar(lat, lon);
+            let nest = ang2pix_scalar(MAX_ORDER, lon, lat);
+            let composed = from_nested_point(nest);
+            assert_eq!(
+                fused, composed,
+                "fused point path != compose at {lat},{lon}"
+            );
         }
     }
 

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -202,18 +202,26 @@ fn split_children_rust(
 /// # Arguments
 /// * `lats` - Latitude(s) in degrees (scalar or NumPy array)
 /// * `lons` - Longitude(s) in degrees (scalar or NumPy array)
-/// * `order` - HEALPix order (default 18)
+/// * `order` - HEALPix order (default 29)
+/// * `points` - When true, encode order-29 `Kind::Point` words instead of area
+///   cells (order-29-only; any other `order` raises `ValueError`).
 #[pyfunction]
-#[pyo3(signature = (lats, lons, order=18))]
+#[pyo3(signature = (lats, lons, order=29, points=false))]
 fn rust_geo2mort<'py>(
     py: Python<'py>,
     lats: &Bound<'py, PyAny>,
     lons: &Bound<'py, PyAny>,
     order: u8,
+    points: bool,
 ) -> PyResult<PyObject> {
     if order > decimal_morton::MAX_ORDER {
         return Err(PyValueError::new_err(
             "Max order is 29 (the packed-u64 decimal_morton limit).",
+        ));
+    }
+    if points && order != decimal_morton::MAX_ORDER {
+        return Err(PyValueError::new_err(
+            "points=True encodes an order-29 point; pass order=29 (the default) or omit it",
         ));
     }
 
@@ -222,7 +230,11 @@ fn rust_geo2mort<'py>(
 
     // Both scalars → return scalar
     if lats_is_scalar && lons_is_scalar {
-        let result = geo2mort::geo2mort_scalar(lat_arr[0], lon_arr[0], order);
+        let result = if points {
+            geo2mort::geo2mort_point_scalar(lat_arr[0], lon_arr[0])
+        } else {
+            geo2mort::geo2mort_scalar(lat_arr[0], lon_arr[0], order)
+        };
         return Ok(result.to_object(py));
     }
 
@@ -244,7 +256,11 @@ fn rust_geo2mort<'py>(
             .map(|i| {
                 let lat = lat_arr[if lat_bcast { 0 } else { i }];
                 let lon = lon_arr[if lon_bcast { 0 } else { i }];
-                geo2mort::geo2mort_scalar(lat, lon, order)
+                if points {
+                    geo2mort::geo2mort_point_scalar(lat, lon)
+                } else {
+                    geo2mort::geo2mort_scalar(lat, lon, order)
+                }
             })
             .collect()
     });

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -230,11 +230,7 @@ fn rust_geo2mort<'py>(
 
     // Both scalars → return scalar
     if lats_is_scalar && lons_is_scalar {
-        let result = if points {
-            geo2mort::geo2mort_point_scalar(lat_arr[0], lon_arr[0])
-        } else {
-            geo2mort::geo2mort_scalar(lat_arr[0], lon_arr[0], order)
-        };
+        let result = geo2mort::geo2mort_word(lat_arr[0], lon_arr[0], order, points);
         return Ok(result.to_object(py));
     }
 
@@ -256,11 +252,7 @@ fn rust_geo2mort<'py>(
             .map(|i| {
                 let lat = lat_arr[if lat_bcast { 0 } else { i }];
                 let lon = lon_arr[if lon_bcast { 0 } else { i }];
-                if points {
-                    geo2mort::geo2mort_point_scalar(lat, lon)
-                } else {
-                    geo2mort::geo2mort_scalar(lat, lon, order)
-                }
+                geo2mort::geo2mort_word(lat, lon, order, points)
             })
             .collect()
     });

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -205,6 +205,11 @@ fn split_children_rust(
 /// * `order` - HEALPix order (default 29)
 /// * `points` - When true, encode order-29 `Kind::Point` words instead of area
 ///   cells (order-29-only; any other `order` raises `ValueError`).
+///
+/// These low-level binding defaults (`order=29`, `points=false`) are a plain
+/// area primitive; the public point-by-default ergonomics live in the
+/// `mortie.tools.geo2mort` wrapper, which resolves `order`/`points` and always
+/// passes them explicitly here.
 #[pyfunction]
 #[pyo3(signature = (lats, lons, order=29, points=false))]
 fn rust_geo2mort<'py>(


### PR DESCRIPTION
Closes #96.

## What this does

Adds a vectorized, numpy-in/numpy-out **point-kind** encoder on the `geo2mort` surface, so zagg's hot path (`HealpixGrid.assign`, per-photon for ATL03) gets a public vectorized point encode and drops the `MortonIndexArray` → ndarray unwrap entirely (the ~12x penalty measured in the issue).

lat/lon inputs are treated as **points by default** (indeterminate resolution, encoded at max precision), so:

```python
geo2mort(lats, lons)                    # -> order-29 Kind::Point words (bare call)
geo2mort(lats, lons, order=12)          # -> order-12 Kind::Area cells (explicit order => area)
geo2mort(lats, lons, points=True)       # -> order-29 Kind::Point words (explicit)
geo2mort(lats, lons, order=12, points=False)  # -> order-12 area (same as `order=12`)
```

Result is always a plain contiguous `uint64` ndarray — no ExtensionArray wrapper. Point encoding is order-29-only, so `points=True` with an explicit `order != 29` raises `ValueError` (matching `MortonIndexArray.from_latlon`). Non-finite `lat`/`lon` encode to the reserved empty word `0` (base cell 0 is the null sentinel) on both routes.

## Recorded design decisions (from review thread)

- **`points` defaults to point.** Per [this comment](https://github.com/espg/mortie/pull/100#issuecomment-4883387347) ("lat/lon inputs are generally expected to be of type point ... flip it"), a bare `geo2mort(lat, lon)` returns order-29 point words. An explicit `order` implies an **area** cell (points inferred `False`), so `geo2mort(lat, lon, order=18)` does not raise. Resolved via a tri-state `order=None`/`points=None`: `points = order is None`, then `order = order or 29` — using an identity check so `order=0` stays 0.
- **Non-finite → reserved `0`.** Per [this comment](https://github.com/espg/mortie/pull/100#issuecomment-4883376017) ("why don't we hash to the reserved 0? we already have base cell '0' reserved for this"), non-finite lat/lon map to `0` on both paths. The guard lives in a new `geo2mort_word` helper scoped to the public `geo2mort` surface, so `linestring`'s internal `geo2mort_scalar` hashing is unchanged.
- **Default order 18→29 is breaking** (bare call now returns order-29 words, not order-18); flagged in `CHANGELOG.md`. All in-tree callers pass an explicit `order`.

## Phases

- [x] **Phase 1 — Rust fused point path + binding.** `geo2mort_point_scalar`; `rust_geo2mort` gains `points` flag; Rust unit tests (point ≠ area at 29 but same nested cell; fused == compose).
- [x] **Phase 2 — Python surface + tests.** `geo2mort` points/order plumbing + validation + uint64 coercion; the four issue-specified tests + `from_latlon` equivalence.
- [x] **Phase 3 — fold self-review 1.** Real non-finite assertion, dead-`noqa` removal, broadcast test, `MAX_ORDER` constant.
- [x] **Phase 4 — maintainer directives.** Non-finite → reserved `0` (`geo2mort_word`, scoped to the public surface, + Rust test); flip the `points` default to point-by-default via the tri-state resolution; CHANGELOG line; updated/added tests (reserved-0, bare-call-defaults-to-point).
- [x] **Phase 5 — fold self-review 2.** Pin `order=0` resolves to an order-0 word (guards against a future truthiness regression); clarify the binding's low-level-default doc comment.

## How it was tested

- `cargo test` (13 geo2mort tests), `cargo fmt --check` clean, `cargo clippy` (no new warnings — only the pre-existing `useless_conversion` false-positives, none in this diff).
- `flake8 mortie --select=E9,F63,F7,F82` clean.
- `pytest -v`: **548 passed, 11 skipped**. `test_geo2mort_points.py` covers the four issue tests, `from_latlon`/kernel equivalence, broadcast, reserved-0 non-finite handling, bare-call-defaults-to-point, and pins the explicit-order (incl. `order=0`) area path.
- CI on the PR: codecov 100% on modified lines, CodSpeed reports no perf change.

Side note: the scalar path previously returned `int64` for small (northern) words and `uint64` for large (bit-63-set southern) words — a latent hemisphere-dependent dtype inconsistency. `geo2mort` now always returns a contiguous `uint64` ndarray.

## Questions for review

None outstanding — both earlier questions were answered on the thread and implemented in phase 4. Ready for your review.
