### PR TITLE
Uniform symbolic crossing predicate: fix base-cell-boundary mis-fill

### DIFF
--- a/mortie/tests/test_coverage_boundary.py
+++ b/mortie/tests/test_coverage_boundary.py
@@ -1,0 +1,217 @@
+"""
+Regression matrix for boundary-degenerate polygon coverage (issue #103).
+
+Polygons whose edges lie exactly on the HEALPix degenerate grid — longitudes
+that are multiples of 45 deg (base-cell boundary *and* centre/diagonal
+meridians) and the equator — used to mis-fill catastrophically: the belt box
+with a west edge on lon 0 leaked around the full longitude range, and a cap
+box with an edge on lon 45 escaped to the pole.  The fix (the uniform
+symbolic crossing predicate + exact determinant signs + seed hardening) is
+pinned here by three invariants, checked for every case:
+
+  (a) **superset** — every sampled interior point's cell is in the cover;
+  (b) **no escape** — every covered cell centre stays within a small pad of
+      the box (the closed-set contract adds at most a one-cell fringe);
+  (c) **flat == MOC** — ``morton_coverage`` equals the densified
+      ``morton_coverage_moc``.
+
+The sweep covers all six degenerate meridians x three latitude bands (belt /
+belt-cap transition / polar cap) x both edge sides x both hemispheres — the
+cap rows exercise lon == 45 (mod 90), the pole-escape family a boundary-only
+sweep would miss, and 315 is included explicitly (it behaved asymmetrically
+to 45/135/225 before the fix).  Width cases pin the non-monotone
+opposite-edge dependence, and the flagship reproducers from the issue run at
+their original orders.
+"""
+
+import numpy as np
+import pytest
+
+from mortie import (
+    geo2mort,
+    moc_to_order,
+    mort2geo,
+    morton_coverage,
+    morton_coverage_moc,
+    order2res,
+)
+
+KM_PER_DEG = 111.0
+
+
+def _box(lat_lo, lat_hi, lon_w, lon_e):
+    lats = np.array([lat_lo, lat_lo, lat_hi, lat_hi, lat_lo], dtype=float)
+    lons = np.array([lon_w, lon_e, lon_e, lon_w, lon_w], dtype=float)
+    return [lats], [lons]
+
+
+def _centres(keys):
+    pts = [mort2geo(int(k)) for k in keys]
+    lat = np.array([float(p[0][0]) for p in pts])
+    lon = np.array([float(p[1][0]) for p in pts])
+    return lat, lon
+
+
+def _lon_dist(lon, mid):
+    """Wrap-aware angular distance in longitude degrees."""
+    return np.abs((lon - mid + 180.0) % 360.0 - 180.0)
+
+
+def _bulge(lat, width):
+    """Poleward bulge (degrees) of a great-circle arc between two points at
+    ``lat`` separated by ``width`` degrees of longitude: the arc's extreme
+    latitude is ``atan(tan(lat) / cos(width / 2))``."""
+    la = np.radians(abs(lat))
+    peak = np.degrees(np.arctan(np.tan(la) / np.cos(np.radians(width / 2.0))))
+    return peak - abs(lat)
+
+
+def _check_box(lat_lo, lat_hi, lon_w, lon_e, order, pad_cells=3.0):
+    """Assert the three #103 invariants for a lat/lon box; return the cover."""
+    lats, lons = _box(lat_lo, lat_hi, lon_w, lon_e)
+    flat = np.asarray(morton_coverage(lats, lons, order=order))
+    assert len(flat) > 0
+
+    # (b) no escape: centres within a few cell widths of the box, allowing
+    # for the poleward bulge of the great-circle edges beyond the corner
+    # parallels.
+    pad = pad_cells * order2res(order) / KM_PER_DEG
+    width = lon_e - lon_w
+    clat, clon = _centres(flat)
+    lo_bound = (lat_lo - pad) - (_bulge(lat_lo, width) if lat_lo < 0 else 0.0)
+    hi_bound = (lat_hi + pad) + (_bulge(lat_hi, width) if lat_hi > 0 else 0.0)
+    assert clat.min() >= lo_bound, f"lat escape: {clat.min():.3f} < {lo_bound:.3f}"
+    assert clat.max() <= hi_bound, f"lat escape: {clat.max():.3f} > {hi_bound:.3f}"
+    mid = (lon_w + lon_e) / 2.0
+    half = width / 2.0
+    cos_floor = max(np.cos(np.radians(max(abs(lat_lo), abs(lat_hi)))), 0.05)
+    lon_slack = half + pad / cos_floor
+    worst = _lon_dist(clon, mid).max()
+    assert worst <= lon_slack, f"lon escape: {worst:.3f} > {lon_slack:.3f}"
+
+    # (a) superset: interior sample points' cells are all covered.  The
+    # equatorward great-circle edge bulges poleward *into* the lat/lon
+    # rectangle, so shrink the sampled band past that bulge — points below
+    # it are genuinely outside the spherical polygon.
+    shrink = 0.01
+    s_lo, s_hi = lat_lo, lat_hi
+    if lat_lo >= 0.0:
+        s_lo = lat_lo + _bulge(lat_lo, width) + shrink
+    if lat_hi <= 0.0:
+        s_hi = lat_hi - _bulge(lat_hi, width) - shrink
+    assert s_lo < s_hi, "box too thin to sample its interior"
+    glat = np.linspace(s_lo, s_hi, 12)[1:-1]
+    glon = np.linspace(lon_w, lon_e, 12)[1:-1]
+    mlat, mlon = np.meshgrid(glat, glon)
+    truth = np.asarray(geo2mort(mlat.ravel(), mlon.ravel(), order=order))
+    missing = set(truth.tolist()) - set(flat.tolist())
+    assert not missing, f"under-coverage: {len(missing)} interior cells missing"
+
+    # (c) the flat cover equals the densified MOC cover.
+    moc = np.asarray(morton_coverage_moc(lats, lons, order=order))
+    dens = np.asarray(moc_to_order(moc, order))
+    assert set(dens.tolist()) == set(flat.tolist()), "flat != densified MOC"
+    return flat
+
+
+# The degenerate meridians: base-cell boundaries (0 mod 90) and base-cell
+# centre/diagonals (45 mod 90); 315 pinned explicitly (pre-fix asymmetry).
+MERIDIANS = [0.0, 45.0, 90.0, 135.0, 180.0, 315.0]
+# (lat_lo, lat_hi): equatorial belt, belt-cap transition, polar cap.
+BANDS = [(20.0, 25.0), (35.0, 45.0), (60.0, 65.0)]
+
+
+class TestDegenerateMeridianSweep:
+    """Boxes with an edge exactly on every 45-deg meridian, both sides,
+    three latitude bands, both hemispheres (issue #103)."""
+
+    @pytest.mark.parametrize("lon0", MERIDIANS)
+    @pytest.mark.parametrize("band", BANDS)
+    @pytest.mark.parametrize("side", ["west", "east"])
+    @pytest.mark.parametrize("south", [False, True])
+    def test_edge_on_meridian(self, lon0, band, side, south):
+        lat_lo, lat_hi = band
+        if south:
+            lat_lo, lat_hi = -lat_hi, -lat_lo
+        if side == "west":
+            lon_w, lon_e = lon0, lon0 + 5.0
+        else:
+            lon_w, lon_e = lon0 - 5.0, lon0
+        _check_box(lat_lo, lat_hi, lon_w, lon_e, order=6)
+
+
+class TestEquatorEdges:
+    """Boxes with an edge exactly on the equator, including through the
+    base-cell centre at (0, 0)."""
+
+    @pytest.mark.parametrize(
+        "lat_lo,lat_hi,lon_w,lon_e",
+        [
+            (0.0, 5.0, 100.0, 105.0),  # the issue's bottom-edge reproducer
+            (-5.0, 0.0, 100.0, 105.0),  # top edge on the equator
+            (0.0, 5.0, -2.5, 2.5),  # edge passes through (0, 0) exactly
+            (-5.0, 5.0, 42.5, 47.5),  # straddles equator AND lon 45
+        ],
+    )
+    def test_equator_edge(self, lat_lo, lat_hi, lon_w, lon_e):
+        _check_box(lat_lo, lat_hi, lon_w, lon_e, order=6)
+
+
+class TestOppositeEdgeWidths:
+    """East edge pinned on lon 45; the opposite edge co-determines which
+    probe legs the descent takes (non-monotone pre-fix: 829/66/231/966/957
+    cells for these widths).  All must satisfy the invariants now."""
+
+    @pytest.mark.parametrize("lon_w", [44.0, 40.0, 35.0, 30.0, 0.0])
+    def test_width(self, lon_w):
+        _check_box(60.0, 65.0, lon_w, 45.0, order=6)
+
+
+class TestIssueReproducers:
+    """The flagship reproducers from the issue body / thread, at their
+    original orders, with the pre-fix failure sizes as regression bounds."""
+
+    def test_belt_west_edge_lon0_order9(self):
+        # pre-fix: 1687 cells spanning lon 0..360; control box: 1886 cells.
+        flat = _check_box(20.0, 25.0, 0.0, 5.0, order=9)
+        assert 1600 < len(flat) < 2200
+
+    def test_cap_east_edge_lon45_order6_pole_escape(self):
+        # pre-fix: 829 cells reaching lat 89.3; expected ~13.
+        flat = _check_box(60.0, 65.0, 44.0, 45.0, order=6)
+        assert len(flat) < 40
+
+    def test_cap_mirrors_45_135_225_315(self):
+        # pre-fix: 45/135/225 escaped to the pole, 315 only locally.
+        sizes = set()
+        for lon_e in (45.0, 135.0, 225.0, 315.0):
+            flat = _check_box(60.0, 65.0, lon_e - 1.0, lon_e, order=6)
+            sizes.add(len(flat))
+        assert all(n < 40 for n in sizes)
+
+    def test_southern_mirror(self):
+        flat = _check_box(-65.0, -60.0, 44.0, 45.0, order=6)
+        assert len(flat) < 40
+
+    def test_polar_ring_sector_order9(self):
+        # pre-fix: 775 cells reaching lat -89.91 (the pole); the polygon's
+        # own great-circle south edge dips to -87.53, so the in-band answer
+        # stays above -87.8.
+        lats, lons = _box(-87.0, -86.7, 0.0, 45.0)
+        flat = np.asarray(morton_coverage(lats, lons, order=9))
+        clat, _ = _centres(flat)
+        assert len(flat) < 200, f"sector over-covers: {len(flat)}"
+        assert clat.min() > -87.8, f"pole escape: reaches {clat.min():.2f}"
+        moc = np.asarray(morton_coverage_moc(lats, lons, order=9))
+        dens = np.asarray(moc_to_order(moc, 9))
+        assert set(dens.tolist()) == set(flat.tolist())
+
+    def test_winding_direction_invariant(self):
+        # The same box wound the other way (normalize=True default) must
+        # produce the same cover.
+        lats, lons = _box(60.0, 65.0, 44.0, 45.0)
+        rev = np.asarray(
+            morton_coverage([lats[0][::-1]], [lons[0][::-1]], order=6)
+        )
+        fwd = np.asarray(morton_coverage(lats, lons, order=6))
+        assert set(rev.tolist()) == set(fwd.tolist())

--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -505,19 +505,29 @@ fn edge_crosses_probe(p: &Vec3, q: &Vec3, ip: PointId, iq: PointId, n_pq: &Vec3,
 }
 
 /// Does polygon edge `e` cross **or exactly touch** the cell edge `c1 → c2`
-/// (normal `n_c = c1 × c2`)?  The straddle test's closed-set form (#103):
+/// (normal `n_c = c1 × c2`)?  The straddle test's closed-set form (#103).
 ///
-/// * A **bit-exact zero** determinant is true geometric incidence — a cell
-///   corner on the polygon edge's great circle or a polygon endpoint on the
-///   cell edge's.  HEALPix corners on the lon ≡ 0 mod 45° meridians are
-///   bit-exact (`y == 0.0`), so on-grid input hits this systematically.  It
-///   reports as a hit, making the cell boundary-touching → refined and, at the
-///   target order, included: "a cell whose boundary the polygon touches
-///   *exactly* is always included" (the closed-set contract agreed on #103).
+/// The hot path keeps the exact two-dot shape of the retired `arcs_cross_n`:
+/// corners strictly (beyond [`ORIENT_EPS`]) on one side of the polygon edge's
+/// great circle exit immediately — the CodSpeed-visible cost of computing all
+/// four determinants up front was a ~19% coverage regression.  Degenerate
+/// configurations take the closed-set logic:
+///
+/// * A **bit-exact zero** determinant with the incident point inside the
+///   *segment* cap (angular slack, `sin ρ`-scaled) is true geometric
+///   incidence — the cell is boundary-touching → refined → included ("a cell
+///   whose boundary the polygon touches exactly is always included").
 /// * A near-zero (< [`ORIENT_EPS`]) but nonzero determinant routes to the
-///   symbolic [`arcs_cross_sos`] for an exact crossing verdict (a 1-ulp-off
-///   edge resolves deterministically to one side — not closed-set).
-/// * Otherwise the plain sign test, unchanged (the hot path).
+///   symbolic [`arcs_cross_sos`] for an exact verdict (a 1-ulp-off edge
+///   resolves deterministically to one side — not closed-set).
+///
+/// One documented nuance of the fast exit: a polygon **vertex-point** lying
+/// exactly on this cell edge while the polygon stays strictly outside the
+/// cell (corners strictly one side, no crossing) is not detected here, so
+/// only the vertex's leaf-owning cell (the vertex-in-cell clause) is
+/// guaranteed for a pure point-touch.  Edge-collinear touches — the
+/// systematic on-grid family the closed-set contract exists for — always
+/// make `d1`/`d2` degenerate and are fully honored.
 ///
 /// Cell corners are one-shot derived points ([`CORNER_ID_A`]/[`CORNER_ID_B`]):
 /// only distinctness matters within a call — this feeds the straddle boolean,
@@ -526,43 +536,38 @@ fn edge_crosses_probe(p: &Vec3, q: &Vec3, ip: PointId, iq: PointId, n_pq: &Vec3,
 fn edge_hits_cell_edge(e: &Edge, c1: &Vec3, c2: &Vec3, n_c: &Vec3) -> bool {
     let d1 = dot(&e.n_ab, c1);
     let d2 = dot(&e.n_ab, c2);
+    let degenerate12 = d1.abs() < ORIENT_EPS || d2.abs() < ORIENT_EPS;
+    if !degenerate12 && (d1 > 0.0) == (d2 > 0.0) {
+        return false; // hot exit: corners strictly on one side
+    }
     let d3 = dot(n_c, &e.a);
     let d4 = dot(n_c, &e.b);
-    // Exact incidence ⇒ closed-set touch — but only when the incident point
-    // lies within the *segment* (its bounding cap), not merely on the infinite
-    // great circle: an on-grid meridian edge's circle runs to the poles, and
-    // gating on the circle alone emitted a spurious strip of cells along it
-    // far beyond the polygon.
-    // The span slack is *angular* (cos(ρ+ε) ≈ cos ρ − ε·sin ρ): a bare
-    // cos-space epsilon would floor the angular slack at √(2ε) ≈ 1.4e-6 rad
-    // for short segments, gating vertices hundreds of cell-widths away as
-    // "touching" at fine orders.
-    let span = |cos_rho: f64, sin_rho: f64, d: f64| {
-        d >= cos_rho - sin_rho * ORIENT_EPS - ORIENT_EPS * ORIENT_EPS
-    };
-    if (d1 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c1)))
-        || (d2 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c2)))
-    {
-        return true;
-    }
-    if d3 == 0.0 || d4 == 0.0 {
-        let mid = normalize(&[c1[0] + c2[0], c1[1] + c2[1], c1[2] + c2[2]]);
-        let cos_rho = dot(&mid, c1);
-        let sin_rho = (1.0 - cos_rho * cos_rho).max(0.0).sqrt();
-        if (d3 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.a)))
-            || (d4 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.b)))
+    if degenerate12 || d3.abs() < ORIENT_EPS || d4.abs() < ORIENT_EPS {
+        // Exact incidence ⇒ closed-set touch, gated to the segment span (the
+        // infinite great circle runs to the poles; gating on it alone emitted
+        // a spurious strip of cells far beyond the polygon).
+        let span = |cos_rho: f64, sin_rho: f64, d: f64| {
+            d >= cos_rho - sin_rho * ORIENT_EPS - ORIENT_EPS * ORIENT_EPS
+        };
+        if (d1 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c1)))
+            || (d2 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c2)))
         {
             return true;
         }
-    }
-    if d1.abs() < ORIENT_EPS
-        || d2.abs() < ORIENT_EPS
-        || d3.abs() < ORIENT_EPS
-        || d4.abs() < ORIENT_EPS
-    {
+        if d3 == 0.0 || d4 == 0.0 {
+            let mid = normalize(&[c1[0] + c2[0], c1[1] + c2[1], c1[2] + c2[2]]);
+            let cos_rho = dot(&mid, c1);
+            let sin_rho = (1.0 - cos_rho * cos_rho).max(0.0).sqrt();
+            if (d3 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.a)))
+                || (d4 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.b)))
+            {
+                return true;
+            }
+        }
         return arcs_cross_sos(c1, c2, &e.a, &e.b, CORNER_ID_A, CORNER_ID_B, e.ia, e.ib);
     }
-    (d1 > 0.0) != (d2 > 0.0) && (d3 > 0.0) != (d4 > 0.0)
+    // d1, d2 straddle (established above); the plain sign test decides.
+    (d3 > 0.0) != (d4 > 0.0)
 }
 
 /// A descent node: cell `(pixel, depth)`, its centre, even-odd fill state, and
@@ -629,9 +634,9 @@ fn covers_complement(rings: &[Vec<Vec3>], cap: &Cap) -> bool {
 /// great-circle plane makes the seed ambiguous, and [`base_fills`] classifies
 /// it through the SoS parity chain, whose answer is exact in the symbolically
 /// perturbed world the descent's own probes live in.
-fn seed_fill(x: &Vec3, edges: &[Edge], rings: &[Vec<Vec3>]) -> Option<bool> {
-    for e in edges {
-        if dot(&normalize(&e.n_ab), x).abs() < ORIENT_EPS {
+fn seed_fill(x: &Vec3, unit_normals: &[Vec3], rings: &[Vec<Vec3>]) -> Option<bool> {
+    for n in unit_normals {
+        if dot(n, x).abs() < ORIENT_EPS {
             return None;
         }
     }
@@ -661,10 +666,13 @@ fn antipodal_base(a: u64, b: u64) -> bool {
 /// passes through all 12 — pathological), the raw winding verdicts are kept.
 fn base_fills(edges: &[Edge], rings: &[Vec<Vec3>]) -> [bool; 12] {
     let centers: Vec<Vec3> = (0..12).map(|b| cell_center_vec(0, b)).collect();
+    // Unit edge normals once (not per seed): the plane-proximity test is the
+    // only consumer and 12 × E normalizations showed up in the profile.
+    let unit_normals: Vec<Vec3> = edges.iter().map(|e| normalize(&e.n_ab)).collect();
     let mut fill = [false; 12];
     let mut known = [false; 12];
     for b in 0..12 {
-        if let Some(f) = seed_fill(&centers[b], edges, rings) {
+        if let Some(f) = seed_fill(&centers[b], &unit_normals, rings) {
             fill[b] = f;
             known[b] = true;
         }
@@ -831,16 +839,12 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
     let quad_straddles = node.relevant.iter().any(|&i| {
         let e = &edges[i];
         (0..4).any(|ci| edge_hits_cell_edge(e, &corners[ci], &corners[(ci + 1) % 4], &n_quad[ci]))
-    }) || corners.iter().any(|c| {
-        arc_crossing_parity(
-            &node.center,
-            c,
-            center_id(node.depth, node.pixel),
-            CORNER_ID_A,
-            &node.relevant,
-            edges,
-        )
-    });
+    }) || {
+        let cid = center_id(node.depth, node.pixel);
+        corners
+            .iter()
+            .any(|c| arc_crossing_parity(&node.center, c, cid, CORNER_ID_A, &node.relevant, edges))
+    };
     if quad_straddles {
         return true;
     }
@@ -859,16 +863,11 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
     node.relevant.iter().any(|&i| {
         let e = &edges[i];
         (0..n).any(|ci| edge_hits_cell_edge(e, &bnd[ci], &bnd[(ci + 1) % n], &n_bnd[ci]))
-    }) || bnd.iter().any(|b| {
-        arc_crossing_parity(
-            &node.center,
-            b,
-            center_id(node.depth, node.pixel),
-            CORNER_ID_A,
-            &node.relevant,
-            edges,
-        )
-    })
+    }) || {
+        let cid = center_id(node.depth, node.pixel);
+        bnd.iter()
+            .any(|b| arc_crossing_parity(&node.center, b, cid, CORNER_ID_A, &node.relevant, edges))
+    }
 }
 
 /// The four children of a node, each with re-culled edges and propagated fill.

--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -38,8 +38,8 @@ use crate::cell_geom::{cell_center_vec, cell_corners, Cap};
 use crate::geo2mort::{ang2pix_scalar, boundaries_step_scalar};
 use crate::morton::nested2mort;
 use crate::sphere::{
-    arcs_cross_n, cross, dot, latlon_to_unit_vec, norm, normalize, parity_filled_robust,
-    ring_winding_sign_at, robust_crossing, PointId, Vec3,
+    arcs_cross_sos, cross, dot, latlon_to_unit_vec, norm, normalize, parity_filled_robust,
+    ring_winding_sign_at, PointId, Vec3,
 };
 
 // ── public entry points ──────────────────────────────────────────────────
@@ -331,27 +331,41 @@ struct Edge {
     leaf: u64,
     /// Stable Simulation-of-Simplicity identities of the endpoints `a`, `b`
     /// (their global vertex index across the ring-set).  Feed the descent's
-    /// robust crossing test ([`robust_crossing`]) so a probe arc whose endpoint
+    /// symbolic crossing test ([`arcs_cross_sos`]) so a probe arc whose endpoint
     /// lies exactly on this edge's great circle — e.g. a HEALPix base-cell centre
-    /// on a base-cell-centre meridian (issue #11) — resolves to a definite,
-    /// traversal-order-independent side instead of a sign-unstable `arcs_cross_n`.
+    /// on a base-cell-centre meridian (issues #11/#103) — resolves to a definite,
+    /// traversal-order-independent side instead of a sign-unstable plain test.
     ia: PointId,
     ib: PointId,
 }
 
-/// SoS identities reserved for the two endpoints of a descent **probe** arc
-/// (cell centre → centre/corner).  Ring vertices are numbered from
-/// [`VERTEX_ID_BASE`] upward, so the probe endpoints take ids `0` and `1` — i.e.
-/// they sort **before** every ring vertex.  This matters when a probe endpoint
-/// lies exactly on an edge's great circle (the issue #11 base-cell-centre-on-a-
-/// meridian degeneracy): SoS resolves the tie by perturbing the lowest-id point
-/// first, so the probe point — not a ring vertex — is the one nudged decisively
-/// off the edge, and it is nudged the **same** way every time it anchors a walk.
-/// That keeps the descent's incremental fill parity consistent with itself.
-const PROBE_ID_P: PointId = 0;
-const PROBE_ID_Q: PointId = 1;
-/// Ring vertices are numbered from here so their ids never collide with the two
-/// reserved probe ids above.
+/// Symbolic identity of a cell centre: its HEALPix UNIQ code with the top bit
+/// set, so it is unique per `(depth, pixel)`, stable across every probe arc
+/// that touches the centre, and disjoint from the ring-vertex id range.
+///
+/// Stability is load-bearing (#103): the even-odd fill parity is chained along
+/// centre→centre probe arcs, and when a centre lies **exactly** on a polygon
+/// edge its SoS-resolved virtual side must be the same in the arc that arrives
+/// at it and in every arc that leaves it — otherwise the chain is
+/// path-dependent and one boundary-coincident centre inverts its whole
+/// subtree.  Positional ids (source=0 / target=1, the pre-#103 scheme) broke
+/// exactly this.  With per-point ids the symbolic perturbation is one global,
+/// consistent perturbation of the configuration; centres carry the top-bit
+/// range, so ring vertices (low ids) perturb first — the polygon is nudged off
+/// the degenerate grid once, the same way for every probe.
+#[inline]
+fn center_id(depth: u8, pixel: u64) -> PointId {
+    (1u64 << 63) | ((4u64 << (2 * depth as u32)) + pixel)
+}
+
+/// SoS ids for one-shot derived endpoints (cell corners, densified near-pole
+/// boundary points).  These feed only the straddle *boolean* — never the
+/// chained fill parity — so they need distinctness within a call, not global
+/// stability.  Top-of-range keeps them clear of vertex and centre ids.
+const CORNER_ID_A: PointId = PointId::MAX;
+const CORNER_ID_B: PointId = PointId::MAX - 1;
+/// Ring vertices are numbered from here (their global index across the
+/// ring-set), below every centre / corner id.
 const VERTEX_ID_BASE: PointId = 2;
 
 /// A straddle determinant (a scalar triple product of unit vectors) below this
@@ -428,33 +442,39 @@ fn edge_relevant(e: &Edge, center: &Vec3, cos_cr: f64, sin_cr: f64) -> bool {
 /// Parity (odd?) of how many of `relevant` edges the short arc `p→q` crosses.
 /// Flips the even-odd fill state between two nearby points.
 ///
-/// The crossing test goes through [`robust_crossing`]: the descent walks `fill`
+/// The crossing test goes through [`arcs_cross_sos`]: the descent walks `fill`
 /// from a cell centre to a neighbour, and when an edge's great circle passes
-/// exactly through one endpoint (the issue #11 degeneracy — a base-cell centre
-/// sitting on a base-cell-centre meridian), a plain `arcs_cross_n` is
-/// sign-unstable and flip-flops the parity, flooding the cell's whole subtree.
-/// Simulation of Simplicity breaks the four exact-zero straddle orientations to a
-/// definite, traversal-order-independent side — the dominant instability — so the
-/// parity is stable for the #11 family.  `robust_crossing`'s on-arc
-/// disambiguation is now SoS-hardened too (#78): its `on_minor_arc` half-plane
-/// tests run through the same canonical-order + SoS tie-break, so an
-/// on-great-circle probe no longer admits a residual float-sign sensitivity there.
-/// This runs on the descent's per-cell fan, but only over the `relevant` edges
-/// (those whose cap reaches the cell), so it stays off the bulk path.
+/// exactly through one endpoint (the issue #11/#103 degeneracy — a cell centre
+/// or a polygon edge sitting on a base-cell meridian), a plain sign test is
+/// noise-unstable and flip-flops the parity, flooding the cell's whole subtree.
+/// The symbolic predicate decides every sidedness question on a canonical,
+/// identity-keyed [`orient_sos`] evaluation with no constructed intersection
+/// point, so a probe passing exactly through a ring vertex counts exactly one
+/// crossing across the two incident edges (#103) and the parity is stable for
+/// the whole on-grid family.  This runs on the descent's per-cell fan, but only
+/// over the `relevant` edges (those whose cap reaches the cell), so it stays
+/// off the bulk path.
 ///
-/// SoS is only needed at a degeneracy (a straddle orientation rounding near
-/// zero), which is rare; away from it the plain four-orientation test is exact
-/// and far cheaper.  So each edge takes the fast `arcs_cross_n` path unless one
-/// of its four straddle determinants is within [`ORIENT_EPS`] of zero, in which
-/// case it falls back to the SoS-robust [`robust_crossing`].  This keeps the
-/// common descent path at `arcs_cross_n` speed while preserving the #11 fix.
+/// The symbolic path is only needed at a degeneracy (a straddle orientation
+/// rounding near zero), which is rare; away from it the plain four-orientation
+/// test is exact and far cheaper.  So each edge takes the fast sign path unless
+/// one of its four straddle determinants is within [`ORIENT_EPS`] of zero, in
+/// which case it falls back to [`arcs_cross_sos`].  This keeps the common
+/// descent path at dot-product speed while preserving the #11/#103 fix.
 #[inline]
-fn arc_crossing_parity(p: &Vec3, q: &Vec3, relevant: &[usize], edges: &[Edge]) -> bool {
+fn arc_crossing_parity(
+    p: &Vec3,
+    q: &Vec3,
+    ip: PointId,
+    iq: PointId,
+    relevant: &[usize],
+    edges: &[Edge],
+) -> bool {
     let n_pq = cross(p, q);
     let mut crossings = 0u32;
     for &i in relevant {
         let e = &edges[i];
-        if edge_crosses_probe(p, q, &n_pq, e) {
+        if edge_crosses_probe(p, q, ip, iq, &n_pq, e) {
             crossings += 1;
         }
     }
@@ -462,10 +482,10 @@ fn arc_crossing_parity(p: &Vec3, q: &Vec3, relevant: &[usize], edges: &[Edge]) -
 }
 
 /// Does polygon edge `e` cross the probe arc `p→q` (normal `n_pq = p × q`)?
-/// Fast `arcs_cross_n` unless a straddle determinant is near-degenerate, then the
-/// SoS-robust [`robust_crossing`].  See [`arc_crossing_parity`].
+/// Fast sign test unless a straddle determinant is near-degenerate, then the
+/// symbolic [`arcs_cross_sos`].  See [`arc_crossing_parity`].
 #[inline]
-fn edge_crosses_probe(p: &Vec3, q: &Vec3, n_pq: &Vec3, e: &Edge) -> bool {
+fn edge_crosses_probe(p: &Vec3, q: &Vec3, ip: PointId, iq: PointId, n_pq: &Vec3, e: &Edge) -> bool {
     // The four straddle determinants of the standard arcs-cross test.  Near-zero
     // in any of them is the cell-centre-on-edge degeneracy (#11) where the plain
     // sign test is unstable; defer those to SoS.
@@ -478,10 +498,63 @@ fn edge_crosses_probe(p: &Vec3, q: &Vec3, n_pq: &Vec3, e: &Edge) -> bool {
         || d_ab_p.abs() < ORIENT_EPS
         || d_ab_q.abs() < ORIENT_EPS
     {
-        return robust_crossing(p, q, &e.a, &e.b, PROBE_ID_P, PROBE_ID_Q, e.ia, e.ib);
+        return arcs_cross_sos(p, q, &e.a, &e.b, ip, iq, e.ia, e.ib);
     }
     // Fast path: p, q straddle edge AB's great circle and a, b straddle PQ's.
     (d_pq_a > 0.0) != (d_pq_b > 0.0) && (d_ab_p > 0.0) != (d_ab_q > 0.0)
+}
+
+/// Does polygon edge `e` cross **or exactly touch** the cell edge `c1 → c2`
+/// (normal `n_c = c1 × c2`)?  The straddle test's closed-set form (#103):
+///
+/// * A **bit-exact zero** determinant is true geometric incidence — a cell
+///   corner on the polygon edge's great circle or a polygon endpoint on the
+///   cell edge's.  HEALPix corners on the lon ≡ 0 mod 45° meridians are
+///   bit-exact (`y == 0.0`), so on-grid input hits this systematically.  It
+///   reports as a hit, making the cell boundary-touching → refined and, at the
+///   target order, included: "a cell whose boundary the polygon touches
+///   *exactly* is always included" (the closed-set contract agreed on #103).
+/// * A near-zero (< [`ORIENT_EPS`]) but nonzero determinant routes to the
+///   symbolic [`arcs_cross_sos`] for an exact crossing verdict (a 1-ulp-off
+///   edge resolves deterministically to one side — not closed-set).
+/// * Otherwise the plain sign test, unchanged (the hot path).
+///
+/// Cell corners are one-shot derived points ([`CORNER_ID_A`]/[`CORNER_ID_B`]):
+/// only distinctness matters within a call — this feeds the straddle boolean,
+/// never the chained fill parity.
+#[inline]
+fn edge_hits_cell_edge(e: &Edge, c1: &Vec3, c2: &Vec3, n_c: &Vec3) -> bool {
+    let d1 = dot(&e.n_ab, c1);
+    let d2 = dot(&e.n_ab, c2);
+    let d3 = dot(n_c, &e.a);
+    let d4 = dot(n_c, &e.b);
+    // Exact incidence ⇒ closed-set touch — but only when the incident point
+    // lies within the *segment* (its bounding cap), not merely on the infinite
+    // great circle: an on-grid meridian edge's circle runs to the poles, and
+    // gating on the circle alone emitted a spurious strip of cells along it
+    // far beyond the polygon.
+    if (d1 == 0.0 && dot(&e.mid, c1) >= e.cos_rho - ORIENT_EPS)
+        || (d2 == 0.0 && dot(&e.mid, c2) >= e.cos_rho - ORIENT_EPS)
+    {
+        return true;
+    }
+    if d3 == 0.0 || d4 == 0.0 {
+        let mid = normalize(&[c1[0] + c2[0], c1[1] + c2[1], c1[2] + c2[2]]);
+        let cos_rho = dot(&mid, c1);
+        if (d3 == 0.0 && dot(&mid, &e.a) >= cos_rho - ORIENT_EPS)
+            || (d4 == 0.0 && dot(&mid, &e.b) >= cos_rho - ORIENT_EPS)
+        {
+            return true;
+        }
+    }
+    if d1.abs() < ORIENT_EPS
+        || d2.abs() < ORIENT_EPS
+        || d3.abs() < ORIENT_EPS
+        || d4.abs() < ORIENT_EPS
+    {
+        return arcs_cross_sos(c1, c2, &e.a, &e.b, CORNER_ID_A, CORNER_ID_B, e.ia, e.ib);
+    }
+    (d1 > 0.0) != (d2 > 0.0) && (d3 > 0.0) != (d4 > 0.0)
 }
 
 /// A descent node: cell `(pixel, depth)`, its centre, even-odd fill state, and
@@ -535,6 +608,93 @@ fn covers_complement(rings: &[Vec<Vec3>], cap: &Cap) -> bool {
     })
 }
 
+/// Even-odd fill verdict at `x` from the winding backend, or `None` when the
+/// verdict is **untrustworthy** because `x` lies (numerically) on some edge's
+/// great circle.
+///
+/// The winding backend cannot flag its own boundary tie: for a point exactly
+/// on an edge, that edge's subtended angle is ±π with the *sign* decided by
+/// rounding noise, so the total lands on a legitimate-looking `0` or `±2π` —
+/// the #103 seed failure (a base centre exactly on a polygon edge tips an
+/// entire subtree, in whichever direction the noise fell).  The tie is
+/// detected geometrically instead: `x` within [`ORIENT_EPS`] of any edge's
+/// great-circle plane makes the seed ambiguous, and [`base_fills`] classifies
+/// it through the SoS parity chain, whose answer is exact in the symbolically
+/// perturbed world the descent's own probes live in.
+fn seed_fill(x: &Vec3, edges: &[Edge], rings: &[Vec<Vec3>]) -> Option<bool> {
+    for e in edges {
+        if dot(&normalize(&e.n_ab), x).abs() < ORIENT_EPS {
+            return None;
+        }
+    }
+    Some(parity_filled_robust(x, rings))
+}
+
+/// Are base cells `a` and `b` centred on antipodal points?  The 12 HEALPix
+/// base centres pair up as north-cap/south-cap (0,10) (1,11) (2,8) (3,9) and
+/// equatorial (4,6) (5,7); a chain probe between an antipodal pair would be a
+/// degenerate (non-minor) arc, so [`base_fills`] never picks one.
+fn antipodal_base(a: u64, b: u64) -> bool {
+    matches!(
+        (a.min(b), a.max(b)),
+        (0, 10) | (1, 11) | (2, 8) | (3, 9) | (4, 6) | (5, 7)
+    )
+}
+
+/// Fill states for the 12 base-cell centres (#103 seed hardening).
+///
+/// Each seed takes the winding verdict when it is trustworthy
+/// ([`seed_fill`]); a seed whose centre lies numerically **on** some edge's
+/// great circle is instead chained from an unambiguous donor centre through the
+/// same SoS crossing parity the descent itself uses
+/// ([`arc_crossing_parity`] over the full edge list), so its verdict is exact
+/// and consistent with every later probe flip — the raw winding tie can no
+/// longer invert a base subtree.  If every centre is ambiguous (the boundary
+/// passes through all 12 — pathological), the raw winding verdicts are kept.
+fn base_fills(edges: &[Edge], rings: &[Vec<Vec3>]) -> [bool; 12] {
+    let centers: Vec<Vec3> = (0..12).map(|b| cell_center_vec(0, b)).collect();
+    let mut fill = [false; 12];
+    let mut known = [false; 12];
+    for b in 0..12 {
+        if let Some(f) = seed_fill(&centers[b], edges, rings) {
+            fill[b] = f;
+            known[b] = true;
+        }
+    }
+    if known.iter().all(|&k| k) {
+        return fill; // common case: no seed on the boundary
+    }
+    if known.iter().all(|&k| !k) {
+        // Pathological: boundary through all 12 centres; keep raw winding.
+        for b in 0..12 {
+            fill[b] = parity_filled_robust(&centers[b], rings);
+        }
+        return fill;
+    }
+    let all: Vec<usize> = (0..edges.len()).collect();
+    for b in 0..12u64 {
+        if known[b as usize] {
+            continue;
+        }
+        // A non-antipodal known donor always exists: each base has exactly one
+        // antipodal partner, and at least one other seed is known.
+        let d = (0..12u64)
+            .find(|&d| known[d as usize] && !antipodal_base(b, d))
+            .expect("a non-antipodal known donor base centre");
+        let parity = arc_crossing_parity(
+            &centers[d as usize],
+            &centers[b as usize],
+            center_id(0, d),
+            center_id(0, b),
+            &all,
+            edges,
+        );
+        fill[b as usize] = fill[d as usize] ^ parity;
+        known[b as usize] = true;
+    }
+    fill
+}
+
 /// Build a base-cell node, or `None` if the base cell is entirely outside the
 /// polygon's bounding cap.  Computes the only full O(V) even-odd parity per base.
 ///
@@ -543,17 +703,11 @@ fn covers_complement(rings: &[Vec<Vec3>], cap: &Cap) -> bool {
 /// can be pruned by cap distance — every base is descended and the even-odd fill
 /// classifies its interior cells.
 ///
-/// The base seed's fill state is the only full O(V) point-in-polygon evaluation
-/// per base cell, and it goes through the single robust winding backend
-/// ([`parity_filled_robust`], #22) — correct at any polygon size, so the seed is
-/// classified the same whether the polygon is a small box or a hemisphere+ ring.
-fn base_node(
-    base: u64,
-    edges: &[Edge],
-    rings: &[Vec<Vec3>],
-    cap: &Cap,
-    complement: bool,
-) -> Option<Node> {
+/// The base seed's `fill` comes precomputed from [`base_fills`] — the winding
+/// backend when unambiguous, the SoS parity chain when the centre lies on the
+/// boundary (#103) — correct at any polygon size, so the seed is classified
+/// the same whether the polygon is a small box or a hemisphere+ ring.
+fn base_node(base: u64, edges: &[Edge], fill: bool, cap: &Cap, complement: bool) -> Option<Node> {
     let center = cell_center_vec(0, base);
     let corners = cell_corners(0, base);
     let (cos_cr, sin_cr) = cell_cos_radius(&center, &corners);
@@ -563,7 +717,6 @@ fn base_node(
     let relevant: SmallVec<[usize; 8]> = (0..edges.len())
         .filter(|&i| edge_relevant(&edges[i], &center, cos_cr, sin_cr))
         .collect();
-    let fill = parity_filled_robust(&center, rings);
     Some(Node {
         pixel: base,
         depth: 0,
@@ -617,8 +770,9 @@ fn near_pole_step(depth: u8) -> u32 {
 }
 
 /// Does the polygon boundary pass through this cell?  True if a polygon vertex
-/// lies in it, a relevant edge crosses a cell edge, or a relevant edge crosses
-/// centre→boundary (a clipped corner/edge).
+/// lies in it, a relevant edge crosses **or exactly touches** a cell edge
+/// ([`edge_hits_cell_edge`], the #103 closed-set contract), or a relevant edge
+/// crosses centre→boundary (a clipped corner/edge).
 ///
 /// The cheap 4-corner geodesic-quad test runs first and settles every solid
 /// overlap.  HEALPix cell edges are not great circles, so near the poles the
@@ -656,19 +810,17 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
     ];
     let quad_straddles = node.relevant.iter().any(|&i| {
         let e = &edges[i];
-        (0..4).any(|ci| {
-            arcs_cross_n(
-                &e.a,
-                &e.b,
-                &e.n_ab,
-                &corners[ci],
-                &corners[(ci + 1) % 4],
-                &n_quad[ci],
-            )
-        })
-    }) || corners
-        .iter()
-        .any(|c| arc_crossing_parity(&node.center, c, &node.relevant, edges));
+        (0..4).any(|ci| edge_hits_cell_edge(e, &corners[ci], &corners[(ci + 1) % 4], &n_quad[ci]))
+    }) || corners.iter().any(|c| {
+        arc_crossing_parity(
+            &node.center,
+            c,
+            center_id(node.depth, node.pixel),
+            CORNER_ID_A,
+            &node.relevant,
+            edges,
+        )
+    });
     if quad_straddles {
         return true;
     }
@@ -686,19 +838,17 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
         .collect();
     node.relevant.iter().any(|&i| {
         let e = &edges[i];
-        (0..n).any(|ci| {
-            arcs_cross_n(
-                &e.a,
-                &e.b,
-                &e.n_ab,
-                &bnd[ci],
-                &bnd[(ci + 1) % n],
-                &n_bnd[ci],
-            )
-        })
-    }) || bnd
-        .iter()
-        .any(|b| arc_crossing_parity(&node.center, b, &node.relevant, edges))
+        (0..n).any(|ci| edge_hits_cell_edge(e, &bnd[ci], &bnd[(ci + 1) % n], &n_bnd[ci]))
+    }) || bnd.iter().any(|b| {
+        arc_crossing_parity(
+            &node.center,
+            b,
+            center_id(node.depth, node.pixel),
+            CORNER_ID_A,
+            &node.relevant,
+            edges,
+        )
+    })
 }
 
 /// The four children of a node, each with re-culled edges and propagated fill.
@@ -716,8 +866,15 @@ fn node_children(node: &Node, edges: &[Edge]) -> Vec<Node> {
                 .copied()
                 .filter(|&i| edge_relevant(&edges[i], &center, cos_cr, sin_cr))
                 .collect();
-            let fill =
-                node.fill ^ arc_crossing_parity(&node.center, &center, &node.relevant, edges);
+            let fill = node.fill
+                ^ arc_crossing_parity(
+                    &node.center,
+                    &center,
+                    center_id(node.depth, node.pixel),
+                    center_id(depth, pixel),
+                    &node.relevant,
+                    edges,
+                );
             Node {
                 pixel,
                 depth,
@@ -755,12 +912,13 @@ fn descend_parallel(rings: &[Vec<Vec3>], order: u8, tolerance: Option<f64>) -> V
     let edges = build_edges(rings, order);
     let cap = Cap::of_rings(rings);
     let complement = covers_complement(rings, &cap);
+    let fills = base_fills(&edges, rings);
 
     (0..12u64)
         .into_par_iter()
         .flat_map_iter(|base| {
             let mut out: Vec<(u64, u8)> = Vec::new();
-            let Some(seed) = base_node(base, &edges, rings, &cap, complement) else {
+            let Some(seed) = base_node(base, &edges, fills[base as usize], &cap, complement) else {
                 return out;
             };
             let mut stack = vec![seed];
@@ -773,8 +931,22 @@ fn descend_parallel(rings: &[Vec<Vec3>], order: u8, tolerance: Option<f64>) -> V
                     } else {
                         stack.extend(node_children(&node, &edges));
                     }
-                } else if node.fill {
-                    out.push((node.pixel, node.depth));
+                } else {
+                    // #103 parity oracle: a uniform (boundary-free) cell's
+                    // incremental even-odd fill must agree with the independent
+                    // winding PIP at its centre; a mismatch means a probe-chain
+                    // parity flip upstream.  Debug builds only — this is the
+                    // assert that would have caught #11, #78, and #103 at once.
+                    debug_assert_eq!(
+                        node.fill,
+                        parity_filled_robust(&node.center, rings),
+                        "parity oracle diverged at uniform cell ({}, {})",
+                        node.pixel,
+                        node.depth
+                    );
+                    if node.fill {
+                        out.push((node.pixel, node.depth));
+                    }
                 }
             }
             out
@@ -793,13 +965,14 @@ fn descend_best_first(rings: &[Vec<Vec3>], order: u8, max_cells: usize) -> (Vec<
     let edges = build_edges(rings, order);
     let cap = Cap::of_rings(rings);
     let complement = covers_complement(rings, &cap);
+    let fills = base_fills(&edges, rings);
 
     let mut out: Vec<(u64, u8)> = Vec::new();
     let mut frontier: BinaryHeap<HeapNode> = BinaryHeap::new();
 
     for base in 0..12u64 {
-        if let Some(node) = base_node(base, &edges, rings, &cap, complement) {
-            consider_node(node, &edges, order, &mut out, &mut frontier);
+        if let Some(node) = base_node(base, &edges, fills[base as usize], &cap, complement) {
+            consider_node(node, &edges, rings, order, &mut out, &mut frontier);
         }
     }
 
@@ -817,7 +990,7 @@ fn descend_best_first(rings: &[Vec<Vec3>], order: u8, max_cells: usize) -> (Vec<
             break;
         }
         for child in node_children(&node, &edges) {
-            consider_node(child, &edges, order, &mut out, &mut frontier);
+            consider_node(child, &edges, rings, order, &mut out, &mut frontier);
         }
     }
     (out, budget)
@@ -828,6 +1001,7 @@ fn descend_best_first(rings: &[Vec<Vec3>], order: u8, max_cells: usize) -> (Vec<
 fn consider_node(
     node: Node,
     edges: &[Edge],
+    rings: &[Vec<Vec3>],
     order: u8,
     out: &mut Vec<(u64, u8)>,
     frontier: &mut BinaryHeap<HeapNode>,
@@ -838,8 +1012,18 @@ fn consider_node(
         } else {
             frontier.push(HeapNode(node));
         }
-    } else if node.fill {
-        out.push((node.pixel, node.depth));
+    } else {
+        // #103 parity oracle — see descend_parallel.
+        debug_assert_eq!(
+            node.fill,
+            parity_filled_robust(&node.center, rings),
+            "parity oracle diverged at uniform cell ({}, {})",
+            node.pixel,
+            node.depth
+        );
+        if node.fill {
+            out.push((node.pixel, node.depth));
+        }
     }
 }
 

--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -533,16 +533,24 @@ fn edge_hits_cell_edge(e: &Edge, c1: &Vec3, c2: &Vec3, n_c: &Vec3) -> bool {
     // great circle: an on-grid meridian edge's circle runs to the poles, and
     // gating on the circle alone emitted a spurious strip of cells along it
     // far beyond the polygon.
-    if (d1 == 0.0 && dot(&e.mid, c1) >= e.cos_rho - ORIENT_EPS)
-        || (d2 == 0.0 && dot(&e.mid, c2) >= e.cos_rho - ORIENT_EPS)
+    // The span slack is *angular* (cos(ρ+ε) ≈ cos ρ − ε·sin ρ): a bare
+    // cos-space epsilon would floor the angular slack at √(2ε) ≈ 1.4e-6 rad
+    // for short segments, gating vertices hundreds of cell-widths away as
+    // "touching" at fine orders.
+    let span = |cos_rho: f64, sin_rho: f64, d: f64| {
+        d >= cos_rho - sin_rho * ORIENT_EPS - ORIENT_EPS * ORIENT_EPS
+    };
+    if (d1 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c1)))
+        || (d2 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c2)))
     {
         return true;
     }
     if d3 == 0.0 || d4 == 0.0 {
         let mid = normalize(&[c1[0] + c2[0], c1[1] + c2[1], c1[2] + c2[2]]);
         let cos_rho = dot(&mid, c1);
-        if (d3 == 0.0 && dot(&mid, &e.a) >= cos_rho - ORIENT_EPS)
-            || (d4 == 0.0 && dot(&mid, &e.b) >= cos_rho - ORIENT_EPS)
+        let sin_rho = (1.0 - cos_rho * cos_rho).max(0.0).sqrt();
+        if (d3 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.a)))
+            || (d4 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.b)))
         {
             return true;
         }
@@ -671,7 +679,6 @@ fn base_fills(edges: &[Edge], rings: &[Vec<Vec3>]) -> [bool; 12] {
         }
         return fill;
     }
-    let all: Vec<usize> = (0..edges.len()).collect();
     for b in 0..12u64 {
         if known[b as usize] {
             continue;
@@ -681,15 +688,28 @@ fn base_fills(edges: &[Edge], rings: &[Vec<Vec3>]) -> [bool; 12] {
         let d = (0..12u64)
             .find(|&d| known[d as usize] && !antipodal_base(b, d))
             .expect("a non-antipodal known donor base centre");
-        let parity = arc_crossing_parity(
-            &centers[d as usize],
-            &centers[b as usize],
-            center_id(0, d),
-            center_id(0, b),
-            &all,
-            edges,
-        );
-        fill[b as usize] = fill[d as usize] ^ parity;
+        // Chain arcs between base centres reach ~122°, where the bare
+        // two-straddle fast path of `edge_crosses_probe` also fires on the
+        // *far* intersection of the two great circles (an edge antipodal to
+        // the chord) and silently inverts the seed.  The full symbolic
+        // predicate is unconditional here — 11 arcs at most, off every hot
+        // path.
+        let crossings = edges
+            .iter()
+            .filter(|e| {
+                arcs_cross_sos(
+                    &centers[d as usize],
+                    &centers[b as usize],
+                    &e.a,
+                    &e.b,
+                    center_id(0, d),
+                    center_id(0, b),
+                    e.ia,
+                    e.ib,
+                )
+            })
+            .count();
+        fill[b as usize] = fill[d as usize] ^ (crossings % 2 == 1);
         known[b as usize] = true;
     }
     fill

--- a/src_rust/src/coverage/tests.rs
+++ b/src_rust/src/coverage/tests.rs
@@ -559,3 +559,44 @@ fn test_build_ring_normalize_false_trusts_subhemisphere_order() {
         "CW ring left as-is selects the complement (centre outside) under normalize=false"
     );
 }
+
+#[test]
+fn test_base_fills_chain_no_antipodal_phantom() {
+    use crate::sphere::parity_filled_robust;
+    // Phase-2 review reproducer (#103): a ring placed so the bare
+    // two-straddle test fires on the *far* (antipodal) intersection for one
+    // of base_fills' long donor→seed chords, silently inverting the seed.
+    // The chain now uses the full symbolic predicate unconditionally: every
+    // seed the winding backend can classify unambiguously must agree with it.
+    let lats = vec![10.0, 50.0, -10.0, -70.0, -10.0];
+    let lons = vec![45.0, 45.0, 170.0, 225.0, 280.0];
+    let rings = build_rings(&[lats], &[lons], true);
+    let edges = build_edges(&rings, 6);
+    let fills = base_fills(&edges, &rings);
+    for b in 0..12u64 {
+        let c = cell_center_vec(0, b);
+        if seed_fill(&c, &edges, &rings).is_some() {
+            assert_eq!(
+                fills[b as usize],
+                parity_filled_robust(&c, &rings),
+                "seed {b} inverted"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "known limitation, out of #103 scope: a polygon edge collinear \
+with the probe lattice over tens of degrees on a hemisphere+ ring can still \
+desynchronize the descent's vertex-graze bookkeeping between the collinear \
+edge and its transversal sibling; predates this PR (the parity oracle made \
+it visible) — see PR #106 'Questions for review'"]
+fn test_descent_hemisphere_ring_collinear_edge_oracle() {
+    // Runs the full descent under the debug parity oracle on the phase-2
+    // review's adversarial ring.  Un-ignore when the long-collinear-overlap
+    // consistency work lands.
+    let lats = vec![10.0, 50.0, -10.0, -70.0, -10.0];
+    let lons = vec![45.0, 45.0, 170.0, 225.0, 280.0];
+    let cov = polygon_to_morton_coverage(&lats, &lons, 6, true);
+    assert!(!cov.is_empty());
+}

--- a/src_rust/src/coverage/tests.rs
+++ b/src_rust/src/coverage/tests.rs
@@ -573,9 +573,10 @@ fn test_base_fills_chain_no_antipodal_phantom() {
     let rings = build_rings(&[lats], &[lons], true);
     let edges = build_edges(&rings, 6);
     let fills = base_fills(&edges, &rings);
+    let units: Vec<Vec3> = edges.iter().map(|e| normalize(&e.n_ab)).collect();
     for b in 0..12u64 {
         let c = cell_center_vec(0, b);
-        if seed_fill(&c, &edges, &rings).is_some() {
+        if seed_fill(&c, &units, &rings).is_some() {
             assert_eq!(
                 fills[b as usize],
                 parity_filled_robust(&c, &rings),

--- a/src_rust/src/coverage/tests.rs
+++ b/src_rust/src/coverage/tests.rs
@@ -362,12 +362,12 @@ fn test_complement_guard_keeps_antipodal_base_cell() {
 
     // Without the guard (complement=false) this base is pruned …
     assert!(
-        base_node(far_base, &edges, &rings, &cap, false).is_none(),
+        base_node(far_base, &edges, false, &cap, false).is_none(),
         "un-guarded cap cull should prune the antipodal base cell"
     );
     // … with the guard (complement=true) it is kept.
     assert!(
-        base_node(far_base, &edges, &rings, &cap, true).is_some(),
+        base_node(far_base, &edges, false, &cap, true).is_some(),
         "complement guard must keep the antipodal base cell"
     );
 }

--- a/src_rust/src/sphere.rs
+++ b/src_rust/src/sphere.rs
@@ -421,6 +421,58 @@ pub fn robust_crossing(
     on_minor_arc(&x, a, b, xi, ia, ib) && on_minor_arc(&x, c, d, xi, ic, id)
 }
 
+/// Uniform symbolic minor-arc crossing, decided purely by [`orient_sos`] signs
+/// on the **input** points (issue #103).
+///
+/// Arcs `a → b` and `c → d` — each **minor** (< 180°, which holds for HEALPix
+/// probe arcs and polygon edges between consecutive vertices) — cross at a
+/// point interior to both iff the four orientations `[a c b]`, `[c b d]`,
+/// `[b d a]`, `[d a c]` share one sign (the S2 `SimpleCrossing` identity; the
+/// four signs jointly encode which antipodal intersection the straddle refers
+/// to, so no constructed intersection point is needed).
+///
+/// This is the replacement for the two-stage [`robust_crossing`] pipeline
+/// (straddle gates + float-constructed intersection + [`on_minor_arc`]): that
+/// pipeline resolved the same degeneracy in three different implicit ways, and
+/// issue #103 showed they can disagree by one crossing — a vertex graze counted
+/// by luck through a bit-exact `coincident` hit on one edge and dropped on the
+/// other because the deciding wedge determinant rounded to `+8e-20` (nonzero,
+/// so the SoS tie-break never engaged).  Here every sidedness question goes
+/// through [`orient_sos`]'s canonical, identity-keyed evaluation, so the same
+/// physical point resolves to the same side in **every** test that consults it
+/// (e.g. the shared vertex of two incident edges appears as `[p v q]` in one
+/// edge's test and `[q v p]` in the other — exact negations by construction).
+/// A probe passing exactly through a ring vertex therefore counts **exactly
+/// one** crossing across the two incident edges when the boundary passes
+/// through the probe circle (and zero or two when it grazes), keeping the
+/// even-odd fill parity consistent: the half-open `[a, b)` convention emerges
+/// instead of being hand-maintained.  Total and reorder-invariant; `ia, ib,
+/// ic, id` are the SoS identities of the four endpoints.
+#[inline]
+#[allow(clippy::too_many_arguments)] // 4 points + 4 SoS ids, same shape as robust_crossing
+pub fn arcs_cross_sos(
+    a: &Vec3,
+    b: &Vec3,
+    c: &Vec3,
+    d: &Vec3,
+    ia: PointId,
+    ib: PointId,
+    ic: PointId,
+    id: PointId,
+) -> bool {
+    let acb = orient_sos(a, c, b, ia, ic, ib);
+    let cbd = orient_sos(c, b, d, ic, ib, id);
+    if acb != cbd {
+        return false;
+    }
+    let bda = orient_sos(b, d, a, ib, id, ia);
+    if cbd != bda {
+        return false;
+    }
+    let dac = orient_sos(d, a, c, id, ia, ic);
+    bda == dac
+}
+
 /// Signed spherical winding of `ring` as seen from `x`: the sum of the signed
 /// angles each directed edge subtends at `x` (Bevis & Chatelain 1989).  It is
 /// `≈ +2π` when `x` lies inside the ring's counter-clockwise interior (the

--- a/src_rust/src/sphere.rs
+++ b/src_rust/src/sphere.rs
@@ -7,8 +7,9 @@
 //! (spherical winding number, correct at any polygon size including
 //! hemisphere+, issue #22) — plus [`parity_filled_robust`], the even-odd rule
 //! over a *ring-set* that gives holes and multipart geometry for free (see issue
-//! #30).  [`orient_sos`] / [`robust_crossing`] add a Simulation-of-Simplicity
-//! tie-break for the descent's degenerate cell-centre crossings (issue #11).
+//! #30).  [`orient_sos`] / [`arcs_cross_sos`] add a Simulation-of-Simplicity
+//! tie-break for the descent's degenerate cell-centre crossings (issues #11,
+//! #103).
 //! Ring orientation (RFC 7946 / S2 right-hand rule) is normalized at ingest by
 //! [`crate::coverage`]; see [`point_in_ring_robust`] for the winding contract.
 
@@ -129,19 +130,21 @@ pub fn arcs_cross_n(a: &Vec3, b: &Vec3, n_ab: &Vec3, c: &Vec3, d: &Vec3, n_cd: &
 //      backend wired into the seed PIP.  It runs only at the 12 base-cell seeds,
 //      so its per-vertex trig is off the hot path.
 //
-//   2. The orientation primitives [`orient_sos`] and [`robust_crossing`] are the
+//   2. The orientation primitives [`orient_sos`] and [`arcs_cross_sos`] are the
 //      **degeneracy-free building blocks** the hierarchical descent's per-cell
-//      parity flips (`arc_crossing_parity`, a later phase) will consume to fix
-//      issue #11 — where the descent predicate hits an exact-zero triple product
-//      at HEALPix cell centres.  `orient_sos` is the scalar triple product of
-//      [`orient`] with its exact-zero (coplanar) case broken by **Simulation of
+//      parity flips (`arc_crossing_parity`) consume to fix issues #11/#103 —
+//      where the descent predicate hits an exact-zero triple product at HEALPix
+//      cell centres.  `orient_sos` is the scalar triple product of [`orient`]
+//      with its exact-zero (coplanar) case broken by **Simulation of
 //      Simplicity** (Edelsbrunner & Mücke 1990): a symbolic perturbation keyed
 //      to each vertex's stable identity, so a coplanar triple resolves to a
 //      definite, consistent side regardless of traversal order — the f64+SoS
-//      approach @espg signed off on (#22).  `robust_crossing` builds an S2
-//      `CrossingSign`-style great-circle-*segment* test on top, valid for arcs
-//      up to ~180° (it verifies the intersection lies on both segments, which a
-//      bare 4-orientation straddle does not guarantee for long arcs).
+//      approach @espg signed off on (#22).  `arcs_cross_sos` builds the
+//      great-circle-*segment* test on top purely from those signs (the S2
+//      `SimpleCrossing` identity), valid for minor arcs (< 180°) — no
+//      constructed intersection point, so no derived-point rounding for a
+//      degeneracy to hide in (the issue #103 failure mode of the retired
+//      two-stage `robust_crossing`).
 //
 // An *edge-crossing* PIP built on layer 2 (rather than the winding number) is
 // deferred: its long-arc / scalloped-boundary behaviour still needs validating
@@ -153,16 +156,120 @@ pub fn arcs_cross_n(a: &Vec3, b: &Vec3, n_ab: &Vec3, c: &Vec3, d: &Vec3, n_cd: &
 /// only need to be **distinct and consistently ordered**, not contiguous.
 pub type PointId = u64;
 
-/// SoS identity of the *intersection* point `x` inside [`robust_crossing`].  `x`
-/// is a derived point (the AB×CD meet), not one of the four arc endpoints, so it
-/// needs its own identity for the half-plane tie-break in [`on_minor_arc`].  A
-/// reserved top id keeps it distinct from every real vertex and orders it
-/// consistently against `a, b, c, d` in both the AB and CD wedge tests, so the
-/// same physical `x` perturbs the same way regardless of which arc it is checked
-/// against.  Endpoint *coincidence* is settled before SoS (see [`on_minor_arc`]),
-/// so this id only governs the rare canonical-order tie of an interior on-circle
-/// `x`.
-const INTERSECTION_ID: PointId = PointId::MAX;
+// ── exact determinant sign (Shewchuk error-free expansions) ───────────────
+//
+// SoS breaks ties only at an **exact** zero, but f64 evaluation of the triple
+// product turns a geometrically degenerate configuration into ~1e-17 noise
+// whenever the inputs are not bit-exactly coplanar (e.g. HEALPix points on the
+// lon-45 meridians, where cos(π/4) and sin(π/4) round differently).  Noise
+// signs are individually stable under permutation (the canonical evaluation)
+// but **jointly inconsistent** — the set of signs need not describe any real
+// point configuration — which is exactly how issue #103's parity chain broke
+// off the bit-exact grid.  The fix is the classical one (Shewchuk 1997):
+// decide the sign of the determinant **exactly** with error-free float
+// expansions, so every sign describes the true configuration of the actual
+// f64 points and the predicate axioms hold jointly; SoS then only ever
+// arbitrates true zeros, where its global perturbation is consistent by
+// construction.  A cheap error-bound filter keeps the fast path fast.
+
+/// Error-free sum: `a + b = s + e` exactly.
+#[inline]
+fn two_sum(a: f64, b: f64) -> (f64, f64) {
+    let s = a + b;
+    let bv = s - a;
+    let av = s - bv;
+    (s, (a - av) + (b - bv))
+}
+
+/// Error-free product via FMA: `a * b = p + e` exactly.
+#[inline]
+fn two_product(a: f64, b: f64) -> (f64, f64) {
+    let p = a * b;
+    (p, a.mul_add(b, -p))
+}
+
+/// Exact sign of `Σ terms`, where every term is an exact f64 component.
+///
+/// Builds a nonoverlapping expansion by repeated GROW-EXPANSION (Shewchuk
+/// 1997, Thm. 10): each term is absorbed with an error-free `two_sum` cascade
+/// over the expansion-so-far (kept in increasing magnitude), so the result's
+/// components are nonoverlapping and ascending, and the **last** component
+/// alone carries the sign of the exact sum.  O(n²) in the term count (≤ 24
+/// here) and only reached when the fast filtered path abstains.
+fn exact_sum_sign(terms: &[f64]) -> i32 {
+    let mut h: Vec<f64> = Vec::with_capacity(terms.len() + 4);
+    let mut tmp: Vec<f64> = Vec::with_capacity(terms.len() + 4);
+    for &t in terms {
+        if t == 0.0 {
+            continue;
+        }
+        tmp.clear();
+        let mut q = t;
+        for &hi in &h {
+            let (sum, err) = two_sum(q, hi);
+            q = sum;
+            if err != 0.0 {
+                tmp.push(err);
+            }
+        }
+        if q != 0.0 {
+            tmp.push(q);
+        }
+        std::mem::swap(&mut h, &mut tmp);
+    }
+    match h.last() {
+        None => 0,
+        Some(&m) if m > 0.0 => 1,
+        _ => -1,
+    }
+}
+
+/// Exact sign of the scalar triple product `a · (b × c)` as `-1 | 0 | +1`.
+///
+/// A relative-error filter accepts the fast f64 evaluation when its magnitude
+/// provably dominates the rounding error; otherwise the determinant is
+/// re-evaluated exactly as a 12-term error-free expansion.
+fn orient_exact_sign(a: &Vec3, b: &Vec3, c: &Vec3) -> i32 {
+    let det = orient(a, b, c);
+    // Permanent-style magnitude bound on the six products.
+    let perm = (b[1] * c[2]).abs()
+        + (b[2] * c[1]).abs()
+        + (b[2] * c[0]).abs()
+        + (b[0] * c[2]).abs()
+        + (b[0] * c[1]).abs()
+        + (b[1] * c[0]).abs();
+    let mag = a[0].abs().max(a[1].abs()).max(a[2].abs()) * perm;
+    // ~2^-50: comfortably above the true bound (~1e-15 · mag) for a 6-product
+    // sum-of-products; anything larger is decided by the float sign.
+    if det.abs() > mag * 1e-15 {
+        return if det > 0.0 { 1 } else { -1 };
+    }
+    // Exact: each a_i · (b_j c_k − b_k c_j) contributes 4 exact components.
+    let mut terms: Vec<f64> = Vec::with_capacity(12);
+    for (ai, bj, ck, bk, cj) in [
+        (a[0], b[1], c[2], b[2], c[1]),
+        (a[1], b[2], c[0], b[0], c[2]),
+        (a[2], b[0], c[1], b[1], c[0]),
+    ] {
+        let (p1, e1) = two_product(bj, ck);
+        let (p2, e2) = two_product(bk, cj);
+        for m in [p1, e1, -p2, -e2] {
+            let (q, f) = two_product(ai, m);
+            terms.push(q);
+            terms.push(f);
+        }
+    }
+    exact_sum_sign(&terms)
+}
+
+/// Exact sign of the 2×2 minor `w·x − y·z` as `-1 | 0 | +1` (for the SoS
+/// tie-break sequence, whose minors need the same exactness as the
+/// determinant itself).
+fn minor_exact_sign(w: f64, x: f64, y: f64, z: f64) -> i32 {
+    let (p1, e1) = two_product(w, x);
+    let (p2, e2) = two_product(y, z);
+    exact_sum_sign(&[p1, e1, -p2, -e2])
+}
 
 /// Robust orientation sign of three unit vectors as `-1 | 0 | +1`.
 ///
@@ -213,15 +320,13 @@ pub fn orient_sos(a: &Vec3, b: &Vec3, c: &Vec3, ia: PointId, ib: PointId, ic: Po
         perm_sign = -perm_sign;
     }
     let (p, q, r) = (pts[0].1, pts[1].1, pts[2].1);
-    // Evaluate the geometric determinant ONCE, on the canonical order.
-    let det = orient(p, q, r);
-    let canon = if det > 0.0 {
-        1
-    } else if det < 0.0 {
-        -1
-    } else {
-        // True degeneracy on the canonical order: symbolic perturbation.
-        sos_sorted_sign(p, q, r)
+    // Decide the geometric sign ONCE, on the canonical order — and decide it
+    // **exactly** ([`orient_exact_sign`]): a near-zero f64 determinant carries
+    // a noise sign that is stable per-triple but jointly inconsistent across
+    // triples (issue #103), so only the exact sign keeps the predicate axioms.
+    let canon = match orient_exact_sign(p, q, r) {
+        0 => sos_sorted_sign(p, q, r), // true degeneracy: symbolic perturbation
+        sign => sign,
     };
     perm_sign * canon
 }
@@ -237,188 +342,28 @@ pub fn orient_sos(a: &Vec3, b: &Vec3, c: &Vec3, ia: PointId, ib: PointId, ic: Po
 /// so it is purely a total-function guard.
 #[inline]
 fn sos_sorted_sign(p: &Vec3, q: &Vec3, r: &Vec3) -> i32 {
-    let minors = [
-        (1.0, q[0] * r[1] - q[1] * r[0]),
-        (-1.0, q[0] * r[2] - q[2] * r[0]),
-        (1.0, q[1] * r[2] - q[2] * r[1]),
-        (-1.0, p[0] * r[1] - p[1] * r[0]),
-        (1.0, p[0] * r[2] - p[2] * r[0]),
-        (-1.0, p[1] * r[2] - p[2] * r[1]),
-        (1.0, p[0] * q[1] - p[1] * q[0]),
-        (-1.0, p[0] * q[2] - p[2] * q[0]),
-        (1.0, p[1] * q[2] - p[2] * q[1]),
+    // Each minor's sign is decided exactly ([`minor_exact_sign`]): the tie-
+    // break sequence needs the same joint consistency as the determinant, and
+    // a rounded minor near zero would reintroduce the very noise SoS exists
+    // to remove.  Evaluated lazily — the first minor usually decides.
+    let minors: [(i32, (f64, f64, f64, f64)); 9] = [
+        (1, (q[0], r[1], q[1], r[0])),
+        (-1, (q[0], r[2], q[2], r[0])),
+        (1, (q[1], r[2], q[2], r[1])),
+        (-1, (p[0], r[1], p[1], r[0])),
+        (1, (p[0], r[2], p[2], r[0])),
+        (-1, (p[1], r[2], p[2], r[1])),
+        (1, (p[0], q[1], p[1], q[0])),
+        (-1, (p[0], q[2], p[2], q[0])),
+        (1, (p[1], q[2], p[2], q[1])),
     ];
-    for (sgn, val) in minors {
-        if val > 0.0 {
-            return sgn as i32;
-        }
-        if val < 0.0 {
-            return -(sgn as i32);
+    for (sgn, (w, x, y, z)) in minors {
+        let s = minor_exact_sign(w, x, y, z);
+        if s != 0 {
+            return sgn * s;
         }
     }
     1
-}
-
-/// Robust sign of the half-plane determinant `(u × v) · n` as `-1 | +1`, where
-/// `n` is the edge's great-circle normal (`a × b`).  This is the per-endpoint
-/// wedge test inside [`on_minor_arc`]; on the edge's great circle `u × v` is
-/// parallel to `±n`, so the sign says whether `v` lies the same rotational way
-/// from `u` as `b` does from `a`.
-///
-/// Like [`orient_sos`], the decision is taken on a **canonical** (identity-
-/// sorted) evaluation with the sort parity reapplied: the determinant is
-/// antisymmetric in `(u, v)`, so the same geometry rounds the same way in every
-/// argument order, killing the f64-noise sign flip when `x` lies exactly on the
-/// edge's great circle.  An exact-`0.0` determinant (`u`, `v` parallel — the
-/// probe coincident with an endpoint) is broken by Simulation of Simplicity: the
-/// canonical-lower-id point is perturbed first along `e₀, e₁, e₂`, and the first
-/// non-vanishing term decides.  The result is **total** (never `0`) and
-/// antisymmetric, matching the `orient_sos` contract the straddle gates rely on.
-#[inline]
-fn half_plane_sign(u: &Vec3, v: &Vec3, n: &Vec3, iu: PointId, iv: PointId) -> i32 {
-    // Canonical order by identity, parity tracked (the det negates under a swap).
-    let (p, q, perm) = if iu <= iv { (u, v, 1) } else { (v, u, -1) };
-    let det = dot(&cross(p, q), n);
-    let canon = if det > 0.0 {
-        1
-    } else if det < 0.0 {
-        -1
-    } else {
-        // p ∥ q: symbolic perturbation, lower-id point (p) first then q.
-        sos_half_plane_sign(p, q, n)
-    };
-    perm * canon
-}
-
-/// SoS tie-break for [`half_plane_sign`] when `(p × q) · n` vanishes (the two
-/// points are parallel).  Perturbs the canonical-lower point `p` along the unit
-/// axes `e₀, e₁, e₂` (largest perturbation), then `q`; the first non-zero term
-/// `(eₖ × q) · n` / `(p × eₖ) · n` decides.  Returns a guaranteed non-zero
-/// `-1 | +1`; the final `+1` is reached only if `n` is the zero vector (a
-/// degenerate edge `a ∥ b`), which the descent never feeds, so it is a
-/// total-function guard.
-#[inline]
-fn sos_half_plane_sign(p: &Vec3, q: &Vec3, n: &Vec3) -> i32 {
-    let e = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
-    for ek in &e {
-        let t = dot(&cross(ek, q), n);
-        if t > 0.0 {
-            return 1;
-        }
-        if t < 0.0 {
-            return -1;
-        }
-    }
-    for ek in &e {
-        let t = dot(&cross(p, ek), n);
-        if t > 0.0 {
-            return 1;
-        }
-        if t < 0.0 {
-            return -1;
-        }
-    }
-    1
-}
-
-/// Is unit vector `x` on the **minor** great-circle arc from `a` to `b`,
-/// counting the arc as half-open `[a, b)` — the start endpoint is on the arc,
-/// the end endpoint is not?
-///
-/// `x` is between `a` and `b` on the shorter arc iff it lies the same rotational
-/// direction from `a` as `b` does and continues that direction to `b`.  The
-/// half-open convention is what makes the crossing count correct when the
-/// reference→point arc passes exactly **through a ring vertex**: the vertex is
-/// shared by two edges, and `[start, end)` assigns the grazing crossing to
-/// exactly one of them, so it is counted once rather than twice or zero times.
-/// Used by [`robust_crossing`] to confirm a great-circle intersection falls on
-/// the real segments and not their antipodal halves (the failure mode of a bare
-/// 4-orientation straddle on long arcs).
-///
-/// `x` is on the great circle in this call (it is the AB×CD intersection), so the
-/// two wedge determinants are O(1) in the arc interior and the raw f64 sign is
-/// only noise-prone when `x` lands near an endpoint (`±a` / `±b`) — the #78
-/// degeneracy.  Each wedge sign goes through [`half_plane_sign`], decided on a
-/// canonical, identity-keyed order, so it cannot flip under argument/edge
-/// reordering.  The half-open `[a, b)` convention is kept without a tolerance: an
-/// `x` coinciding **exactly** with the start vertex `a` is included and one
-/// coinciding with the end vertex `b` is excluded (coincidence ⇔ the cross
-/// product is exactly the zero vector and the points are not antipodal), exactly
-/// as the original `>= 0.0` / `> 0.0` bounds did.  `ix`, `ia`, `ib` are the SoS
-/// identities of `x`, `a`, `b`.
-#[inline]
-fn on_minor_arc(x: &Vec3, a: &Vec3, b: &Vec3, ix: PointId, ia: PointId, ib: PointId) -> bool {
-    let n = cross(a, b);
-    // Start bound is inclusive at a, end bound exclusive at b: settle exact
-    // endpoint coincidence first (order-independent), then the robust wedge sign.
-    if coincident(x, b) {
-        return false; // x ≡ b ⇒ end excluded
-    }
-    // Start is inclusive at a: x ≡ a satisfies it outright, else the robust wedge.
-    let s_start = half_plane_sign(a, x, &n, ia, ix);
-    let s_end = half_plane_sign(x, b, &n, ix, ib);
-    // Invariant: the SoS-hardened wedge sign is total — never undecided (#78).
-    debug_assert!(
-        s_start != 0 && s_end != 0,
-        "on_minor_arc wedge sign must be total"
-    );
-    (coincident(x, a) || s_start > 0) && s_end > 0
-}
-
-/// Do unit vectors `p` and `q` point in exactly the same direction?  True iff
-/// `p × q` is the exact zero vector (parallel) and `p · q > 0` (not antipodal).
-/// This is a tolerance-free coincidence test for the endpoint cases of
-/// [`on_minor_arc`].
-#[inline]
-fn coincident(p: &Vec3, q: &Vec3) -> bool {
-    cross(p, q) == [0.0, 0.0, 0.0] && dot(p, q) > 0.0
-}
-
-/// Robust great-circle-*segment* crossing using [`orient_sos`].
-///
-/// Returns `true` iff the arcs `a → b` and `c → d` cross at a point interior to
-/// both.  A 4-orientation straddle test (each pair on opposite sides of the
-/// other's great circle) is necessary but **not** sufficient for arcs longer
-/// than a quadrant — the two great circles meet at two antipodal points, and the
-/// straddle can be satisfied by the one on the *far* halves.  So we additionally
-/// locate the intersection and require it to lie on both minor arcs
-/// ([`on_minor_arc`]).  This keeps the test correct for the long reference→point
-/// arc of the crossing-number PIP, where [`arcs_cross`]'s minor-arc precondition
-/// does not hold.  SoS makes the straddle decisions total, so coplanar and
-/// shared-endpoint configurations resolve to a definite, consistent side.
-#[inline]
-#[allow(clippy::too_many_arguments)]
-pub fn robust_crossing(
-    a: &Vec3,
-    b: &Vec3,
-    c: &Vec3,
-    d: &Vec3,
-    ia: PointId,
-    ib: PointId,
-    ic: PointId,
-    id: PointId,
-) -> bool {
-    // c, d must straddle great circle AB and a, b must straddle great circle CD.
-    let abc = orient_sos(a, b, c, ia, ib, ic);
-    let abd = orient_sos(a, b, d, ia, ib, id);
-    if abc == abd {
-        return false;
-    }
-    let cda = orient_sos(c, d, a, ic, id, ia);
-    let cdb = orient_sos(c, d, b, ic, id, ib);
-    if cda == cdb {
-        return false;
-    }
-    // Disambiguate which antipodal intersection the straddle refers to: it must
-    // lie on both minor arcs.  (The intersection is along ±(AB × CD).)  The
-    // on-arc tests carry SoS identities so an `x` landing exactly on an endpoint
-    // resolves to a definite, traversal-order-independent side (#78).
-    let xi = INTERSECTION_ID;
-    let mut x = normalize(&cross(&cross(a, b), &cross(c, d)));
-    if !on_minor_arc(&x, a, b, xi, ia, ib) {
-        x = [-x[0], -x[1], -x[2]];
-    }
-    on_minor_arc(&x, a, b, xi, ia, ib) && on_minor_arc(&x, c, d, xi, ic, id)
 }
 
 /// Uniform symbolic minor-arc crossing, decided purely by [`orient_sos`] signs
@@ -431,8 +376,8 @@ pub fn robust_crossing(
 /// four signs jointly encode which antipodal intersection the straddle refers
 /// to, so no constructed intersection point is needed).
 ///
-/// This is the replacement for the two-stage [`robust_crossing`] pipeline
-/// (straddle gates + float-constructed intersection + [`on_minor_arc`]): that
+/// This replaces the retired two-stage `robust_crossing` pipeline
+/// (straddle gates + float-constructed intersection + `on_minor_arc`): that
 /// pipeline resolved the same degeneracy in three different implicit ways, and
 /// issue #103 showed they can disagree by one crossing — a vertex graze counted
 /// by luck through a bit-exact `coincident` hit on one edge and dropped on the
@@ -446,8 +391,11 @@ pub fn robust_crossing(
 /// one** crossing across the two incident edges when the boundary passes
 /// through the probe circle (and zero or two when it grazes), keeping the
 /// even-odd fill parity consistent: the half-open `[a, b)` convention emerges
-/// instead of being hand-maintained.  Total and reorder-invariant; `ia, ib,
-/// ic, id` are the SoS identities of the four endpoints.
+/// instead of being hand-maintained.  Total and reorder-invariant **provided
+/// the four SoS identities are pairwise distinct** — a duplicated id makes the
+/// symbolic perturbation ill-defined and voids the invariance; every call site
+/// (probe ids, vertex ids, corner ids) draws from disjoint ranges.  `ia, ib,
+/// ic, id` are the identities of the four endpoints.
 #[inline]
 #[allow(clippy::too_many_arguments)] // 4 points + 4 SoS ids, same shape as robust_crossing
 pub fn arcs_cross_sos(

--- a/src_rust/src/sphere.rs
+++ b/src_rust/src/sphere.rs
@@ -481,11 +481,10 @@ fn ring_winding_at(x: &Vec3, ring: &[Vec3]) -> f64 {
 /// untouched. A ring supplied with reversed orientation selects the
 /// complementary region — not a bug, the documented contract.
 ///
-/// The companion SoS predicates [`orient_sos`] and [`robust_crossing`] are the
-/// orientation-only building blocks the descent's per-cell parity flips will use
-/// in a later phase; an *edge-crossing* PIP built on them is deferred while its
-/// long-arc / scalloped-boundary behaviour is validated against this winding
-/// reference.
+/// The companion SoS predicates [`orient_sos`] and [`arcs_cross_sos`] are the
+/// orientation-only building blocks the descent's per-cell parity flips use; an
+/// *edge-crossing* PIP built on them is deferred while its long-arc /
+/// scalloped-boundary behaviour is validated against this winding reference.
 pub fn point_in_ring_robust(p: &Vec3, ring: &[Vec3]) -> bool {
     if ring.len() < 3 {
         return false;

--- a/src_rust/src/sphere/tests.rs
+++ b/src_rust/src/sphere/tests.rs
@@ -232,10 +232,10 @@ fn test_robust_crossing_basic() {
         latlon_to_unit_vec(0.0, -10.0),
         latlon_to_unit_vec(0.0, 10.0),
     );
-    assert!(robust_crossing(&ns.0, &ns.1, &ew.0, &ew.1, 0, 1, 2, 3));
+    assert!(arcs_cross_sos(&ns.0, &ns.1, &ew.0, &ew.1, 0, 1, 2, 3));
     let a = ring(&[(20.0, -10.0), (20.0, 10.0)]);
     let b = ring(&[(40.0, -10.0), (40.0, 10.0)]);
-    assert!(!robust_crossing(&a[0], &a[1], &b[0], &b[1], 0, 1, 2, 3));
+    assert!(!arcs_cross_sos(&a[0], &a[1], &b[0], &b[1], 0, 1, 2, 3));
 }
 
 #[test]
@@ -250,7 +250,7 @@ fn test_robust_crossing_rejects_far_intersection() {
     let c = latlon_to_unit_vec(80.0, 180.0);
     let d = latlon_to_unit_vec(80.0, 200.0);
     assert!(
-        !robust_crossing(&r, &p, &c, &d, 0, 1, 2, 3),
+        !arcs_cross_sos(&r, &p, &c, &d, 0, 1, 2, 3),
         "long arc must not falsely cross a far north-cap edge"
     );
 }
@@ -304,7 +304,7 @@ fn crossing_under_reorder(
         let (q0, q1, j0, j1) = e2;
         for &(pa, pb, pia, pib) in &[(p0, p1, i0, i1), (p1, p0, i1, i0)] {
             for &(pc, pd, pic, pid) in &[(q0, q1, j0, j1), (q1, q0, j1, j0)] {
-                out.insert(robust_crossing(pa, pb, pc, pd, pia, pib, pic, pid));
+                out.insert(arcs_cross_sos(pa, pb, pc, pd, pia, pib, pic, pid));
             }
         }
     }
@@ -794,7 +794,7 @@ fn crossing_pip(r: &Vec3, p: &Vec3, ring: &[Vec3]) -> bool {
         let a = &ring[i];
         let b = &ring[(i + 1) % n];
         let (ia, ib) = (i as PointId + 2, ((i + 1) % n) as PointId + 2);
-        if robust_crossing(r, p, a, b, 0, 1, ia, ib) {
+        if arcs_cross_sos(r, p, a, b, 0, 1, ia, ib) {
             crossings += 1;
         }
     }
@@ -891,24 +891,24 @@ fn rotate_about(v: &Vec3, axis: &Vec3, theta: f64) -> Vec3 {
 // ── arcs_cross_sos: the uniform symbolic crossing predicate (issue #103) ──
 
 #[test]
-fn test_arcs_cross_sos_matches_robust_crossing_non_degenerate() {
-    // On clean (non-degenerate) quadruples the symbolic predicate must agree
-    // with the existing robust_crossing pipeline it replaces.  (Not with the
-    // bare arcs_cross: the straddle-only test is wrong on antipodal
-    // quadruples, which this grid contains — pinned separately below.)  Skip
-    // shared endpoints and any quadruple with a near-zero orientation —
-    // exactly the configurations the symbolic predicate exists to fix.
+fn test_arcs_cross_sos_matches_arcs_cross_hemisphere_confined() {
+    // Differential check against the plain geometric arcs_cross.  The bare
+    // straddle test is only a valid oracle when both arcs sit inside one open
+    // hemisphere (the two great circles then meet at most once there, so a
+    // straddle is a crossing); the antipodal counterexample is pinned in the
+    // rejection test below.  Skip shared endpoints and near-zero orientations
+    // — exactly the configurations the symbolic predicate exists to fix.
     let pts = ring(&[
         (-10.0, 0.0),
         (10.0, 0.0),
         (0.0, -10.0),
         (0.0, 10.0),
-        (40.0, -125.0),
-        (50.0, -115.0),
-        (-72.0, 30.0),
-        (12.0, 88.0),
-        (33.0, 171.0),
-        (-45.0, -60.0),
+        (40.0, -55.0),
+        (50.0, -45.0),
+        (-32.0, 30.0),
+        (12.0, 48.0),
+        (33.0, 71.0),
+        (-45.0, -20.0),
     ]);
     let degenerate = |a: &Vec3, b: &Vec3, c: &Vec3| orient(a, b, c).abs() < 1e-9;
     let mut checked = 0;
@@ -920,7 +920,10 @@ fn test_arcs_cross_sos_matches_robust_crossing_non_degenerate() {
                         continue;
                     }
                     let (pa, pb, pc, pd) = (&pts[a], &pts[b], &pts[c], &pts[d]);
-                    if degenerate(pa, pc, pb)
+                    let quad = [pa, pb, pc, pd];
+                    let confined = (0..4).all(|i| (i + 1..4).all(|j| dot(quad[i], quad[j]) > 0.1));
+                    if !confined
+                        || degenerate(pa, pc, pb)
                         || degenerate(pc, pb, pd)
                         || degenerate(pb, pd, pa)
                         || degenerate(pd, pa, pc)
@@ -929,8 +932,8 @@ fn test_arcs_cross_sos_matches_robust_crossing_non_degenerate() {
                     }
                     assert_eq!(
                         arcs_cross_sos(pa, pb, pc, pd, a as u64, b as u64, c as u64, d as u64),
-                        robust_crossing(pa, pb, pc, pd, a as u64, b as u64, c as u64, d as u64),
-                        "disagrees with robust_crossing at ({a},{b},{c},{d})"
+                        arcs_cross(pa, pb, pc, pd),
+                        "disagrees with arcs_cross at ({a},{b},{c},{d})"
                     );
                     checked += 1;
                 }

--- a/src_rust/src/sphere/tests.rs
+++ b/src_rust/src/sphere/tests.rs
@@ -887,3 +887,206 @@ fn rotate_about(v: &Vec3, axis: &Vec3, theta: f64) -> Vec3 {
         v[2] * c + k_cross_v[2] * s + axis[2] * k_dot_v * (1.0 - c),
     ]
 }
+
+// ── arcs_cross_sos: the uniform symbolic crossing predicate (issue #103) ──
+
+#[test]
+fn test_arcs_cross_sos_matches_robust_crossing_non_degenerate() {
+    // On clean (non-degenerate) quadruples the symbolic predicate must agree
+    // with the existing robust_crossing pipeline it replaces.  (Not with the
+    // bare arcs_cross: the straddle-only test is wrong on antipodal
+    // quadruples, which this grid contains — pinned separately below.)  Skip
+    // shared endpoints and any quadruple with a near-zero orientation —
+    // exactly the configurations the symbolic predicate exists to fix.
+    let pts = ring(&[
+        (-10.0, 0.0),
+        (10.0, 0.0),
+        (0.0, -10.0),
+        (0.0, 10.0),
+        (40.0, -125.0),
+        (50.0, -115.0),
+        (-72.0, 30.0),
+        (12.0, 88.0),
+        (33.0, 171.0),
+        (-45.0, -60.0),
+    ]);
+    let degenerate = |a: &Vec3, b: &Vec3, c: &Vec3| orient(a, b, c).abs() < 1e-9;
+    let mut checked = 0;
+    for a in 0..pts.len() {
+        for b in 0..pts.len() {
+            for c in 0..pts.len() {
+                for d in 0..pts.len() {
+                    if a == b || a == c || a == d || b == c || b == d || c == d {
+                        continue;
+                    }
+                    let (pa, pb, pc, pd) = (&pts[a], &pts[b], &pts[c], &pts[d]);
+                    if degenerate(pa, pc, pb)
+                        || degenerate(pc, pb, pd)
+                        || degenerate(pb, pd, pa)
+                        || degenerate(pd, pa, pc)
+                    {
+                        continue;
+                    }
+                    assert_eq!(
+                        arcs_cross_sos(pa, pb, pc, pd, a as u64, b as u64, c as u64, d as u64),
+                        robust_crossing(pa, pb, pc, pd, a as u64, b as u64, c as u64, d as u64),
+                        "disagrees with robust_crossing at ({a},{b},{c},{d})"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+    }
+    assert!(checked > 1000, "fuzz grid too sparse ({checked})");
+}
+
+#[test]
+fn test_arcs_cross_sos_rejects_antipodal_straddle() {
+    // Both straddle conditions hold for two tiny arcs in antipodal regions
+    // (their great circles meet on the far side), yet the arcs do not cross.
+    // The old pipeline needed the constructed-x on_minor_arc stage for this;
+    // the four-sign identity encodes it directly.
+    let a = latlon_to_unit_vec(0.0, -5.0);
+    let b = latlon_to_unit_vec(0.0, 5.0);
+    let c = latlon_to_unit_vec(-5.0, 180.0);
+    let d = latlon_to_unit_vec(5.0, 180.0);
+    // The bare 4-orientation straddle is fooled ...
+    let n_ab = cross(&a, &b);
+    let n_cd = cross(&c, &d);
+    assert!(
+        (dot(&n_ab, &c) > 0.0) != (dot(&n_ab, &d) > 0.0)
+            && (dot(&n_cd, &a) > 0.0) != (dot(&n_cd, &b) > 0.0),
+        "precondition: straddle gates alone accept the antipodal pair"
+    );
+    // ... the symbolic predicate is not.
+    assert!(!arcs_cross_sos(&a, &b, &c, &d, 0, 1, 2, 3));
+    // And the genuine crossing at the origin still reports.
+    let e = latlon_to_unit_vec(-5.0, 0.0);
+    let f = latlon_to_unit_vec(5.0, 0.0);
+    assert!(arcs_cross_sos(&a, &b, &e, &f, 0, 1, 2, 3));
+}
+
+#[test]
+fn test_arcs_cross_sos_issue_103_meridian_vertex_graze() {
+    // The exact parity-breaking configuration from issue #103: the descent
+    // probe leg between the centres of nested pixels 19@depth1 and 79@depth2
+    // (both on the lon-0 meridian, y == 0 bit-exact) against the box
+    // lat[20,25] lon[0,5], whose west edge lies ON that meridian.  The old
+    // pipeline counted the graze at vertex (20,0) once (bit-exact coincident
+    // hit) and the one at (25,0) zero times (wedge determinant rounded to
+    // +8e-20, so the SoS tie-break never engaged) — odd parity, subtree-wide
+    // fill inversion.  The symbolic predicate counts each vertex passage
+    // exactly once: edges E0 and E2 cross, E1 and the probe-collinear E3 do
+    // not — parity even, matching both endpoints lying outside the box.
+    use crate::cell_geom::cell_center_vec;
+
+    let p = cell_center_vec(1, 19);
+    let q = cell_center_vec(2, 79);
+    assert_eq!((p[1], q[1]), (0.0, 0.0), "probe endpoints bit-exact on y=0");
+    let v = [
+        latlon_to_unit_vec(20.0, 0.0),
+        latlon_to_unit_vec(20.0, 5.0),
+        latlon_to_unit_vec(25.0, 5.0),
+        latlon_to_unit_vec(25.0, 0.0),
+    ];
+    let crossings: Vec<bool> = (0..4)
+        .map(|i| {
+            let j = (i + 1) % 4;
+            arcs_cross_sos(&p, &q, &v[i], &v[j], 0, 1, 2 + i as u64, 2 + j as u64)
+        })
+        .collect();
+    assert_eq!(
+        crossings,
+        vec![true, false, true, false],
+        "E0/E2 cross once each; E1 and the collinear E3 do not"
+    );
+}
+
+#[test]
+fn test_arcs_cross_sos_parity_even_under_id_relabeling() {
+    // Individual crossing attributions may legitimately move between incident
+    // edges under a different SoS id assignment; the load-bearing invariant is
+    // the total parity.  Both probe endpoints are outside the box, so the
+    // crossing count must stay even for every vertex-id rotation.
+    use crate::cell_geom::cell_center_vec;
+
+    let p = cell_center_vec(1, 19);
+    let q = cell_center_vec(2, 79);
+    let v = [
+        latlon_to_unit_vec(20.0, 0.0),
+        latlon_to_unit_vec(20.0, 5.0),
+        latlon_to_unit_vec(25.0, 5.0),
+        latlon_to_unit_vec(25.0, 0.0),
+    ];
+    for rot in 0..4u64 {
+        let count = (0..4)
+            .filter(|&i| {
+                let j = (i + 1) % 4;
+                arcs_cross_sos(
+                    &p,
+                    &q,
+                    &v[i],
+                    &v[j],
+                    0,
+                    1,
+                    2 + (i as u64 + rot) % 4,
+                    2 + (j as u64 + rot) % 4,
+                )
+            })
+            .count();
+        assert_eq!(count % 2, 0, "odd parity under id rotation {rot}");
+    }
+}
+
+#[test]
+fn test_arcs_cross_sos_vertex_graze_counts_once() {
+    // A probe passing exactly through a shared ring vertex whose two incident
+    // edges continue to opposite sides of the probe circle must count exactly
+    // one crossing across the pair — the emergent half-open convention.  Run
+    // it on the axis-aligned meridian family and on tilted copies so the
+    // degeneracy is not coordinate luck.
+    let axis_cases: Vec<([Vec3; 3], [Vec3; 2])> = vec![
+        // (u, v, w): v on the probe circle (lon 0), u west, w east.
+        (
+            [
+                latlon_to_unit_vec(30.0, -8.0),
+                latlon_to_unit_vec(35.0, 0.0),
+                latlon_to_unit_vec(32.0, 7.0),
+            ],
+            [latlon_to_unit_vec(20.0, 0.0), latlon_to_unit_vec(50.0, 0.0)],
+        ),
+        // equator probe, vertex exactly on it
+        (
+            [
+                latlon_to_unit_vec(-6.0, 100.0),
+                latlon_to_unit_vec(0.0, 103.0),
+                latlon_to_unit_vec(9.0, 106.0),
+            ],
+            [
+                latlon_to_unit_vec(0.0, 95.0),
+                latlon_to_unit_vec(0.0, 110.0),
+            ],
+        ),
+    ];
+    let tilt_axis = normalize(&[0.3, -0.5, 0.81]);
+    for (tilt, theta) in [(false, 0.0), (true, 0.4), (true, 1.1)] {
+        for (tri, probe) in &axis_cases {
+            let mv = |x: &Vec3| {
+                if tilt {
+                    rotate_about(x, &tilt_axis, theta)
+                } else {
+                    *x
+                }
+            };
+            let (u, v, w) = (mv(&tri[0]), mv(&tri[1]), mv(&tri[2]));
+            let (p, q) = (mv(&probe[0]), mv(&probe[1]));
+            let c1 = arcs_cross_sos(&p, &q, &u, &v, 0, 1, 2, 3);
+            let c2 = arcs_cross_sos(&p, &q, &v, &w, 0, 1, 3, 4);
+            assert_eq!(
+                c1 as u32 + c2 as u32,
+                1,
+                "vertex passage must count exactly once (tilt {theta})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #103. Refs #78, #87, #44 (the prior per-predicate hardenings this generalizes), #90 (re-scoped on the back of this PR), #107 (the follow-up limitation this PR's oracle discovered).

## What this does

Implements the plan agreed on the issue thread ([approach (1)](https://github.com/espg/mortie/issues/103#issuecomment-4930976666), [sign-off + closed-set semantics](https://github.com/espg/mortie/issues/103#issuecomment-4931072519)): one uniform symbolic crossing predicate for every sidedness decision in the coverage descent. **All the issue's reproducers now come back in-band** (see "How it was tested").

## Phases

- [x] **Phase 1 — the predicate + differential tests.** `arcs_cross_sos` in `src_rust/src/sphere.rs`: arcs cross iff the four orientations `[a c b]`, `[c b d]`, `[b d a]`, `[d a c]` share a sign (the S2 `SimpleCrossing` identity), each through the SoS-hardened `orient_sos`. No constructed intersection point. Five test groups incl. the exact #103 parity-breaking configuration (pinned) and vertex-graze-counts-once.
- [x] **Phase 2 — wiring + the deeper fixes the parity oracle forced.** Call-site swap (old `robust_crossing`/`on_minor_arc` pipeline deleted); closed-set touch semantics with a segment gate (`edge_hits_cell_edge`); the parity oracle `debug_assert` (uniform-cell fill must equal the independent winding PIP); globally unique UNIQ-coded SoS ids for cell centres (positional ids made the fill chain path-dependent at boundary-coincident centres); seed hardening (`seed_fill` geometric ambiguity detection + `base_fills` donor chaining); **exact determinant signs** under `orient_sos` (Shewchuk error-free expansions, std-only, no new dependency, filter-guarded) — near-coplanar noise signs were jointly inconsistent across triples, the residual #103 mechanism off the bit-exact grid.
- [x] **Phase 3 — regression matrix** (`mortie/tests/test_coverage_boundary.py`, 87 tests): all six degenerate meridians incl. 315 × three latitude bands × both sides × both hemispheres; equator edges incl. through (0,0); the non-monotone width family; flagship reproducers at original orders; winding invariance. Asserts superset / no-escape (bulge-aware) / flat == densified MOC.
- [x] **Phase 4 — folded self-review findings.** Major: `base_fills`' donor chain ran ~122° chords through the bare two-straddle fast path (antipodal phantom crossings) — now unconditionally symbolic, reviewer's reproducer pinned. Medium: the closed-set span gate's cos-space epsilon → angular (`sin ρ`-scaled). Plus docstring precondition, rustdoc link, stale docs.
- [x] **Phase 5 — perf recovery for the CodSpeed regression.** The −15..35% on clean-geometry coverage benches traced to `edge_hits_cell_edge` computing all four determinants up front where `arcs_cross_n` exited after two on the common corners-same-side case (the straddle-test hot path), plus per-seed re-normalization of edge normals in `seed_fill`. The two-dot early exit is restored (same shape as the retired `arcs_cross_n`), unit normals are computed once per descent, and `center_id` is hoisted out of the corner loops. One documented closed-set nuance from the fast exit: a pure vertex-**point** touch on a cell edge with the polygon strictly outside is guaranteed only for the vertex's leaf-owning cell; edge-collinear touches — the systematic on-grid family the contract exists for — are always degenerate-path and fully honored. Awaiting CodSpeed re-measure on this head; the exact-arithmetic layer itself is filter-guarded and was never the cost.

## How it was tested

- `cargo test` — 197 passed (parity oracle live in the test profile), 1 deliberately `#[ignore]`d (#107). `cargo clippy` no new warnings; `cargo fmt --check` clean.
- `maturin develop --release` + `pytest` — **635 passed** (87 new matrix tests), 11 skipped; `flake8` clean.
- Issue reproducers, before → after at the issue's orders: belt `lon[0,5]` o9 1687-cells-spanning-the-globe → **1887 in-band** (control 1886); cap `lon[44,45]` o6 829-to-the-pole → **13 in-band**; 315° mirror-symmetric (**13**); southern mirror **13**; ring sector o9 775-reaching-−89.9 → **87**, max dip −87.26 vs the polygon's own chord dip of −87.53.

## Questions for review

1. ~~Known limitation~~ → filed as **#107** with the full diagnosis per your go-ahead (`#[ignore]`d acceptance test in-tree).
2. Module sizes (`sphere/tests.rs`, `coverage.rs` past ~1000 lines) — **deferred to the 1.x freeze sweep (#68)** per your call.
3. #90 — **re-scoped** per your ask ([comment](https://github.com/espg/mortie/issues/90#issuecomment-4932545686)): unblocked by this PR, baseline moves here, relaxation target excludes closed-set touch refinements, parity oracle as guard rail.
4. **New (phase 5):** is the vertex-point-touch nuance above acceptable as the closed-set contract's fine print, or do you want the neighbor cell guaranteed too (costs the two extra dots on the hot path — roughly the difference CodSpeed flagged)?