### PR TITLE
Gate the seed cull to sub-hemisphere caps

### DIFF
--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -696,8 +696,15 @@ fn base_fills(edges: &[Edge], rings: &[Vec<Vec3>], cap: &Cap, complement: bool) 
     // winding PIP for it was the dominant fixed cost CodSpeed flagged on
     // small polygons (12 PIPs where pre-#103 code paid ~2).  Culled bases
     // keep fill = false; base_node returns None for them regardless.
+    // The cull-skip's exactness argument (an excluded centre is provably
+    // outside the polygon, so fill = false is a valid donor verdict) needs
+    // the boundary contained in the vertex cap, which cap convexity only
+    // gives for sub-hemisphere caps: a minor arc between in-cap vertices can
+    // exit a > 90° cap by up to a quadrant.  Gate the skip accordingly —
+    // oversize caps classify all 12 seeds, the pre-#109 behavior.
+    let cullable = !complement && cap.radius <= std::f64::consts::FRAC_PI_2;
     for b in 0..12u64 {
-        if !complement {
+        if cullable {
             let center = &centers[b as usize];
             let corners = cell_corners(0, b);
             let (cos_cr, sin_cr) = cell_cos_radius(center, &corners);
@@ -730,11 +737,15 @@ fn base_fills(edges: &[Edge], rings: &[Vec<Vec3>], cap: &Cap, complement: bool) 
         if known[b as usize] {
             continue;
         }
-        // A non-antipodal known donor always exists: each base has exactly one
-        // antipodal partner, and at least one other seed is known.
-        let d = (0..12u64)
-            .find(|&d| known[d as usize] && !antipodal_base(b, d))
-            .expect("a non-antipodal known donor base centre");
+        // A non-antipodal known donor almost always exists (each base has
+        // exactly one antipodal partner).  The pathological residue — every
+        // candidate ambiguous and the only known seed antipodal to `b` —
+        // falls back to the raw winding verdict rather than panicking.
+        let Some(d) = (0..12u64).find(|&d| known[d as usize] && !antipodal_base(b, d)) else {
+            fill[b as usize] = parity_filled_robust(&centers[b as usize], rings);
+            known[b as usize] = true;
+            continue;
+        };
         // Chain arcs between base centres reach ~122°, where the bare
         // two-straddle fast path of `edge_crosses_probe` also fires on the
         // *far* intersection of the two great circles (an edge antipodal to

--- a/src_rust/src/coverage/tests.rs
+++ b/src_rust/src/coverage/tests.rs
@@ -603,3 +603,34 @@ fn test_descent_hemisphere_ring_collinear_edge_oracle() {
     let cov = polygon_to_morton_coverage(&lats, &lons, 6, true);
     assert!(!cov.is_empty());
 }
+
+#[test]
+fn test_base_fills_oversize_cap_classifies_all_seeds() {
+    use crate::sphere::parity_filled_robust;
+    // A ring whose vertex cap exceeds 90°: cap convexity no longer bounds
+    // the boundary, so the cull-skip must disengage and every seed the
+    // winding backend can classify must carry its own verdict (PR #109
+    // review follow-up) — a culled false would not be provably exact here.
+    let lats = vec![80.0, -10.0, -60.0, -10.0, 80.0];
+    let lons = vec![0.0, 60.0, 130.0, 200.0, 260.0];
+    let rings = build_rings(&[lats], &[lons], true);
+    let edges = build_edges(&rings, 6);
+    let cap = Cap::of_rings(&rings);
+    assert!(
+        cap.radius > std::f64::consts::FRAC_PI_2,
+        "cap must be oversize"
+    );
+    let complement = covers_complement(&rings, &cap);
+    let fills = base_fills(&edges, &rings, &cap, complement);
+    let units: Vec<Vec3> = edges.iter().map(|e| normalize(&e.n_ab)).collect();
+    for b in 0..12u64 {
+        let c = cell_center_vec(0, b);
+        if seed_fill(&c, &units, &rings).is_some() {
+            assert_eq!(
+                fills[b as usize],
+                parity_filled_robust(&c, &rings),
+                "seed {b} diverged under an oversize cap"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Refs PR #109 (merged before its adversarial self-review finished; this folds the review's findings — [review thread](https://github.com/espg/mortie/pull/109)).

## What this does

The #109 review verified the cull-skip's "culled ⇒ provably outside ⇒ `fill = false` is an exact donor verdict" argument is airtight **only for vertex caps ≤ 90°**: cap convexity bounds the polygon boundary inside the cap for sub-hemisphere caps, but a minor arc between in-cap vertices can exit a >90° cap by up to a quadrant and pass exactly through a culled base centre. The review's differential fuzz (423 adversarial configs vs the pre-#109 `base_fills`, plus 60 end-to-end rings vs a main-built wheel) found **zero live divergence** — the exposure is the bit-exact incidence family only — but the fix is free:

1. **The cull-skip now engages only when `cap.radius ≤ π/2`** (and not complement, as before). Oversize-cap polygons classify all 12 seeds — the pre-#109 behavior — which costs nothing in practice: polygons with >90° vertex caps are the rare, already-expensive case.
2. **The donor `.expect()` panic sliver is gone**: if every candidate donor is ambiguous and the only known seed is antipodal to `b` (a pathological configuration the review constructed), the seed falls back to the raw winding verdict instead of panicking.
3. **Regression test**: `test_base_fills_oversize_cap_classifies_all_seeds` pins a 98.5°-cap ring — every winding-classifiable seed must carry its own verdict under the disengaged cull.

## How it was tested

- `cargo test` — 198 passed (parity oracle live), 1 `#[ignore]`d (#107); clippy/fmt clean.
- `maturin develop --release` + `pytest` — 670 passed, 11 skipped; `flake8` clean.

## Questions for review

None — a strictly-tightening guard; perf-neutral for every benchmarked shape (the gate is one comparison per descent).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3JyUn7YUxZ294nxbu8Jw8)_