### PR TITLE
Decimal-string display & casting layer for morton_index

### DIFF
--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -30,6 +30,40 @@ __all__ = ["MortonIndexScalar"]
 MAX_ORDER = 29
 
 
+def _decimal_to_word(s):
+    """Parse a decimal Morton string back to its packed word (issue #104).
+
+    The inverse of the decode-through-kernel repr: sign + leading base digit
+    (``1..6``) then one ``1..4`` digit per order. Raises ``ValueError`` on any
+    malformed id. Order-29 strings parse to the *area* word -- the point/area
+    flag is not part of the decimal form, so the point word is unreachable
+    from its repr (the documented non-injectivity).
+    """
+    body = s[1:] if s.startswith("-") else s
+    if not (body.isdigit() and body.isascii()):
+        raise ValueError(f"malformed decimal Morton id {s!r}")
+    lead, digits = int(body[0]), body[1:]
+    if not 1 <= lead <= 6:
+        raise ValueError(
+            f"decimal Morton id {s!r}: base digit {lead} outside 1..6"
+        )
+    order = len(digits)
+    if order > MAX_ORDER:
+        raise ValueError(
+            f"decimal Morton id {s!r}: order {order} exceeds {MAX_ORDER}"
+        )
+    within = 0
+    for d in digits:
+        if not "1" <= d <= "4":
+            raise ValueError(
+                f"decimal Morton id {s!r}: digit {d} outside 1..4"
+            )
+        within = (within << 2) | (int(d) - 1)
+    base = lead + 5 if s.startswith("-") else lead - 1
+    nested = np.asarray([(base << (2 * order)) | within], dtype=np.uint64)
+    return int(_rustie.rust_mi_from_nested(nested, order)[0])
+
+
 class MortonIndexScalar(np.uint64):
     """A packed ``morton_index`` word that displays as its decimal string.
 
@@ -501,6 +535,63 @@ def _build_classes():
                     f"{int(orders.max())}); use to_decimal() for orders 19-29"
                 )
             return np.asarray([int(s) for s in strings], dtype=np.int64)
+
+        def hive_path(self, root="", suffix=".zarr"):
+            """Hive-layout path per element (issue #104; spec lands on #62).
+
+            The ``morton-hive/1`` convention (zagg's sparse-coverage design
+            record): one decimal digit per directory level, the full id as the
+            leaf inside its own node --
+            ``{root}/{sign+base}/{d1}/.../{d_order}/{full_id}{suffix}``, e.g.
+            ``-31123`` -> ``-3/1/1/2/3/-31123.zarr`` and the order-0 ``-3`` ->
+            ``-3/-3.zarr``. Every order is a node, so mixed shard orders nest
+            naturally: a coarser shard's leaf sits in the same directory its
+            finer siblings descend through. Returns a list of ``str``; raises
+            ``ValueError`` on any empty / invalid word.
+            """
+            prefix = root.rstrip("/") + "/" if root else ""
+            paths = []
+            for s in self.decimal_repr():
+                head = 2 if s.startswith("-") else 1
+                levels = "/".join([s[:head], *s[head:]])
+                paths.append(f"{prefix}{levels}/{s}{suffix}")
+            return paths
+
+        @classmethod
+        def from_hive_path(cls, paths, suffix=".zarr"):
+            """Parse hive-layout paths back to words (inverse of hive_path).
+
+            ``paths`` is a single path (``str``) or an iterable of them. The
+            leaf basename carries the full decimal id; when the path also
+            carries the digit directories, they are checked against the leaf
+            and a mis-filed leaf raises ``ValueError`` (a shorter path -- a
+            bare ``{full_id}.zarr`` or one under an arbitrary root -- skips
+            the check for the components it does not have). Order-29 ids
+            parse to the *area* word (see :func:`_decimal_to_word`).
+            """
+            if isinstance(paths, str):
+                paths = [paths]
+            words = []
+            for p in paths:
+                parts = str(p).rstrip("/").split("/")
+                leaf = parts[-1]
+                if suffix and not leaf.endswith(suffix):
+                    raise ValueError(
+                        f"hive leaf {leaf!r} does not end with {suffix!r}"
+                    )
+                dec = leaf[: len(leaf) - len(suffix)] if suffix else leaf
+                word = _decimal_to_word(dec)
+                head = 2 if dec.startswith("-") else 1
+                levels = [dec[:head], *dec[head:]]
+                if len(parts) - 1 >= len(levels):
+                    got = parts[-1 - len(levels):-1]
+                    if got != levels:
+                        raise ValueError(
+                            f"hive path {p!r} directories {'/'.join(got)!r} "
+                            f"do not match leaf id {dec!r}"
+                        )
+                words.append(word)
+            return cls(np.asarray(words, dtype=np.uint64))
 
         # -- repr ------------------------------------------------------------
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -17,6 +17,8 @@ numpy installed. The pandas machinery here is built lazily on first use, and a
 clear ``ImportError`` is raised if the ExtensionArray is touched without pandas.
 """
 
+import os
+
 import numpy as np
 
 from . import _rustie
@@ -93,8 +95,15 @@ class MortonIndexScalar(np.uint64):
         # numpy's numeric __format__ would print the packed word; the display
         # form of a morton_index is its decimal string, so f"{shard_key}" (and
         # any string spec, e.g. ">10") formats that instead. int(self) remains
-        # the escape hatch to format the raw word numerically.
+        # the escape hatch to format the raw word numerically. Old-style
+        # "%d" % key bypasses __format__ entirely and emits the raw word.
         return format(str(self), spec)
+
+    def __reduce__(self):
+        # numpy scalars pickle through multiarray.scalar, which rebuilds the
+        # bare np.uint64 and would silently drop the decimal display on any
+        # process boundary (multiprocessing/dask); rebuild the wrapper instead.
+        return (type(self), (int(self),))
 
 
 def _require_pandas():
@@ -561,15 +570,17 @@ def _build_classes():
         def from_hive_path(cls, paths, suffix=".zarr"):
             """Parse hive-layout paths back to words (inverse of hive_path).
 
-            ``paths`` is a single path (``str``) or an iterable of them. The
-            leaf basename carries the full decimal id; when the path also
-            carries the digit directories, they are checked against the leaf
-            and a mis-filed leaf raises ``ValueError`` (a shorter path -- a
-            bare ``{full_id}.zarr`` or one under an arbitrary root -- skips
-            the check for the components it does not have). Order-29 ids
-            parse to the *area* word (see :func:`_decimal_to_word`).
+            ``paths`` is a single path (``str`` / ``os.PathLike``) or an
+            iterable of them. The leaf basename carries the full decimal id;
+            when the path also carries the digit directories -- recognized by
+            the ``{sign+base}`` component sitting at its slot above the leaf
+            -- the whole chain is checked against the leaf and a mis-filed
+            leaf raises ``ValueError``. A bare ``{full_id}.zarr``, or one
+            under an arbitrary root without the digit chain, skips the check.
+            Order-29 ids parse to the *area* word (see
+            :func:`_decimal_to_word`).
             """
-            if isinstance(paths, str):
+            if isinstance(paths, (str, os.PathLike)):
                 paths = [paths]
             words = []
             for p in paths:
@@ -583,7 +594,14 @@ def _build_classes():
                 word = _decimal_to_word(dec)
                 head = 2 if dec.startswith("-") else 1
                 levels = [dec[:head], *dec[head:]]
-                if len(parts) - 1 >= len(levels):
+                # Enforce the directory cross-check only when the chain is
+                # anchored: the {sign+base} component at its expected slot.
+                # (Root components are indistinguishable from digit dirs by
+                # count alone, so an unanchored tail is treated as root.)
+                if (
+                    len(parts) - 1 >= len(levels)
+                    and parts[-1 - len(levels)] == levels[0]
+                ):
                     got = parts[-1 - len(levels):-1]
                     if got != levels:
                         raise ValueError(

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -24,10 +24,43 @@ from . import _rustie
 # ``MortonIndexDtype`` / ``MortonIndexArray`` are provided via module-level
 # ``__getattr__`` (built lazily so a numpy-only install can import this module),
 # so they are intentionally not named in ``__all__`` here.
-__all__ = []
+__all__ = ["MortonIndexScalar"]
 
 # HEALPix orders this datatype reaches (0 = base cell, 29 = max resolution).
 MAX_ORDER = 29
+
+
+class MortonIndexScalar(np.uint64):
+    """A packed ``morton_index`` word that displays as its decimal string.
+
+    Element access and iteration on a ``MortonIndexArray`` yield this type
+    (issue #104), so a downstream ``f"{shard_key}"`` prints the decimal Morton
+    id (``-31123`` style) rather than the raw packed word. It subclasses
+    ``numpy.uint64``: comparisons, hashing, and ``int()`` (the packed word)
+    behave exactly like the word itself; only ``str``/``repr`` differ. The
+    empty sentinel renders ``"<NA>"``; a word with an invalid prefix renders
+    ``"<invalid 0x...>"`` rather than raising (a repr must never raise).
+    """
+
+    def __str__(self):
+        word = int(self)
+        if word == 0:
+            return "<NA>"
+        try:
+            return _rustie.rust_mi_decimal_repr(
+                np.asarray([word], dtype=np.uint64)
+            )[0]
+        except ValueError:
+            return f"<invalid {word:#018x}>"
+
+    __repr__ = __str__
+
+    def __format__(self, spec):
+        # numpy's numeric __format__ would print the packed word; the display
+        # form of a morton_index is its decimal string, so f"{shard_key}" (and
+        # any string spec, e.g. ">10") formats that instead. int(self) remains
+        # the escape hatch to format the raw word numerically.
+        return format(str(self), spec)
 
 
 def _require_pandas():
@@ -272,7 +305,7 @@ def _build_classes():
         def __getitem__(self, item):
             result = self._data[item]
             if np.isscalar(result) or isinstance(result, np.integer):
-                return np.uint64(result)
+                return MortonIndexScalar(result)
             return type(self)(result)
 
         def __setitem__(self, key, value):
@@ -435,13 +468,8 @@ def _build_classes():
         # -- repr ------------------------------------------------------------
 
         def _word_repr(self, word):
-            """Compact ``base/order`` label for one packed word."""
-            w = np.asarray([word], dtype=np.uint64)
-            if word == int(self._SENTINEL):
-                return "<NA>"
-            base = int(_rustie.rust_mi_base_cell_of(w)[0])
-            order = int(_rustie.rust_mi_order_of(w)[0])
-            return f"base={base} order={order}"
+            """Decimal-string label for one packed word (issue #104)."""
+            return str(MortonIndexScalar(word))
 
         def __repr__(self):
             n = len(self)

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -581,11 +581,18 @@ def _build_classes():
             Order-29 ids parse to the *area* word (see
             :func:`_decimal_to_word`).
             """
+            import pathlib
+
             if isinstance(paths, (str, os.PathLike)):
                 paths = [paths]
             words = []
             for p in paths:
-                parts = str(p).rstrip("/").split("/")
+                if isinstance(p, pathlib.PurePath):
+                    # honor the path's own flavor: a WindowsPath splits on
+                    # backslashes too, which a raw "/"-split would not
+                    parts = list(p.parts)
+                else:
+                    parts = str(p).rstrip("/").split("/")
                 leaf = parts[-1]
                 if suffix and not leaf.endswith(suffix):
                     raise ValueError(

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -461,9 +461,46 @@ def _build_classes():
             produced by *decoding* each word (the canonical render-only repr;
             backward-compatible with the legacy ``str(legacy_i64)`` for orders
             0..=18, the natural extension for 19..=29). Raises ``ValueError`` on
-            any empty / invalid word.
+            any empty / invalid word. Note the repr is not injective across
+            kinds: an order-29 *point* renders identically to the order-29
+            *area* on the same path (the point/area flag is not part of the
+            decimal form).
             """
             return _rustie.rust_mi_decimal_repr(self._data)
+
+        def to_decimal(self):
+            """Vectorized decimal-string emit as a fixed-width numpy array.
+
+            The always-strings interchange convention from issue #48: returns
+            the decode-through-kernel decimal strings as a ``"<U31"`` numpy
+            array (sign + base digit + 29 order digits is the widest form, so
+            the width is order-independent and stable across arrays). Raises
+            ``ValueError`` on any empty / invalid word. Same non-injectivity
+            note as :meth:`decimal_repr`: point and area render identically at
+            order 29.
+            """
+            return np.asarray(self.decimal_repr(), dtype="<U31")
+
+        def to_legacy_i64(self):
+            """Emit the legacy signed decimal ``int64`` form (orders <= 18).
+
+            The named escape hatch from issue #48's emit conventions --
+            interchange is always the decimal *string* (:meth:`to_decimal`),
+            storage the packed ``uint64``; this exists solely for testing new
+            output against old pinned values (pairing with
+            :meth:`from_legacy`). Any element above order 18 raises
+            ``ValueError`` (the legacy decimal overflows ``int64`` above
+            that), as does any empty / invalid word -- never truncated, never
+            data-dependent.
+            """
+            strings = self.decimal_repr()  # raises on empty / invalid words
+            orders = self.orders()
+            if len(self) and int(orders.max()) > 18:
+                raise ValueError(
+                    f"to_legacy_i64 is capped at order 18 (array holds order "
+                    f"{int(orders.max())}); use to_decimal() for orders 19-29"
+                )
+            return np.asarray([int(s) for s in strings], dtype=np.int64)
 
         # -- repr ------------------------------------------------------------
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -570,12 +570,13 @@ def _build_classes():
         def from_hive_path(cls, paths, suffix=".zarr"):
             """Parse hive-layout paths back to words (inverse of hive_path).
 
-            ``paths`` is a single path (``str`` / ``os.PathLike``) or an
-            iterable of them. The leaf basename carries the full decimal id;
-            when the path also carries the digit directories -- recognized by
-            the ``{sign+base}`` component sitting at its slot above the leaf
-            -- the whole chain is checked against the leaf and a mis-filed
-            leaf raises ``ValueError``. A bare ``{full_id}.zarr``, or one
+            ``paths`` is a single slash-separated path (``str`` /
+            ``os.PathLike``) or an iterable of them. The leaf basename
+            carries the full decimal id; when the path also carries the digit
+            directories -- recognized by a ``{sign+base}``-shaped component
+            sitting at its slot above the leaf -- the whole chain is checked
+            against the leaf and a mis-filed leaf (wrong base cell, wrong
+            descent) raises ``ValueError``. A bare ``{full_id}.zarr``, or one
             under an arbitrary root without the digit chain, skips the check.
             Order-29 ids parse to the *area* word (see
             :func:`_decimal_to_word`).
@@ -595,13 +596,17 @@ def _build_classes():
                 head = 2 if dec.startswith("-") else 1
                 levels = [dec[:head], *dec[head:]]
                 # Enforce the directory cross-check only when the chain is
-                # anchored: the {sign+base} component at its expected slot.
-                # (Root components are indistinguishable from digit dirs by
-                # count alone, so an unanchored tail is treated as root.)
-                if (
+                # anchored: a {sign+base}-shaped component (optional "-" plus
+                # one digit 1..6) at its expected slot. Anchoring on shape --
+                # not equality with the leaf's own sign+base -- keeps a
+                # mis-filed wrong-base leaf detectable while still treating
+                # an arbitrary root as skippable (root components are
+                # indistinguishable from digit dirs by count alone).
+                anchor = parts[-1 - len(levels)] if (
                     len(parts) - 1 >= len(levels)
-                    and parts[-1 - len(levels)] == levels[0]
-                ):
+                ) else ""
+                body = anchor[1:] if anchor.startswith("-") else anchor
+                if len(body) == 1 and "1" <= body <= "6":
                     got = parts[-1 - len(levels):-1]
                     if got != levels:
                         raise ValueError(

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -372,6 +372,62 @@ class TestReprAndPandas:
 
 
 # ---------------------------------------------------------------------------
+# decimal-string display layer (issue #104)
+# ---------------------------------------------------------------------------
+
+
+class TestDecimalDisplay:
+    """Element display is the decode-through-kernel decimal string."""
+
+    def test_element_repr_is_decimal_string(self):
+        a = MIA.from_legacy(np.array([-31123, 41123], dtype=np.int64))
+        assert a._word_repr(int(a._data[0])) == "-31123"
+        assert a._word_repr(int(a._data[1])) == "41123"
+
+    def test_array_repr_decimal_elements_with_summary_header(self):
+        a = MIA.from_legacy(np.array([-31123, 41123], dtype=np.int64))
+        r = repr(a)
+        assert "-31123" in r and "41123" in r
+        assert "len=2" in r and "order=4" in r
+        assert "base=" not in r  # the old per-element label is gone
+
+    def test_scalar_wrapper_str_repr_int(self):
+        from mortie.morton_index import MortonIndexScalar
+
+        a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
+        s = a[0]
+        assert isinstance(s, MortonIndexScalar)
+        assert isinstance(s, np.uint64)  # still a word for compute paths
+        assert str(s) == "-31123"
+        assert repr(s) == "-31123"
+        assert f"{s}" == "-31123"
+        assert int(s) == int(a._data[0])
+        assert s == a._data[0]  # comparisons stay word-valued
+
+    def test_scalar_wrapper_na_and_invalid_never_raise(self):
+        from mortie.morton_index import MortonIndexScalar
+
+        assert str(MortonIndexScalar(0)) == "<NA>"
+        # prefix 15 is outside the valid 1..=12 range; repr must not raise
+        assert str(MortonIndexScalar(0xF000000000000000)).startswith("<invalid")
+
+    def test_series_repr_prints_decimal(self):
+        a = MIA.from_legacy(np.array([-31123, 41123], dtype=np.int64))
+        text = repr(pd.Series(a))
+        assert "-31123" in text and "41123" in text
+
+    def test_display_matches_kernel_across_orders(self):
+        for base in (0, 5, 11):
+            for order in (0, 1, 18, 19, MAX_ORDER):
+                tuples = _sample_tuples(order, base + 1)
+                nested = _nested_from_tuples(base, tuples, order)
+                a = MIA.from_nested(np.array([nested], dtype=np.uint64), order)
+                expect = _rustie.rust_mi_decimal_repr(a._data)[0]
+                assert a._word_repr(int(a._data[0])) == expect
+                assert str(a[0]) == expect
+
+
+# ---------------------------------------------------------------------------
 # encode / decode bindings
 # ---------------------------------------------------------------------------
 

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -404,6 +404,29 @@ class TestDecimalDisplay:
         assert int(s) == int(a._data[0])
         assert s == a._data[0]  # comparisons stay word-valued
 
+    def test_scalar_wrapper_format_specs(self):
+        a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
+        s = a[0]
+        # string specs format the decimal string
+        assert f"{s:>10}" == "    -31123"
+        # numeric specs raise: the display form is a string; int(s) is the
+        # escape hatch for formatting the raw word numerically
+        with pytest.raises(ValueError):
+            f"{s:d}"
+        # old-style %-formatting bypasses __format__ and emits the raw word
+        assert ("%d" % s) == str(int(s))
+
+    def test_scalar_wrapper_pickles_as_itself(self):
+        import pickle
+
+        from mortie.morton_index import MortonIndexScalar
+
+        a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
+        s = pickle.loads(pickle.dumps(a[0]))
+        assert isinstance(s, MortonIndexScalar)
+        assert str(s) == "-31123"
+        assert int(s) == int(a._data[0])
+
     def test_scalar_wrapper_na_and_invalid_never_raise(self):
         from mortie.morton_index import MortonIndexScalar
 
@@ -528,9 +551,26 @@ class TestHivePath:
         bare = MIA.from_hive_path("-31123.zarr")
         assert int(bare._data[0]) == int(a._data[0])
 
+    def test_pathlike_input(self):
+        from pathlib import Path
+
+        a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
+        one = MIA.from_hive_path(Path("-3/1/1/2/3/-31123.zarr"))
+        assert int(one._data[0]) == int(a._data[0])
+
+    def test_bare_leaf_under_root_skips_dir_check(self):
+        # root components are not digit directories: the check only engages
+        # when the {sign+base} anchor sits at its slot above the leaf
+        a = MIA.from_legacy(np.array([-3], dtype=np.int64))
+        for p in ("s3://bucket/-3.zarr", "x/-3.zarr", "a/b/c/-3.zarr"):
+            assert int(MIA.from_hive_path(p)._data[0]) == int(a._data[0])
+
     def test_misfiled_leaf_raises(self):
         with pytest.raises(ValueError, match="do not match leaf"):
             MIA.from_hive_path("-3/1/1/2/4/-31123.zarr")
+        # anchored but wrong descent raises too
+        with pytest.raises(ValueError, match="do not match leaf"):
+            MIA.from_hive_path("-3/x/1/2/3/-31123.zarr")
 
     def test_malformed_ids_raise(self):
         from mortie.morton_index import _decimal_to_word

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -479,6 +479,74 @@ class TestDecimalDisplay:
                 assert str(a[0]) == expect
 
 
+class TestHivePath:
+    """hive_path / from_hive_path round-trips (issue #104; spec on #62)."""
+
+    def test_layout_one_digit_per_level_full_id_leaf(self):
+        a = MIA.from_legacy(np.array([-31123, 41123], dtype=np.int64))
+        assert a.hive_path() == [
+            "-3/1/1/2/3/-31123.zarr",
+            "4/1/1/2/3/41123.zarr",
+        ]
+
+    def test_order_zero_leaf_sits_in_base_node(self):
+        a = MIA.from_legacy(np.array([-3, 4], dtype=np.int64))
+        assert a.hive_path() == ["-3/-3.zarr", "4/4.zarr"]
+
+    def test_root_and_suffix(self):
+        a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
+        assert a.hive_path(root="s3://bucket/store/") == [
+            "s3://bucket/store/-3/1/1/2/3/-31123.zarr"
+        ]
+        assert a.hive_path(suffix="") == ["-3/1/1/2/3/-31123"]
+
+    def test_mixed_orders_nest(self):
+        # the order-3 shard's leaf sits in the directory its order-4
+        # sibling descends through
+        a = MIA.from_legacy(np.array([-3112, -31123], dtype=np.int64))
+        coarse, fine = a.hive_path()
+        assert coarse == "-3/1/1/2/-3112.zarr"
+        assert fine.startswith("-3/1/1/2/3/")
+
+    def test_round_trip(self):
+        a = MIA.from_legacy(np.array([-31123, 41123, -3], dtype=np.int64))
+        back = MIA.from_hive_path(a.hive_path(root="s3://bucket/x"))
+        np.testing.assert_array_equal(back._data, a._data)
+
+    def test_round_trip_high_order(self):
+        deep = MIA.from_nested(
+            np.array([11 << (2 * MAX_ORDER), 5], dtype=np.uint64), MAX_ORDER
+        )
+        back = MIA.from_hive_path(deep.hive_path())
+        np.testing.assert_array_equal(back._data, deep._data)
+
+    def test_single_path_and_bare_leaf(self):
+        a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
+        one = MIA.from_hive_path("-3/1/1/2/3/-31123.zarr")
+        assert len(one) == 1 and int(one._data[0]) == int(a._data[0])
+        # a bare leaf (no digit directories) parses too
+        bare = MIA.from_hive_path("-31123.zarr")
+        assert int(bare._data[0]) == int(a._data[0])
+
+    def test_misfiled_leaf_raises(self):
+        with pytest.raises(ValueError, match="do not match leaf"):
+            MIA.from_hive_path("-3/1/1/2/4/-31123.zarr")
+
+    def test_malformed_ids_raise(self):
+        from mortie.morton_index import _decimal_to_word
+
+        for bad in ("", "-", "0123", "7123", "31023", "3125", "x123",
+                    "3" + "1" * 30):
+            with pytest.raises(ValueError):
+                _decimal_to_word(bad)
+        with pytest.raises(ValueError, match="does not end with"):
+            MIA.from_hive_path("-3/1/-31.parquet")
+
+    def test_sentinel_raises(self):
+        with pytest.raises(ValueError):
+            MIA(np.array([0], dtype=np.uint64)).hive_path()
+
+
 # ---------------------------------------------------------------------------
 # encode / decode bindings
 # ---------------------------------------------------------------------------

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -571,6 +571,18 @@ class TestHivePath:
         # anchored but wrong descent raises too
         with pytest.raises(ValueError, match="do not match leaf"):
             MIA.from_hive_path("-3/x/1/2/3/-31123.zarr")
+        # a wrong *base* directory is still base-shaped, so it anchors the
+        # check and raises rather than being mistaken for a root component
+        with pytest.raises(ValueError, match="do not match leaf"):
+            MIA.from_hive_path("-4/1/1/2/3/-31123.zarr")
+        with pytest.raises(ValueError, match="do not match leaf"):
+            MIA.from_hive_path("2/1/1/2/3/41123.zarr")
+
+    def test_root_ending_in_digit_chain_still_parses(self):
+        # the anchor slot holding the id's own sign+base under a real root
+        a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
+        p = "data/2023/-3/1/1/2/3/-31123.zarr"
+        assert int(MIA.from_hive_path(p)._data[0]) == int(a._data[0])
 
     def test_malformed_ids_raise(self):
         from mortie.morton_index import _decimal_to_word

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -552,11 +552,14 @@ class TestHivePath:
         assert int(bare._data[0]) == int(a._data[0])
 
     def test_pathlike_input(self):
-        from pathlib import Path
+        from pathlib import Path, PureWindowsPath
 
         a = MIA.from_legacy(np.array([-31123], dtype=np.int64))
         one = MIA.from_hive_path(Path("-3/1/1/2/3/-31123.zarr"))
         assert int(one._data[0]) == int(a._data[0])
+        # a Windows-flavored path splits on its own separators
+        win = MIA.from_hive_path(PureWindowsPath(r"-3\1\1\2\3\-31123.zarr"))
+        assert int(win._data[0]) == int(a._data[0])
 
     def test_bare_leaf_under_root_skips_dir_check(self):
         # root components are not digit directories: the check only engages

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -416,6 +416,58 @@ class TestDecimalDisplay:
         text = repr(pd.Series(a))
         assert "-31123" in text and "41123" in text
 
+    def test_to_decimal_fixed_width(self):
+        a = MIA.from_legacy(np.array([-31123, 41123], dtype=np.int64))
+        out = a.to_decimal()
+        assert out.dtype == np.dtype("<U31")
+        np.testing.assert_array_equal(
+            out, np.array(["-31123", "41123"], dtype="<U31")
+        )
+        # width holds the widest form: southern order-29 is 31 chars
+        deep = MIA.from_nested(
+            np.array([11 << (2 * MAX_ORDER)], dtype=np.uint64), MAX_ORDER
+        )
+        s = deep.to_decimal()[0]
+        assert len(s) == 31 and s.startswith("-6")
+
+    def test_to_decimal_empty_and_invalid(self):
+        assert MIA(np.empty(0, dtype=np.uint64)).to_decimal().shape == (0,)
+        with pytest.raises(ValueError):
+            MIA(np.array([0], dtype=np.uint64)).to_decimal()
+
+    def test_to_legacy_i64_round_trips(self):
+        legacy = np.array([-31123, 41123, 1, -6], dtype=np.int64)
+        a = MIA.from_legacy(legacy)
+        out = a.to_legacy_i64()
+        assert out.dtype == np.int64
+        np.testing.assert_array_equal(out, legacy)
+        # and the pair is a true inverse
+        np.testing.assert_array_equal(
+            MIA.from_legacy(out)._data, a._data
+        )
+
+    def test_to_legacy_i64_hard_error_above_order_18(self):
+        a = MIA.from_nested(np.array([5], dtype=np.uint64), 19)
+        with pytest.raises(ValueError, match="capped at order 18"):
+            a.to_legacy_i64()
+        # mixed: one legal element does not soften the error
+        mixed = MIA(
+            np.concatenate(
+                [
+                    MIA.from_nested(np.array([5], dtype=np.uint64), 3)._data,
+                    a._data,
+                ]
+            )
+        )
+        with pytest.raises(ValueError, match="capped at order 18"):
+            mixed.to_legacy_i64()
+
+    def test_to_legacy_i64_empty_and_sentinel(self):
+        out = MIA(np.empty(0, dtype=np.uint64)).to_legacy_i64()
+        assert out.dtype == np.int64 and out.shape == (0,)
+        with pytest.raises(ValueError):
+            MIA(np.array([0], dtype=np.uint64)).to_legacy_i64()
+
     def test_display_matches_kernel_across_orders(self):
         for base in (0, 5, 11):
             for order in (0, 1, 18, 19, MAX_ORDER):

--- a/mortie/tests/test_packed_golden.py
+++ b/mortie/tests/test_packed_golden.py
@@ -224,3 +224,90 @@ def test_morton_index_array_legacy_and_repr():
     )
     arr = MIA.from_legacy(legacy)
     assert arr.decimal_repr() == [str(int(x)) for x in legacy]
+
+
+# ---------------------------------------------------------------------------
+# string-layer golden pins (issue #104): the display / emit / hive-path
+# surface renders the same pinned decimal strings, so it joins the frozen 1.x
+# contract through the same fixture.
+# ---------------------------------------------------------------------------
+
+
+def _string_layer_array():
+    import pytest
+
+    pytest.importorskip("pandas")
+    from mortie import MortonIndexArray as MIA
+
+    records = _load_fixture()["records"]
+    words = np.asarray([r["word"] for r in records], dtype=np.uint64)
+    return MIA(words), [r["decimal_repr"] for r in records], records
+
+
+def test_golden_string_emit_layer():
+    """to_decimal / _word_repr / scalar str all pin to the fixture strings."""
+    arr, reprs, _ = _string_layer_array()
+    out = arr.to_decimal()
+    assert out.dtype == np.dtype("<U31")
+    np.testing.assert_array_equal(out, np.asarray(reprs, dtype="<U31"))
+    # spot-check the element formatter and the scalar wrapper on the extremes
+    for i in (0, 1, len(reprs) // 2, len(reprs) - 1):
+        assert arr._word_repr(int(arr._data[i])) == reprs[i]
+        assert str(arr[i]) == reprs[i]
+
+
+def test_golden_to_legacy_i64_orders_0_to_18():
+    """to_legacy_i64 equals the pinned decimal read as an integer (0-18)."""
+    import pytest
+
+    pytest.importorskip("pandas")
+    from mortie import MortonIndexArray as MIA
+
+    _, _, records = _string_layer_array()
+    legal = [r for r in records if r["order"] <= 18]
+    arr = MIA(np.asarray([r["word"] for r in legal], dtype=np.uint64))
+    np.testing.assert_array_equal(
+        arr.to_legacy_i64(),
+        np.asarray([int(r["decimal_repr"]) for r in legal], dtype=np.int64),
+    )
+
+
+def test_golden_hive_path_round_trip():
+    """hive_path over every fixture word parses back to the same words."""
+    arr, reprs, _ = _string_layer_array()  # skips first if pandas is absent
+    from mortie import MortonIndexArray as MIA
+    paths = arr.hive_path()
+    back = MIA.from_hive_path(paths)
+    np.testing.assert_array_equal(back._data, arr._data)
+    # pin the literal layout on representative ids (order 0, mid, deep south)
+    by_repr = dict(zip(reprs, paths))
+    assert by_repr["3"] == "3/3.zarr"
+    assert by_repr["-1"] == "-1/-1.zarr"
+    assert by_repr["31111"] == "3/1/1/1/1/31111.zarr"
+    assert by_repr["-64444"] == "-6/4/4/4/4/-64444.zarr"
+
+
+def test_golden_repr_not_injective_point_vs_area():
+    """An order-29 point renders identically to the area on the same path.
+
+    The point/area flag is not part of the decimal form (documented on
+    decimal_repr / to_decimal), so the repr is not injective across kinds --
+    the words differ, the strings do not, and parsing the string back always
+    lands on the area word.
+    """
+    import pytest
+
+    pytest.importorskip("pandas")
+    from mortie import MortonIndexArray as MIA
+    from mortie.morton_index import _decimal_to_word
+
+    nested = np.asarray(
+        [_nested_from_tuples(4, _variant_tuples("seed", MAX_ORDER, 9),
+                             MAX_ORDER)],
+        dtype=np.uint64,
+    )
+    area = MIA(_rustie.rust_mi_from_nested(nested, MAX_ORDER))
+    point = MIA(_rustie.rust_mi_from_nested_point(nested))
+    assert int(area._data[0]) != int(point._data[0])
+    assert area.decimal_repr() == point.decimal_repr()
+    assert _decimal_to_word(point.decimal_repr()[0]) == int(area._data[0])


### PR DESCRIPTION
Closes #104. Refs #48 (emit-conventions decisions), #62 (spec page the hive convention lands on).

## What this does

The user-visible half of the repr/casting layer settled on #48: printed shard ids downstream (zagg) currently resolve to raw packed-word integers because the `morton_index` skin never renders the decode-through-kernel decimal string. The Rust layer (`to_decimal_repr`, `rust_mi_decimal_repr`, `from_legacy_decimal`) is already merged and pinned; this PR wires the Python surface to it.

## Phases

- [x] **Phase 1 — element display = the decimal string.** `MortonIndexArray._word_repr` / `_formatter` / `__repr__` now render each element as its decimal Morton id (`-31123` style) instead of the old `base=X order=Y` label; the `len=N, order=K` summary stays in the array-level header. Adds the lightweight scalar wrapper `MortonIndexScalar(np.uint64)`, returned from element access/iteration: `__str__`/`__repr__`/`__format__` are the decimal string, `int()` is the packed word, and comparisons/hashing stay word-valued. The empty sentinel renders `<NA>`; an invalid prefix renders `<invalid 0x...>` rather than raising (a repr must never raise). `__format__` is overridden because numpy's numeric formatting would otherwise print the packed word through `f"{shard_key}"` — exactly the downstream case the issue calls out.
- [x] **Phase 2 — vectorized emit + legacy escape hatch.** `to_decimal()` returns the decimal strings as a fixed-width numpy `<U31` array (sign + base digit + 29 order digits is the widest form, so the width is order-independent and stable across arrays). `to_legacy_i64()` emits the signed decimal `int64` for orders ≤ 18 with a **hard `ValueError` above** (pairs with the existing `from_legacy`; a mixed array with any element above 18 errors — never truncated, never data-dependent, per the #48 emit conventions).
- [x] **Phase 3 — `hive_path()` + inverse parser.** `hive_path(root="", suffix=".zarr")` emits `{root}/{sign+base}/{d1}/…/{d_order}/{full_id}.zarr` (one digit per level, full-id leaf inside its own node; order-0 `-3` → `-3/-3.zarr`), so mixed shard orders nest naturally — every order is a node. `from_hive_path` parses the leaf basename back to words via the new `_decimal_to_word` (full validation: base digit 1–6, order digits 1–4, order ≤ 29) and cross-checks the digit directories against the leaf id when the chain is present.
- [x] **Phase 4 — golden fixtures.** The string layer is pinned through the existing `packed_u64_golden.json` (all 1,080 records): `to_decimal`/`_word_repr`/scalar `str` equal the pinned `decimal_repr` strings, `to_legacy_i64` equals the pinned decimal read as an integer for orders 0–18, and `hive_path`→`from_hive_path` round-trips every fixture word, with literal layout pins for representative ids. Plus the documented non-injectivity test: an order-29 *point* renders identically to the *area* on the same path (words differ, strings don't, and parsing the string lands on the area word).
- [x] **Phase 5 — folded self-review findings (round 1).** (a) `MortonIndexScalar.__reduce__` so pickling preserves the wrapper across process boundaries (multiprocessing/dask) + pinning test; (b) tests pinning `__format__` for string specs, numeric specs (raise), and old-style `%`-formatting (bypasses `__format__`, emits the raw word — documented in-line); (c) `from_hive_path` accepts a single `os.PathLike`; (d) first cut of the directory cross-check anchor. The NA-boxing and per-call-FFI review notes are answered on their threads as recorded decisions.
- [x] **Phase 6 — folded self-review findings (round 2).** The converging review demonstrated phase 5's anchor (equality with the leaf's own sign+base) regressed the wrong-base case (`-4/1/1/2/3/-31123.zarr` silently parsed). The anchor is now the sign+base **shape** (optional `-` + digit 1..6) at its slot: wrong-base and wrong-descent mis-filings raise again (pinned), arbitrary roots still skip, and a real root above a full chain parses (pinned).
- [x] **Phase 7 — Windows-flavored paths.** `from_hive_path` splits `PurePath` inputs via their own `.parts` (a `WindowsPath` honors backslashes; raw strings keep exact `"/"`-split semantics), pinned with a `PureWindowsPath` round-trip that runs on the ubuntu CI.

## How it was tested

- `maturin develop --release` (no Rust change; ext rebuilt at current `main`), `flake8 mortie --select=E9,F63,F7,F82` clean; the 88-col style pass is clean on all touched files.
- `pytest -v` — **578 passed, 11 skipped** (30 new: `TestDecimalDisplay`, `TestHivePath`, and 4 golden string-layer pins in `test_packed_golden.py`).
- Three adversarial self-review rounds ran (phase 1; phases 2–4; phase 5) and converged — every diff-scoped finding is folded (phases 5–7) or answered on its thread as a recorded decision.

## Questions for review

- **Hive path shape:** the zagg design record (`docs/design/sparse_coverage.md`) gives `{sign+base}/{d1}/{d2}/…/` with a `{full_id}.zarr` leaf; with "every order is a node" I read the leaf as sitting *inside its own* digit directory — `-31123` → `-3/1/1/2/3/-31123.zarr`, and order-0 `-3` → `-3/-3.zarr`. If you read the ellipsis as stopping at `d_{order-1}` instead, say so and I'll flip it (it's one line + the pinned fixtures).
- `__format__` formats the *decimal string* under any format spec (so `f"{key:>10}"` pads the string; numeric specs like `:d` raise — `int(key)` is the escape; `"%d" % key` bypasses `__format__` and emits the raw word). All three behaviors are pinned by tests; flagging in case you'd rather have numeric specs fall through to the word.
- `__getitem__` on a missing entry returns `MortonIndexScalar(0)` (renders `<NA>`, but `pd.isna()` is `False`) — pre-existing deviation from the strict ExtensionArray contract, kept deliberately; see the review thread if you want it switched to `pd.NA`.
- `from_hive_path`'s anchored cross-check accepts that a root component coincidentally shaped like `{sign+base}` at exactly its slot with a non-matching descent raises (strict-on-suspicious); flip to lenient if you'd rather never false-reject.