### PR TITLE
Cause-tagged node_straddles instrumentation + over-refinement measurement (issue #90, phases 1-2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,20 @@ healpix = "0.3.3"
 smallvec = "1"
 arrow = { version = "53", features = ["ffi"] }
 
+[features]
+# Cause-tagged `node_straddles` instrumentation for the issue #90 measurement.
+# A cfg flag only (no dependency); off by default so release builds compile
+# none of it.  Build dev wheels with:
+#   maturin develop --release --features descent-stats
+descent-stats = []
+
 [dev-dependencies]
 criterion = { version = "4.3.0", package = "codspeed-criterion-compat" }
+
+[[test]]
+name = "descent_stats"
+path = "src_rust/tests/descent_stats.rs"
+required-features = ["descent-stats"]
 
 [profile.release]
 opt-level = 3

--- a/benchmarks/measure_straddle_overrefinement.py
+++ b/benchmarks/measure_straddle_overrefinement.py
@@ -210,6 +210,10 @@ def measure_stats(lats, lons, order):
     smort = np.asarray(mortie.geo2mort(slat, slon, order=order), np.uint64)
 
     morton = st["morton"]
+    # The order-level membership test below (`np.isin(morton, smort)`) is only
+    # sound for the exact descent, where every straddle leaf stops at `order`;
+    # a tolerance/budget stop would record coarser leaves and misclassify.
+    assert np.all(st["depth"] == order), "measurement requires exact-mode leaves"
     cause = st["cause"]
     fill = st["fill"]
     centers = np.stack([st["cx"], st["cy"], st["cz"]], axis=1)
@@ -262,11 +266,12 @@ def measure_stats(lats, lons, order):
         "ambiguous": int(ambiguous.sum()),
         "moc_hyp": int(len(moc_hyp)),
         "flat_hyp": int(flat_hyp),
-        "moc_reduction_pct": 100.0 * (1.0 - len(moc_hyp) / len(moc)),
+        "moc_reduction_pct": 100.0 * (1.0 - len(moc_hyp) / max(len(moc), 1)),
         "flat_reduction_pct": 100.0 * (1.0 - flat_hyp / max(flat_cur, 1)),
         "ceiling_removed": int(len(ceil_removed)),
         "moc_ceiling": int(len(moc_ceil)),
-        "moc_ceiling_reduction_pct": 100.0 * (1.0 - len(moc_ceil) / len(moc)),
+        "moc_ceiling_reduction_pct": 100.0
+        * (1.0 - len(moc_ceil) / max(len(moc), 1)),
         "samples": int(len(samples)),
         "sample_spacing_rad": float(spacing),
         "stats_build_wall_s": wall,

--- a/benchmarks/measure_straddle_overrefinement.py
+++ b/benchmarks/measure_straddle_overrefinement.py
@@ -1,0 +1,376 @@
+"""
+Issue #90 phase-2 measurement: how much of the `node_straddles` boundary
+refinement is provable over-refinement, by cause?
+
+Dev script — not wired to CI ("run and reported", the issue #78 benchmark
+precedent).  Protocol (two builds):
+
+    # 1. wall-time baseline on the normal release build (no instrumentation)
+    maturin develop --release
+    python benchmarks/measure_straddle_overrefinement.py timing -o timing.json
+
+    # 2. cause-tagged stats on the instrumented build
+    maturin develop --release --features descent-stats
+    python benchmarks/measure_straddle_overrefinement.py stats -o stats.json
+
+    # 3. merge into the report table
+    python benchmarks/measure_straddle_overrefinement.py report timing.json \
+        stats.json
+
+For each straddle-stopped leaf the descent recorded, the polygon boundary is
+re-tested independently of the descent's own predicates: every polygon edge
+is densely sampled along its great circle (spacing 0.2 cells) and each sample
+is classified with the exact HEALPix point-in-cell assignment (`geo2mort`).
+
+  * a sample lands in the leaf          -> the boundary genuinely enters it;
+  * min angular distance from the leaf centre to every sample exceeds the
+    leaf's densified circumradius + half the sample spacing (+1e-6 rad
+    safety) -> the boundary **provably misses** the cell = over-refinement;
+  * anything between                    -> ambiguous, counted but not claimed.
+
+`quad_touch` leaves (the #103 closed-set exact-incidence branch) are contract,
+not waste: they are excluded from the over-refinement count and from the
+hypothetical reduction regardless of the geometric verdict.
+
+The achievable reduction assumes provably-missed leaves whose centre fill is
+False (fully outside) are dropped; provably-missed fill=True leaves are fully
+inside and already merge optimally in the MOC, so they change descent work
+but not output size.  Hypothetical covers are computed exactly with
+`moc_minus` + renormalization.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+import numpy as np
+
+import mortie
+from mortie import _rustie, moc_minus, morton_coverage_moc
+
+CAUSES = ["vertex_leaf", "quad_cross", "quad_touch", "corner_parity",
+          "near_pole_bulge"]
+QUAD_TOUCH = CAUSES.index("quad_touch")
+ORDERS = [6, 9, 11]
+SAMPLE_FRACTION = 0.2  # sample spacing as a fraction of the cell resolution
+SAFETY_RAD = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Polygon suite
+# ---------------------------------------------------------------------------
+
+def _unit(lats, lons):
+    la, lo = np.radians(lats), np.radians(lons)
+    return np.stack(
+        [np.cos(la) * np.cos(lo), np.cos(la) * np.sin(lo), np.sin(la)], axis=-1
+    )
+
+
+def _latlon(v):
+    return (
+        np.degrees(np.arcsin(np.clip(v[:, 2], -1, 1))),
+        np.degrees(np.arctan2(v[:, 1], v[:, 0])),
+    )
+
+
+def box(lat_lo, lat_hi, lon_w, lon_e):
+    return (
+        np.array([lat_lo, lat_lo, lat_hi, lat_hi], float),
+        np.array([lon_w, lon_e, lon_e, lon_w], float),
+    )
+
+
+def circle(n, lat0=-75.0, lon0=0.0, radius=5.0):
+    """The bench circle: lat/lon-offset approximation (matches
+    benchmarks/test_bench_coverage.py and the Rust coverage bench)."""
+    ang = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    return lat0 + radius * np.cos(ang), lon0 + radius * np.sin(ang)
+
+
+def icesat2_swath(width_deg=0.06, n_track=260):
+    """Synthetic ICESat-2-style swath: a ~130 deg near-polar ground-track
+    segment buffered to ~6.6 km total width (the beam-pair span)."""
+    a = _unit(np.array([-65.0]), np.array([-40.0]))[0]
+    b = _unit(np.array([65.0]), np.array([20.0]))[0]
+    omega = np.arccos(np.clip(np.dot(a, b), -1, 1))
+    t = np.linspace(0.0, 1.0, n_track)
+    p = (
+        np.sin((1 - t) * omega)[:, None] * a + np.sin(t * omega)[:, None] * b
+    ) / np.sin(omega)
+    p /= np.linalg.norm(p, axis=1, keepdims=True)
+    # local track tangent and cross-track normal
+    tan = np.gradient(p, axis=0)
+    tan /= np.linalg.norm(tan, axis=1, keepdims=True)
+    nrm = np.cross(p, tan)
+    nrm /= np.linalg.norm(nrm, axis=1, keepdims=True)
+    h = np.radians(width_deg / 2.0)
+    left = np.cos(h) * p + np.sin(h) * nrm
+    right = np.cos(h) * p - np.sin(h) * nrm
+    ring = np.concatenate([left, right[::-1]])
+    return _latlon(ring)
+
+
+def hemisphere_ring():
+    """Hemisphere-plus ring: the pinned #22 world ring (lat -80..80,
+    lon -90..90, vertex sum balanced so ingest trusts the winding), whose
+    interior is the lon-0-facing hemisphere+ region including both poles —
+    the shape `test_coverage_hemisphere.test_complement_world_minus_cap`
+    validates.  Verified here to cover > half the sphere."""
+    lats = np.array([-80.0, -80.0, 80.0, 80.0])
+    lons = np.array([-90.0, 90.0, 90.0, -90.0])
+    cells = morton_coverage_moc(lats, lons, order=3)
+    frac = _rustie.rust_moc_to_order_count(
+        np.asarray(cells, np.uint64), 3
+    ) / (12 * 4 ** 3)
+    if frac <= 0.5:
+        raise RuntimeError(f"hemisphere+ ring covers only {frac:.3f}")
+    return lats, lons
+
+
+def shapes():
+    tri_lat, tri_lon = np.array([20.0, 30.0, 25.0]), np.array(
+        [-120.0, -120.0, -110.0]
+    )
+    sq_lat, sq_lon = np.array([20.0, 20.0, 30.0, 30.0]), np.array(
+        [-125.0, -115.0, -115.0, -125.0]
+    )
+    trip_lat, trip_lon = np.array([-80.0, -88.0, -84.0]), np.array(
+        [-120.0, -120.0, -100.0]
+    )
+    sqp_lat, sqp_lon = np.array([-80.0, -80.0, -87.0, -87.0]), np.array(
+        [-130.0, -100.0, -100.0, -130.0]
+    )
+    return [
+        # (class, name, lats, lons)
+        ("ongrid_box", "box_belt_lon0", *box(20.0, 25.0, 0.0, 5.0)),
+        ("ongrid_box", "box_cap_lon45", *box(60.0, 65.0, 44.0, 45.0)),
+        ("ongrid_box", "box_equator", *box(0.0, 5.0, 100.0, 105.0)),
+        ("midlat", "triangle_midlat", tri_lat, tri_lon),
+        ("midlat", "square_midlat", sq_lat, sq_lon),
+        ("polar", "triangle_polar", trip_lat, trip_lon),
+        ("polar", "square_polar", sqp_lat, sqp_lon),
+        ("circle", "circle32", *circle(32)),
+        ("circle", "circle100", *circle(100)),
+        ("circle", "circle500", *circle(500)),
+        ("swath", "icesat2_swath", *icesat2_swath()),
+        ("hemisphere", "hemisphere_ring", *hemisphere_ring()),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Boundary sampling + independent leaf classification
+# ---------------------------------------------------------------------------
+
+def cell_resolution_rad(order):
+    return np.sqrt(np.pi / 3.0) / (1 << order)
+
+
+def sample_boundary(lats, lons, delta):
+    """Sample every polygon edge along its great circle at spacing <= delta
+    (vertices included).  Returns (unit vectors, actual max spacing)."""
+    v = _unit(np.asarray(lats, float), np.asarray(lons, float))
+    out, max_step = [], 0.0
+    for i in range(len(v)):
+        a, b = v[i], v[(i + 1) % len(v)]
+        omega = np.arccos(np.clip(np.dot(a, b), -1, 1))
+        if omega < 1e-12:
+            continue
+        n = max(1, int(np.ceil(omega / delta)))
+        max_step = max(max_step, omega / n)
+        t = np.arange(n) / n  # endpoint b belongs to the next edge
+        pts = (
+            np.sin((1 - t) * omega)[:, None] * a + np.sin(t * omega)[:, None] * b
+        ) / np.sin(omega)
+        out.append(pts / np.linalg.norm(pts, axis=1, keepdims=True))
+    return np.concatenate(out), max_step
+
+
+def min_angle_to_samples(centers, samples, chunk=2048):
+    """Min angular distance from each centre to the sample set (chunked)."""
+    best = np.full(len(centers), -1.0)
+    for i in range(0, len(samples), chunk):
+        np.maximum(best, (centers @ samples[i:i + chunk].T).max(axis=1),
+                   out=best)
+    return np.arccos(np.clip(best, -1.0, 1.0))
+
+
+def measure_stats(lats, lons, order):
+    take = _rustie.rust_descent_stats_take
+    take()  # clear
+    t0 = time.perf_counter()
+    moc = np.asarray(morton_coverage_moc(lats, lons, order=order), np.uint64)
+    wall = time.perf_counter() - t0
+    st = take()
+
+    delta = SAMPLE_FRACTION * cell_resolution_rad(order)
+    samples, spacing = sample_boundary(lats, lons, delta)
+    slat, slon = _latlon(samples)
+    smort = np.asarray(mortie.geo2mort(slat, slon, order=order), np.uint64)
+
+    morton = st["morton"]
+    cause = st["cause"]
+    fill = st["fill"]
+    centers = np.stack([st["cx"], st["cy"], st["cz"]], axis=1)
+    circ = st["circ"]
+
+    hit = np.isin(morton, smort)  # a boundary sample lands in the leaf
+    dist = np.full(len(morton), np.inf)
+    cand = ~hit
+    if cand.any():
+        dist[cand] = min_angle_to_samples(centers[cand], samples)
+    missed = cand & (dist > circ + spacing / 2.0 + SAFETY_RAD)
+    ambiguous = cand & ~missed
+
+    contract = cause == QUAD_TOUCH
+    over = missed & ~contract
+    removed = morton[over & ~fill]
+
+    moc_hyp = moc_minus(moc, removed) if len(removed) else moc
+    flat_cur = _rustie.rust_moc_to_order_count(moc, order)
+    flat_hyp = _rustie.rust_moc_to_order_count(
+        np.asarray(moc_hyp, np.uint64), order
+    )
+
+    # Unclaimable ceiling: what if every *ambiguous*, non-contract, fill=false
+    # leaf were also dropped?  Not a safe relaxation (ambiguous cells may truly
+    # intersect; dropping them can under-cover) — reported only to bound the
+    # best case any relaxation could reach.
+    ceil_removed = morton[(cand & ~contract & ~fill)]
+    moc_ceil = moc_minus(moc, ceil_removed) if len(ceil_removed) else moc
+
+    per_cause = {}
+    for ci, name in enumerate(CAUSES):
+        m = cause == ci
+        per_cause[name] = {
+            "total": int(m.sum()),
+            "intersecting": int((m & hit).sum()),
+            "provably_missed": int((m & missed).sum()),
+            "ambiguous": int((m & ambiguous).sum()),
+            "internal": int(st["internal_counts"][ci]),
+        }
+    return {
+        "order": order,
+        "moc_cells": int(len(moc)),
+        "flat_cells": int(flat_cur),
+        "straddle_leaves": int(len(morton)),
+        "per_cause": per_cause,
+        "over_refined": int(over.sum()),
+        "over_refined_outside": int(len(removed)),
+        "over_refined_inside": int((over & fill).sum()),
+        "ambiguous": int(ambiguous.sum()),
+        "moc_hyp": int(len(moc_hyp)),
+        "flat_hyp": int(flat_hyp),
+        "moc_reduction_pct": 100.0 * (1.0 - len(moc_hyp) / len(moc)),
+        "flat_reduction_pct": 100.0 * (1.0 - flat_hyp / max(flat_cur, 1)),
+        "ceiling_removed": int(len(ceil_removed)),
+        "moc_ceiling": int(len(moc_ceil)),
+        "moc_ceiling_reduction_pct": 100.0 * (1.0 - len(moc_ceil) / len(moc)),
+        "samples": int(len(samples)),
+        "sample_spacing_rad": float(spacing),
+        "stats_build_wall_s": wall,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+def run_timing(out_path, reps=7):
+    res = {}
+    for cls, name, la, lo in shapes():
+        for order in ORDERS:
+            morton_coverage_moc(la, lo, order=order)  # warm
+            best = min(
+                _timed(lambda: morton_coverage_moc(la, lo, order=order))
+                for _ in range(reps)
+            )
+            res[f"{name}@o{order}"] = {"class": cls, "wall_s": best}
+            print(f"{name}@o{order}: {best * 1e3:.3f} ms", flush=True)
+    json.dump(res, open(out_path, "w"), indent=1)
+
+
+def _timed(f):
+    t0 = time.perf_counter()
+    f()
+    return time.perf_counter() - t0
+
+
+def run_stats(out_path):
+    if not hasattr(_rustie, "rust_descent_stats_take"):
+        sys.exit(
+            "extension lacks rust_descent_stats_take; rebuild with "
+            "`maturin develop --release --features descent-stats`"
+        )
+    res = {}
+    for cls, name, la, lo in shapes():
+        for order in ORDERS:
+            r = measure_stats(la, lo, order)
+            r["class"] = cls
+            res[f"{name}@o{order}"] = r
+            print(
+                f"{name}@o{order}: {r['straddle_leaves']} straddle leaves, "
+                f"{r['over_refined']} provably over-refined "
+                f"({r['over_refined_outside']} outside), "
+                f"{r['ambiguous']} ambiguous, "
+                f"MOC {r['moc_cells']} -> {r['moc_hyp']} "
+                f"(-{r['moc_reduction_pct']:.2f}%)",
+                flush=True,
+            )
+    json.dump(res, open(out_path, "w"), indent=1)
+
+
+def run_report(timing_path, stats_path):
+    timing = json.load(open(timing_path))
+    stats = json.load(open(stats_path))
+    cols = (
+        "| shape | order | wall ms | straddle leaves | VL / QC / QT / CP / NP "
+        "| over-refined (out+in) | ambig | MOC cur->hyp | MOC dv% | flat dv% "
+        "| MOC ceiling dv% |"
+    )
+    print(cols)
+    print("|" + "---|" * 11)
+    for key, r in stats.items():
+        c = r["per_cause"]
+        vl, qc, qt, cp, np_ = (
+            c["vertex_leaf"]["total"],
+            c["quad_cross"]["total"],
+            c["quad_touch"]["total"],
+            c["corner_parity"]["total"],
+            c["near_pole_bulge"]["total"],
+        )
+        wall = timing.get(key, {}).get("wall_s")
+        wall_ms = f"{wall * 1e3:.2f}" if wall is not None else "-"
+        print(
+            f"| {key.split('@')[0]} | {r['order']} | {wall_ms} "
+            f"| {r['straddle_leaves']} | {vl}/{qc}/{qt}/{cp}/{np_} "
+            f"| {r['over_refined']} ({r['over_refined_outside']}+"
+            f"{r['over_refined_inside']}) | {r['ambiguous']} "
+            f"| {r['moc_cells']}->{r['moc_hyp']} "
+            f"| {r['moc_reduction_pct']:.2f} | {r['flat_reduction_pct']:.2f} "
+            f"| {r['moc_ceiling_reduction_pct']:.2f} |"
+        )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="mode", required=True)
+    t = sub.add_parser("timing", help="wall-time baseline (normal build)")
+    t.add_argument("-o", "--out", default="straddle_timing.json")
+    s = sub.add_parser("stats", help="cause-tagged stats (descent-stats build)")
+    s.add_argument("-o", "--out", default="straddle_stats.json")
+    r = sub.add_parser("report", help="merge the two JSONs into a table")
+    r.add_argument("timing_json")
+    r.add_argument("stats_json")
+    args = ap.parse_args()
+    if args.mode == "timing":
+        run_timing(args.out)
+    elif args.mode == "stats":
+        run_stats(args.out)
+    else:
+        run_report(args.timing_json, args.stats_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/mortie/tests/test_descent_stats.py
+++ b/mortie/tests/test_descent_stats.py
@@ -1,0 +1,43 @@
+"""
+Smoke test for the descent-stats instrumentation binding (issue #90).
+
+Skipped unless the extension was built with the ``descent-stats`` cargo
+feature (``maturin develop --release --features descent-stats``); the default
+CI build carries no instrumentation and no binding.
+"""
+
+import numpy as np
+import pytest
+
+from mortie import _rustie, morton_coverage
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(_rustie, "rust_descent_stats_take"),
+    reason="extension built without the descent-stats feature",
+)
+
+CAUSES = ["vertex_leaf", "quad_cross", "quad_touch", "corner_parity",
+          "near_pole_bulge"]
+
+
+def test_take_returns_cause_tagged_straddle_leaves():
+    lats = np.array([20.0, 20.0, 30.0, 30.0])
+    lons = np.array([-125.0, -115.0, -115.0, -125.0])
+    _rustie.rust_descent_stats_take()  # clear
+    flat = np.asarray(morton_coverage(lats, lons, order=6))
+    stats = _rustie.rust_descent_stats_take()
+
+    assert stats["causes"] == CAUSES
+    n = int(np.sum(stats["leaf_counts"]))
+    assert n == len(stats["morton"]) > 0
+    # Every straddle leaf is a member of the flat cover, at the target order.
+    assert set(stats["morton"].tolist()) <= set(flat.tolist())
+    assert np.all(stats["depth"] == 6)
+    assert np.all(stats["circ"] > 0)
+    r2 = stats["cx"] ** 2 + stats["cy"] ** 2 + stats["cz"] ** 2
+    assert np.allclose(r2, 1.0)
+
+    # Take-and-reset: a second take is empty.
+    drained = _rustie.rust_descent_stats_take()
+    assert len(drained["morton"]) == 0
+    assert int(np.sum(drained["leaf_counts"])) == 0

--- a/src_rust/src/coverage.rs
+++ b/src_rust/src/coverage.rs
@@ -27,6 +27,11 @@
 //! is unambiguously the interior); hemisphere-plus rings are never reordered, so
 //! supply those CCW (holes CW) exactly as the right-hand rule prescribes.
 
+/// Cause-tagged straddle instrumentation for the issue #90 measurement; a
+/// dev-only cargo feature (cfg flag, no dependency), absent from release builds.
+#[cfg(feature = "descent-stats")]
+pub mod descent_stats;
+
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::f64::consts::PI;
@@ -546,7 +551,12 @@ fn edge_hits_cell_edge(e: &Edge, c1: &Vec3, c2: &Vec3, n_c: &Vec3) -> bool {
         return edge_touches_cell_edge_degenerate(e, c1, c2, d1, d2, d3, d4);
     }
     // d1, d2 straddle (established above); the plain sign test decides.
-    (d3 > 0.0) != (d4 > 0.0)
+    let crossed = (d3 > 0.0) != (d4 > 0.0);
+    #[cfg(feature = "descent-stats")]
+    if crossed {
+        descent_stats::note_touch(false);
+    }
+    crossed
 }
 
 /// Cold half of [`edge_hits_cell_edge`]: the closed-set / symbolic logic for
@@ -575,6 +585,8 @@ fn edge_touches_cell_edge_degenerate(
     if (d1 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c1)))
         || (d2 == 0.0 && span(e.cos_rho, e.sin_rho, dot(&e.mid, c2)))
     {
+        #[cfg(feature = "descent-stats")]
+        descent_stats::note_touch(true);
         return true;
     }
     if d3 == 0.0 || d4 == 0.0 {
@@ -584,10 +596,17 @@ fn edge_touches_cell_edge_degenerate(
         if (d3 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.a)))
             || (d4 == 0.0 && span(cos_rho, sin_rho, dot(&mid, &e.b)))
         {
+            #[cfg(feature = "descent-stats")]
+            descent_stats::note_touch(true);
             return true;
         }
     }
-    arcs_cross_sos(c1, c2, &e.a, &e.b, CORNER_ID_A, CORNER_ID_B, e.ia, e.ib)
+    let crossed = arcs_cross_sos(c1, c2, &e.a, &e.b, CORNER_ID_A, CORNER_ID_B, e.ia, e.ib);
+    #[cfg(feature = "descent-stats")]
+    if crossed {
+        descent_stats::note_touch(false);
+    }
+    crossed
 }
 
 /// A descent node: cell `(pixel, depth)`, its centre, even-odd fill state, and
@@ -862,6 +881,8 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
         .iter()
         .any(|&i| edges[i].leaf >> shift == node.pixel)
     {
+        #[cfg(feature = "descent-stats")]
+        descent_stats::set_cause(descent_stats::Cause::VertexLeaf);
         return true;
     }
 
@@ -875,17 +896,26 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
         cross(&corners[2], &corners[3]),
         cross(&corners[3], &corners[0]),
     ];
-    let quad_straddles = node.relevant.iter().any(|&i| {
+    if node.relevant.iter().any(|&i| {
         let e = &edges[i];
         (0..4).any(|ci| edge_hits_cell_edge(e, &corners[ci], &corners[(ci + 1) % 4], &n_quad[ci]))
-    }) || {
+    }) {
+        // The short-circuiting loops stop at the deciding hit, so under
+        // `descent-stats` its touch/cross tag is still current here.
+        #[cfg(feature = "descent-stats")]
+        descent_stats::set_cause(descent_stats::quad_cause());
+        return true;
+    }
+    {
         let cid = center_id(node.depth, node.pixel);
-        corners
+        if corners
             .iter()
             .any(|c| arc_crossing_parity(&node.center, c, cid, CORNER_ID_A, &node.relevant, edges))
-    };
-    if quad_straddles {
-        return true;
+        {
+            #[cfg(feature = "descent-stats")]
+            descent_stats::set_cause(descent_stats::Cause::CornerParity);
+            return true;
+        }
     }
 
     // (3) near-pole bulge graze: re-test against the true (curved) boundary, but
@@ -899,14 +929,19 @@ fn node_straddles(node: &Node, edges: &[Edge], order: u8) -> bool {
     let n_bnd: Vec<Vec3> = (0..n)
         .map(|ci| cross(&bnd[ci], &bnd[(ci + 1) % n]))
         .collect();
-    node.relevant.iter().any(|&i| {
+    let bulge_hit = node.relevant.iter().any(|&i| {
         let e = &edges[i];
         (0..n).any(|ci| edge_hits_cell_edge(e, &bnd[ci], &bnd[(ci + 1) % n], &n_bnd[ci]))
     }) || {
         let cid = center_id(node.depth, node.pixel);
         bnd.iter()
             .any(|b| arc_crossing_parity(&node.center, b, cid, CORNER_ID_A, &node.relevant, edges))
+    };
+    #[cfg(feature = "descent-stats")]
+    if bulge_hit {
+        descent_stats::set_cause(descent_stats::Cause::NearPoleBulge);
     }
+    bulge_hit
 }
 
 /// The four children of a node, each with re-culled edges and propagated fill.
@@ -982,11 +1017,17 @@ fn descend_parallel(rings: &[Vec<Vec3>], order: u8, tolerance: Option<f64>) -> V
             let mut stack = vec![seed];
             while let Some(node) = stack.pop() {
                 if node_straddles(&node, &edges, order) {
+                    #[cfg(feature = "descent-stats")]
+                    let cause = descent_stats::take_cause();
                     let stop = node.depth >= order
                         || tolerance.is_some_and(|tol| node_radius(&node) <= tol);
                     if stop {
+                        #[cfg(feature = "descent-stats")]
+                        descent_stats::record_leaf(&node, cause);
                         out.push((node.pixel, node.depth));
                     } else {
+                        #[cfg(feature = "descent-stats")]
+                        descent_stats::record_internal(cause);
                         stack.extend(node_children(&node, &edges));
                     }
                 } else {
@@ -1065,9 +1106,15 @@ fn consider_node(
     frontier: &mut BinaryHeap<HeapNode>,
 ) {
     if node_straddles(&node, edges, order) {
+        #[cfg(feature = "descent-stats")]
+        let cause = descent_stats::take_cause();
         if node.depth >= order {
+            #[cfg(feature = "descent-stats")]
+            descent_stats::record_leaf(&node, cause);
             out.push((node.pixel, node.depth));
         } else {
+            #[cfg(feature = "descent-stats")]
+            descent_stats::record_internal(cause);
             frontier.push(HeapNode(node));
         }
     } else {

--- a/src_rust/src/coverage/descent_stats.rs
+++ b/src_rust/src/coverage/descent_stats.rs
@@ -1,0 +1,157 @@
+//! Cause-tagged `node_straddles` instrumentation (issue #90).
+//!
+//! Compiled only under the `descent-stats` cargo feature — a cfg flag, not a
+//! dependency — so release builds carry none of it and the descent hot path is
+//! byte-for-byte unchanged.  The collector answers *why* each straddle verdict
+//! fired (the issue #90 cause taxonomy) and records every straddle-**stopped**
+//! leaf with enough geometry for an independent Python-side over-refinement
+//! test.
+//!
+//! Protocol (single descent at a time): [`take`] to clear, run one descent,
+//! [`take`] again to read.  Concurrent descents from multiple Python threads
+//! would interleave their records — the measurement harness runs one at a time.
+
+use std::cell::Cell;
+use std::sync::Mutex;
+
+use crate::geo2mort::boundaries_step_scalar;
+use crate::morton::nested2mort;
+use crate::sphere::{dot, Vec3};
+
+/// Why `node_straddles` returned `true`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Cause {
+    /// A polygon vertex's leaf cell falls in the cell (clause 1).
+    VertexLeaf = 0,
+    /// A relevant edge crosses a cell edge of the 4-corner quad (clause 2).
+    QuadCross = 1,
+    /// The closed-set exact-incidence branch of the quad test
+    /// ([`super::edge_touches_cell_edge_degenerate`]'s bit-exact-zero returns).
+    /// Deliberate refinement under the #103 contract — **excluded** from the
+    /// over-refinement count.
+    QuadTouch = 2,
+    /// The centre→corner crossing-parity clause (clipped corner/edge).
+    CornerParity = 3,
+    /// The densified near-pole true-boundary path (issue #32).
+    NearPoleBulge = 4,
+}
+
+pub const N_CAUSES: usize = 5;
+
+/// One straddle-stopped leaf (refined to the stop rule and emitted as a
+/// boundary cell), with everything the measurement needs to re-test the cell
+/// independently: the cell as a morton word + depth, the cause, the centre
+/// fill state, the centre vector, and the circumradius of the **densified**
+/// (true, curved) boundary in radians.
+pub struct LeafRecord {
+    pub morton: u64,
+    pub depth: u8,
+    pub cause: Cause,
+    pub fill: bool,
+    pub center: Vec3,
+    pub circ: f64,
+}
+
+/// Everything recorded since the last [`take`].
+pub struct Stats {
+    /// Straddle-stopped leaves per cause.
+    pub leaf: [u64; N_CAUSES],
+    /// Straddle nodes refined further per cause.
+    pub internal: [u64; N_CAUSES],
+    pub leaves: Vec<LeafRecord>,
+}
+
+impl Stats {
+    const fn new() -> Self {
+        Stats {
+            leaf: [0; N_CAUSES],
+            internal: [0; N_CAUSES],
+            leaves: Vec::new(),
+        }
+    }
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Stats::new()
+    }
+}
+
+/// Global collector.  A stdlib `Mutex` (no new dependency) rather than
+/// per-worker counters: the descent's rayon workers contend only at straddle
+/// events, `record_leaf` updates count and record under one lock (so
+/// `sum(leaf) == leaves.len()` holds under any interleaving), and this
+/// feature never ships in a release build.
+static STATS: Mutex<Stats> = Mutex::new(Stats::new());
+
+thread_local! {
+    /// Cause of this thread's most recent `node_straddles == true` verdict.
+    /// Same-thread hand-off only: `node_straddles` sets it on its `true`
+    /// returns and the caller consumes it immediately via [`take_cause`].
+    static LAST_CAUSE: Cell<Option<Cause>> = const { Cell::new(None) };
+    /// Whether this thread's most recent `edge_hits_cell_edge == true`
+    /// verdict came from the closed-set exact-incidence branch (a touch)
+    /// rather than a crossing.  Only written on `true` verdicts, so the
+    /// short-circuiting quad loop leaves it set by the deciding hit.
+    static LAST_HIT_TOUCH: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Tag the most recent `edge_hits_cell_edge == true` verdict: `true` for the
+/// closed-set exact-incidence branch, `false` for a crossing.
+pub(super) fn note_touch(touch: bool) {
+    LAST_HIT_TOUCH.with(|c| c.set(touch));
+}
+
+/// Cause for a quad-loop hit, from the deciding `edge_hits_cell_edge` verdict.
+pub(super) fn quad_cause() -> Cause {
+    if LAST_HIT_TOUCH.with(|c| c.get()) {
+        Cause::QuadTouch
+    } else {
+        Cause::QuadCross
+    }
+}
+
+/// Record the cause of a `node_straddles == true` verdict (called on each of
+/// its `true` return paths).
+pub(super) fn set_cause(cause: Cause) {
+    LAST_CAUSE.with(|c| c.set(Some(cause)));
+}
+
+/// Consume the cause set by the `node_straddles` call that just returned
+/// `true`.  Panics if a `true` path failed to tag — a taxonomy gap.
+pub(super) fn take_cause() -> Cause {
+    LAST_CAUSE
+        .with(|c| c.take())
+        .expect("node_straddles returned true without tagging a cause")
+}
+
+/// Count a straddle node that will be refined further.
+pub(super) fn record_internal(cause: Cause) {
+    STATS.lock().unwrap().internal[cause as usize] += 1;
+}
+
+/// Record a straddle-stopped leaf.  The circumradius is measured against the
+/// densified true boundary (step 8 ⇒ 32 points), not the 4-corner quad, so a
+/// near-pole cell's bulge is inside it.
+pub(super) fn record_leaf(node: &super::Node, cause: Cause) {
+    let bnd = boundaries_step_scalar(node.depth, node.pixel, 8);
+    let circ = bnd
+        .iter()
+        .map(|b| dot(&node.center, b).clamp(-1.0, 1.0).acos())
+        .fold(0.0_f64, f64::max);
+    let mut s = STATS.lock().unwrap();
+    s.leaf[cause as usize] += 1;
+    s.leaves.push(LeafRecord {
+        morton: nested2mort(node.pixel, node.depth),
+        depth: node.depth,
+        cause,
+        fill: node.fill,
+        center: node.center,
+        circ,
+    });
+}
+
+/// Return everything recorded since the last call and reset the collector.
+pub fn take() -> Stats {
+    std::mem::take(&mut *STATS.lock().unwrap())
+}

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -618,6 +618,66 @@ fn rust_polygon_coverage_moc(
     }
 }
 
+/// Drain the cause-tagged `node_straddles` instrumentation (issue #90).
+///
+/// Compiled only under the `descent-stats` cargo feature
+/// (`maturin develop --release --features descent-stats`).  Take-and-reset:
+/// call once to clear, run one descent, call again to read it.  Returns a
+/// dict with `causes` (the taxonomy names, indexed by cause id),
+/// `leaf_counts` / `internal_counts` (per-cause straddle counters), and the
+/// per-leaf table `morton`, `depth`, `cause`, `fill`, `cx`/`cy`/`cz` (cell
+/// centre unit vector), `circ` (densified-boundary circumradius, radians).
+#[cfg(feature = "descent-stats")]
+#[pyfunction]
+fn rust_descent_stats_take(py: Python<'_>) -> PyResult<PyObject> {
+    use coverage::descent_stats as ds;
+    let stats = ds::take();
+    let n = stats.leaves.len();
+    let mut morton = Vec::with_capacity(n);
+    let mut depth = Vec::with_capacity(n);
+    let mut cause = Vec::with_capacity(n);
+    let mut fill = Vec::with_capacity(n);
+    let (mut cx, mut cy, mut cz) = (
+        Vec::with_capacity(n),
+        Vec::with_capacity(n),
+        Vec::with_capacity(n),
+    );
+    let mut circ = Vec::with_capacity(n);
+    for l in &stats.leaves {
+        morton.push(l.morton);
+        depth.push(l.depth);
+        cause.push(l.cause as u8);
+        fill.push(l.fill);
+        cx.push(l.center[0]);
+        cy.push(l.center[1]);
+        cz.push(l.center[2]);
+        circ.push(l.circ);
+    }
+    let dict = pyo3::types::PyDict::new_bound(py);
+    dict.set_item(
+        "causes",
+        [
+            "vertex_leaf",
+            "quad_cross",
+            "quad_touch",
+            "corner_parity",
+            "near_pole_bulge",
+        ]
+        .to_vec(),
+    )?;
+    dict.set_item("leaf_counts", stats.leaf.to_vec())?;
+    dict.set_item("internal_counts", stats.internal.to_vec())?;
+    dict.set_item("morton", morton.into_pyarray_bound(py))?;
+    dict.set_item("depth", depth.into_pyarray_bound(py))?;
+    dict.set_item("cause", cause.into_pyarray_bound(py))?;
+    dict.set_item("fill", fill.into_pyarray_bound(py))?;
+    dict.set_item("cx", cx.into_pyarray_bound(py))?;
+    dict.set_item("cy", cy.into_pyarray_bound(py))?;
+    dict.set_item("cz", cz.into_pyarray_bound(py))?;
+    dict.set_item("circ", circ.into_pyarray_bound(py))?;
+    Ok(dict.into_any().unbind())
+}
+
 /// Extract a readable message from a caught panic payload, falling back to
 /// `fallback` when the payload is neither a `String` nor a `&str`.
 fn panic_msg(e: Box<dyn std::any::Any + Send>, fallback: &str) -> String {
@@ -1189,6 +1249,8 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_moc_xor, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_min, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
+    #[cfg(feature = "descent-stats")]
+    m.add_function(wrap_pyfunction!(rust_descent_stats_take, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_from_nested, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_from_nested_point, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_to_nested, m)?)?;

--- a/src_rust/tests/descent_stats.rs
+++ b/src_rust/tests/descent_stats.rs
@@ -1,0 +1,69 @@
+//! Tests for the `descent-stats` instrumentation (issue #90).
+//!
+//! An integration test in its own binary (see `[[test]]` in Cargo.toml,
+//! `required-features = ["descent-stats"]`): the collector is a process-wide
+//! global, and the lib's other unit tests run descents concurrently — a
+//! separate process keeps the take → run → take protocol clean.  Runs under
+//! `cargo test --features descent-stats`; plain `cargo test` skips it.
+
+use mortie_rustie::coverage::descent_stats::{self as ds, Cause};
+use mortie_rustie::coverage::{polygon_to_morton_coverage, polygon_to_morton_moc};
+use mortie_rustie::moc;
+
+/// One serial test fn: the collector is global, so the scenarios must not
+/// interleave.
+#[test]
+fn straddle_leaves_are_cause_tagged() {
+    // Mid-latitude square (the bench shape): vertex leaves + quad crossings,
+    // no exact-incidence touches, no near-pole path.
+    let lats = vec![20.0, 20.0, 30.0, 30.0];
+    let lons = vec![-125.0, -115.0, -115.0, -125.0];
+    let _ = ds::take();
+    let flat = polygon_to_morton_coverage(&lats, &lons, 6, true);
+    let stats = ds::take();
+
+    // Counter/record consistency and per-leaf sanity.
+    assert_eq!(stats.leaf.iter().sum::<u64>() as usize, stats.leaves.len());
+    assert!(!stats.leaves.is_empty());
+    for l in &stats.leaves {
+        assert_eq!(l.depth, 6, "exact descent stops at the target order");
+        assert!(
+            flat.binary_search(&l.morton).is_ok(),
+            "straddle leaf {} not in the flat cover",
+            l.morton
+        );
+        assert!(l.circ > 0.0 && l.circ < 0.1, "order-6 circumradius sane");
+        let c = &l.center;
+        let norm2 = c[0] * c[0] + c[1] * c[1] + c[2] * c[2];
+        assert!((norm2 - 1.0).abs() < 1e-9, "centre is a unit vector");
+    }
+    assert!(stats.leaf[Cause::VertexLeaf as usize] >= 1);
+    assert!(stats.leaf[Cause::QuadCross as usize] > 0);
+    assert_eq!(stats.leaf[Cause::QuadTouch as usize], 0);
+    assert_eq!(stats.leaf[Cause::NearPoleBulge as usize], 0);
+    assert!(
+        stats.internal.iter().sum::<u64>() > 0,
+        "coarse straddle nodes were refined"
+    );
+
+    // take() drained the collector.
+    let empty = ds::take();
+    assert_eq!(empty.leaves.len(), 0);
+    assert_eq!(empty.leaf.iter().sum::<u64>(), 0);
+
+    // #103 on-grid box (west edge exactly on lon 0): the closed-set
+    // exact-incidence branch fires and is tagged QuadTouch.
+    let lats = vec![20.0, 20.0, 25.0, 25.0];
+    let lons = vec![0.0, 5.0, 5.0, 0.0];
+    let moc_cells = polygon_to_morton_moc(&lats, &lons, 6);
+    let stats = ds::take();
+    assert!(
+        stats.leaf[Cause::QuadTouch as usize] > 0,
+        "on-grid edge must tag exact-incidence touches"
+    );
+    // Leaf records are pre-normalization: flattening both must agree.
+    let flat = moc::to_order(&moc_cells, 6);
+    for l in &stats.leaves {
+        assert!(flat.binary_search(&l.morton).is_ok());
+    }
+}


### PR DESCRIPTION
Refs #90

Phases 1 and 2 of the measure-then-relax program agreed in the [issue plan](https://github.com/espg/mortie/issues/90#issuecomment-4932919988) and the [maintainer's answers](https://github.com/espg/mortie/issues/90#issuecomment-4932984344): a cargo-feature instrumentation (usable from Python dev builds), both KPIs (output cell count flat + MOC, and wall time, MOC size the priority), go threshold >=10% MOC-size reduction or comparable wall-time percentage reduction on at least one realistic polygon class. **Phase 3 (the actual relaxation) is explicitly a separate future PR** and is not part of this one.

## What this does

### Phase 1 — cause-tagged instrumentation (`descent-stats` cargo feature)

- `Cargo.toml` declares a `descent-stats` feature — a cfg flag only, **no new dependency**. Off by default; release builds compile none of the instrumentation (all sites are `#[cfg(feature = "descent-stats")]`).
- `src_rust/src/coverage/descent_stats.rs` (new, feature-gated): the issue #90 cause taxonomy — `VertexLeaf`, `QuadCross`, `QuadTouch` (the closed-set exact-incidence branch, contract per #103, excluded from over-refinement), `CornerParity`, `NearPoleBulge` (the densified #32 path) — plus a global collector (stdlib `Mutex`; counters and per-leaf records updated under one lock so `sum(leaf) == leaves.len()` holds under rayon interleaving) and a thread-local cause/touch hand-off from `node_straddles` to its callers.
- `src_rust/src/coverage.rs`: each `node_straddles` true-return path tags its cause; `edge_hits_cell_edge` / `edge_touches_cell_edge_degenerate` tag whether the deciding hit was the exact-incidence touch branch or a crossing; both descent drivers (`descend_parallel`, `consider_node`) record straddle-stopped leaves (morton, depth, cause, centre fill, centre vector, densified-boundary circumradius) vs internal refinements. The only feature-off structural change is splitting the quad clause's `A || B` into two sequential `if`s — semantically identical short-circuit.
- `src_rust/src/lib.rs`: one feature-gated binding, `rust_descent_stats_take()` (take-and-reset), returning the counters and the per-leaf table as numpy arrays.
- Tests: `src_rust/tests/descent_stats.rs` (own integration binary via `[[test]] required-features`, so the process-global collector is isolated from the lib's other descent tests) + `mortie/tests/test_descent_stats.py` (skips unless the extension was built with the feature).

### Phase 2 — the measurement

`benchmarks/measure_straddle_overrefinement.py` — a dev script, **not wired to CI**; run and reported, and may be dropped before merge (the #78 benchmark precedent). For each straddle-stopped leaf it independently re-tests whether the polygon boundary actually intersects the cell: dense great-circle sampling of every edge (spacing 0.2 cells) classified with the exact HEALPix point-in-cell assignment (`geo2mort`), plus a distance proof — a leaf is **provably missed** only when the min angular distance from its centre to every sample exceeds its densified circumradius + half the sample spacing + 1e-6 rad; anything closer that no sample lands in is **ambiguous** and never claimed. `quad_touch` leaves are excluded from the over-refinement count by the #103 contract regardless of the geometric verdict. Achievable reductions are computed exactly: drop provably-missed fill=false leaves via `moc_minus` and renormalize (MOC size), `moc_to_order_count` (flat size).

Suite: the #103 on-grid boxes (belt/lon 0, cap/lon 45, equator), the bench polygons (circles 32/100/500, mid-lat + polar triangles/squares), a synthetic ICESat-2-style swath (~130 deg near-polar track, ~6.6 km width), and a hemisphere+ ring (spherical circle, radius 100 deg), at orders {6, 9, 11}. Wall time is measured on the normal (uninstrumented) release build; cause stats on the `descent-stats` build. Results are posted as a table on issue #90.

## Phases

- [x] Phase 1 — feature-gated cause-tagged instrumentation + tests
- [x] Phase 2 — measurement script, run across the suite; results table + go/no-go recommendation posted on issue #90

## How tested

- `cargo test` (feature off: 197 passed) and `cargo test --features descent-stats` (197 + the new integration test), `cargo fmt`, `cargo clippy --all-targets` both with and without the feature (the one new clippy note is the same macro-generated `useless_conversion` that fires on every existing `#[pyfunction]`).
- `maturin develop --release` + full `pytest -v`: 670 passed, 12 skipped (the new Python test skips on the uninstrumented build, runs on the `descent-stats` build).
- `flake8 mortie --select=E9,F63,F7,F82` clean.
- Zero-cost check (feature off): timed `morton_coverage_moc` across triangle / polar square / circle100 / circle500 at orders 6/9/11 before and after; cross-build ratios 0.84–1.12 are entirely inside the same-build run-to-run noise floor on this box (up to 1.47x), i.e. no detectable regression — expected, since the feature-off diff is a semantically-identity restructure.

## Questions for review

- The plan sketched "thread-local counters merged per descent"; the implementation uses one stdlib `Mutex` instead (no new dependency, atomic count+record invariant, contention only at straddle events on a dev-only build). Flagging the deviation for visibility.
- `descent_stats` is `pub` (not `pub(crate)`) so the integration test binary can reach it; it only exists under the dev feature, so nothing new ships in release wheels.
- The measurement script is committed on this branch per the "run and reported" precedent — say the word and it is dropped before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn3kUE3NLLMN1sSEGeswmG)_