### PR TITLE
Wire up the arro3-no-pyarrow CI leg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,56 @@ jobs:
         name: codecov-mortie
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Proves the pyarrow-free Arrow C Data carrier (issue #93 / PR #94): arro3-core
+  # installed, pyarrow deliberately absent, so TestArro3Interop actually runs
+  # instead of skipping. Designed on issue #92; wired up for issue #98.
+  arro3-no-pyarrow:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install dependencies (NOTE - no pyarrow)
+      run: |
+        python -m pip install --upgrade pip
+        # pytest-cov: pyproject addopts pass --cov, so bare pytest would error.
+        # arro3-core==0.8.1 is the pinned Lambda version (issue #93 item 2).
+        pip install maturin numpy pandas pytest pytest-cov "arro3-core==0.8.1"
+
+    - name: Build and install mortie
+      run: pip install -e .
+
+    - name: Assert pyarrow is absent
+      run: |
+        if python -c "import pyarrow" 2>/dev/null; then
+          echo "::error::pyarrow is importable in the no-pyarrow leg; it must stay absent"
+          exit 1
+        fi
+        echo "pyarrow absent, as required"
+
+    - name: Run Arrow C Data interop tests (arro3-core, no pyarrow)
+      run: |
+        pytest mortie/tests/test_arrow_cdata.py -v -rs --junitxml=arro3-junit.xml
+
+    - name: Fail if the arro3 interop tests skipped
+      run: |
+        python - <<'EOF'
+        import xml.etree.ElementTree as ET
+
+        cases = [c for c in ET.parse("arro3-junit.xml").getroot().iter("testcase")
+                 if c.get("classname", "").endswith("TestArro3Interop")]
+        assert cases, "no TestArro3Interop tests collected -- the arro3 leg did not run"
+        skipped = [c.get("name") for c in cases if c.find("skipped") is not None]
+        assert not skipped, f"arro3 interop tests skipped instead of running: {skipped}"
+        print(f"TestArro3Interop: {len(cases)} ran, 0 skipped")
+        EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,11 +88,13 @@ jobs:
 
     - name: Assert pyarrow is absent
       run: |
-        if python -c "import pyarrow" 2>/dev/null; then
-          echo "::error::pyarrow is importable in the no-pyarrow leg; it must stay absent"
-          exit 1
-        fi
-        echo "pyarrow absent, as required"
+        python - <<'EOF'
+        import importlib.util
+
+        spec = importlib.util.find_spec("pyarrow")
+        assert spec is None, f"pyarrow is installed in the no-pyarrow leg: {spec.origin}"
+        print("pyarrow absent, as required")
+        EOF
 
     - name: Run Arrow C Data interop tests (arro3-core, no pyarrow)
       run: |


### PR DESCRIPTION
Closes #98. Refs #92, #93.

## What this does

Adds the `arro3-no-pyarrow` job to `test.yml` — the CI leg designed in the [#92 proposal comment](https://github.com/espg/mortie/issues/92#issuecomment-4859163096) but never landed (the routine lacked the `workflow` OAuth scope; #95 closed #92 with only the changelog/codecov fixes). This is the leg that actually exercises `TestArro3Interop` from PR #94: mortie built and installed with **arro3-core 0.8.1 present and pyarrow absent**, proving the pyarrow-free carrier contract zagg's Lambda worker depends on.

The job:

1. installs `maturin numpy pandas pytest pytest-cov "arro3-core==0.8.1"` — **no pyarrow**;
2. builds/installs mortie (`pip install -e .` — numpy is the only runtime dep, so nothing drags pyarrow in transitively);
3. **asserts pyarrow is absent** (`python -c "import pyarrow"` must fail, else the job errors) — so a future transitive pyarrow can't silently un-prove the contract;
4. runs `pytest mortie/tests/test_arrow_cdata.py -v -rs --junitxml=arro3-junit.xml`;
5. **hard-fails on silent skips**: parses the junit XML and errors if `TestArro3Interop` collected zero tests or any of its tests skipped. A leg that quietly skips the arro3 tests would recreate #98, so skipping is a failure, not a pass.

The 9 pyarrow-gated skips in the rest of `test_arrow_cdata.py` are expected in this leg (that's the point); the guard is scoped to `TestArro3Interop` only. The full pyarrow-dependent suite stays in the existing `test` matrix job, untouched.

## Deltas from the #92-proposed YAML

- `pip install` list gains **`pytest-cov`** — `pyproject.toml`'s pytest `addopts` pass `--cov=mortie`, so bare `pytest` errors with "unrecognized arguments" without it.
- `maturin develop --release` → **`pip install -e .`** — `maturin develop` requires an activated virtualenv/conda env, which a plain `setup-python` runner doesn't provide; `pip install -e .` builds through the maturin backend (release profile) exactly like the existing `test` job.
- Added the pyarrow-absence assertion and the junit skip guard (steps 3 and 5 above) — the issue #98 requirement beyond the original sketch.
- Steps carry names matching the existing job's style; everything else (ubuntu-latest, Python 3.11, `dtolnay/rust-toolchain@stable`, `arro3-core==0.8.1` pin, scope limited to `test_arrow_cdata.py`) is as proposed.

## How it was tested

Local dry-run of the exact leg semantics (macOS arm64, Python 3.11.9, cargo 1.96.0, maturin 1.14.1): built the wheel with `maturin build --release`, installed it into a fresh venv with `numpy pandas pytest pytest-cov "arro3-core==0.8.1"` and **no pyarrow** (`import pyarrow` fails; `pip list` shows no pyarrow), ran `test_arrow_cdata.py`:

- **14 passed, 9 skipped** — all 9 skips are `importorskip("pyarrow")` in `TestPyarrowInterop`, as designed;
- **all 4 `TestArro3Interop` tests passed** (extension-metadata consume, null round-trip, chunked stream, no-pyarrow-symbol check);
- the junit guard script run against that report prints `TestArro3Interop: 4 ran, 0 skipped` and was also verified to fail on a skipped/missing class.

Workflow YAML parses clean (`yaml.safe_load`). The real proof is this PR's own CI run of the new job — see the `arro3-no-pyarrow` check on this PR.

## Questions for review

- The guard requires ≥1 `TestArro3Interop` test collected and 0 skipped, rather than pinning the exact count (currently 4), so adding an arro3 test doesn't need a workflow edit. Pinning `len(cases) == 4` is the stricter alternative if you'd rather be alerted on count drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
