### PR TITLE
Decimal kind suffix p for point ids (issue #120)

### DIFF
--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -74,12 +74,12 @@ def _decimal_to_word(s):
     base = lead + 5 if text.startswith("-") else lead - 1
     nested = np.asarray([(base << (2 * order)) | within], dtype=np.uint64)
     if point:
-        # The point word shares prefix+body with the area parse; only the
-        # suffix differs: area = 28 + t28*5 + t29 + 1, point = 48 + t28*4 +
-        # t29 (spec section 1/section 4 tie-break, stored 0..=3 tuples).
-        area = int(_rustie.rust_mi_from_nested(nested, order)[0])
-        t28, t29 = int(digits[-2]) - 1, int(digits[-1]) - 1
-        return (area & ~0x3F) | (48 + t28 * 4 + t29)
+        # Delegate the point-suffix layout to the kernel rather than
+        # reimplement it here: `nested` is the full order-29 NESTED id (order
+        # == MAX_ORDER is guaranteed above), and the kernel packs the point
+        # word directly (suffix = 48 + t28*4 + t29, spec section 1/section 4
+        # tie-break). Keeping the formula in one place -- the kernel.
+        return int(_rustie.rust_mi_from_nested_point(nested)[0])
     return int(_rustie.rust_mi_from_nested(nested, order)[0])
 
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -36,12 +36,16 @@ def _decimal_to_word(s):
     """Parse a decimal Morton string back to its packed word (issue #104).
 
     The inverse of the decode-through-kernel repr: sign + leading base digit
-    (``1..6``) then one ``1..4`` digit per order. Raises ``ValueError`` on any
-    malformed id. Order-29 strings parse to the *area* word -- the point/area
-    flag is not part of the decimal form, so the point word is unreachable
-    from its repr (the documented non-injectivity).
+    (``1..6``), one ``1..4`` digit per order, and an optional terminal ``p``
+    kind suffix (spec section 4, issue #120). Parse rules: a ``p``-marked
+    string (legal only at order 29) yields the POINT word; an unmarked
+    string always yields the AREA word -- the tie-break for the one
+    ambiguous form, and fully backward compatible (every pre-suffix string
+    is unmarked). Raises ``ValueError`` on any malformed id.
     """
-    body = s[1:] if s.startswith("-") else s
+    point = s.endswith("p")
+    text = s[:-1] if point else s
+    body = text[1:] if text.startswith("-") else text
     if not (body.isdigit() and body.isascii()):
         raise ValueError(f"malformed decimal Morton id {s!r}")
     lead, digits = int(body[0]), body[1:]
@@ -54,6 +58,12 @@ def _decimal_to_word(s):
         raise ValueError(
             f"decimal Morton id {s!r}: order {order} exceeds {MAX_ORDER}"
         )
+    if point and order != MAX_ORDER:
+        raise ValueError(
+            f"decimal Morton id {s!r}: the kind suffix 'p' is legal only on "
+            f"full order-{MAX_ORDER} point ids (points exist only at order "
+            f"{MAX_ORDER})"
+        )
     within = 0
     for d in digits:
         if not "1" <= d <= "4":
@@ -61,8 +71,15 @@ def _decimal_to_word(s):
                 f"decimal Morton id {s!r}: digit {d} outside 1..4"
             )
         within = (within << 2) | (int(d) - 1)
-    base = lead + 5 if s.startswith("-") else lead - 1
+    base = lead + 5 if text.startswith("-") else lead - 1
     nested = np.asarray([(base << (2 * order)) | within], dtype=np.uint64)
+    if point:
+        # The point word shares prefix+body with the area parse; only the
+        # suffix differs: area = 28 + t28*5 + t29 + 1, point = 48 + t28*4 +
+        # t29 (spec section 1/section 4 tie-break, stored 0..=3 tuples).
+        area = int(_rustie.rust_mi_from_nested(nested, order)[0])
+        t28, t29 = int(digits[-2]) - 1, int(digits[-1]) - 1
+        return (area & ~0x3F) | (48 + t28 * 4 + t29)
     return int(_rustie.rust_mi_from_nested(nested, order)[0])
 
 
@@ -504,10 +521,9 @@ def _build_classes():
             produced by *decoding* each word (the canonical render-only repr;
             backward-compatible with the legacy ``str(legacy_i64)`` for orders
             0..=18, the natural extension for 19..=29). Raises ``ValueError`` on
-            any empty / invalid word. Note the repr is not injective across
-            kinds: an order-29 *point* renders identically to the order-29
-            *area* on the same path (the point/area flag is not part of the
-            decimal form).
+            any empty / invalid word. Point words carry the terminal ``p``
+            kind suffix (spec section 2, issue #120), so the repr is
+            injective across kinds and the round-trip is lossless.
             """
             return _rustie.rust_mi_decimal_repr(self._data)
 
@@ -515,14 +531,13 @@ def _build_classes():
             """Vectorized decimal-string emit as a fixed-width numpy array.
 
             The always-strings interchange convention from issue #48: returns
-            the decode-through-kernel decimal strings as a ``"<U31"`` numpy
-            array (sign + base digit + 29 order digits is the widest form, so
-            the width is order-independent and stable across arrays). Raises
-            ``ValueError`` on any empty / invalid word. Same non-injectivity
-            note as :meth:`decimal_repr`: point and area render identically at
-            order 29.
+            the decode-through-kernel decimal strings as a ``"<U32"`` numpy
+            array (sign + base digit + 29 order digits + the point ``p`` kind
+            suffix is the widest form, so the width is order-independent and
+            stable across arrays). Raises ``ValueError`` on any empty /
+            invalid word. Point words carry the ``p`` suffix (issue #120).
             """
-            return np.asarray(self.decimal_repr(), dtype="<U31")
+            return np.asarray(self.decimal_repr(), dtype="<U32")
 
         def to_legacy_i64(self):
             """Emit the legacy signed decimal ``int64`` form (orders <= 18).
@@ -561,6 +576,13 @@ def _build_classes():
             prefix = root.rstrip("/") + "/" if root else ""
             paths = []
             for s in self.decimal_repr():
+                if s.endswith("p"):
+                    raise ValueError(
+                        f"hive_path is undefined for point ids ({s!r}): "
+                        f"points do not live in paths, and the kind suffix "
+                        f"never enters a path component (spec section 2, "
+                        f"issue #120)"
+                    )
                 head = 2 if s.startswith("-") else 1
                 levels = "/".join([s[:head], *s[head:]])
                 paths.append(f"{prefix}{levels}/{s}{suffix}")
@@ -599,6 +621,12 @@ def _build_classes():
                         f"hive leaf {leaf!r} does not end with {suffix!r}"
                     )
                 dec = leaf[: len(leaf) - len(suffix)] if suffix else leaf
+                if dec.endswith("p"):
+                    raise ValueError(
+                        f"hive leaf {leaf!r} carries the point kind suffix: "
+                        f"points do not live in paths (spec section 2, issue "
+                        f"#120)"
+                    )
                 word = _decimal_to_word(dec)
                 head = 2 if dec.startswith("-") else 1
                 levels = [dec[:head], *dec[head:]]

--- a/mortie/tests/test_morton_index.py
+++ b/mortie/tests/test_morton_index.py
@@ -442,11 +442,12 @@ class TestDecimalDisplay:
     def test_to_decimal_fixed_width(self):
         a = MIA.from_legacy(np.array([-31123, 41123], dtype=np.int64))
         out = a.to_decimal()
-        assert out.dtype == np.dtype("<U31")
+        # <U32 since issue #120: the point kind suffix widens the max form.
+        assert out.dtype == np.dtype("<U32")
         np.testing.assert_array_equal(
-            out, np.array(["-31123", "41123"], dtype="<U31")
+            out, np.array(["-31123", "41123"], dtype="<U32")
         )
-        # width holds the widest form: southern order-29 is 31 chars
+        # width holds the widest AREA form: southern order-29 is 31 chars
         deep = MIA.from_nested(
             np.array([11 << (2 * MAX_ORDER)], dtype=np.uint64), MAX_ORDER
         )

--- a/mortie/tests/test_packed_golden.py
+++ b/mortie/tests/test_packed_golden.py
@@ -248,7 +248,8 @@ def test_golden_string_emit_layer():
     """to_decimal / _word_repr / scalar str all pin to the fixture strings."""
     arr, reprs, _ = _string_layer_array()
     out = arr.to_decimal()
-    assert out.dtype == np.dtype("<U31")
+    # <U32 since issue #120: the point kind suffix widens the max form by one.
+    assert out.dtype == np.dtype("<U32")
     np.testing.assert_array_equal(out, np.asarray(reprs, dtype="<U31"))
     # spot-check the element formatter and the scalar wrapper on the extremes
     for i in (0, 1, len(reprs) // 2, len(reprs) - 1):
@@ -288,12 +289,12 @@ def test_golden_hive_path_round_trip():
 
 
 def test_golden_repr_not_injective_point_vs_area():
-    """An order-29 point renders identically to the area on the same path.
+    """Kind survives the decimal round-trip via the ``p`` suffix (issue #120).
 
-    The point/area flag is not part of the decimal form (documented on
-    decimal_repr / to_decimal), so the repr is not injective across kinds --
-    the words differ, the strings do not, and parsing the string back always
-    lands on the area word.
+    A point renders as the area string plus a terminal ``p``, so the repr is
+    injective across kinds and both round-trip losslessly; an UNMARKED
+    order-29 string still parses to the area word (the spec section 4
+    tie-break -- backward compatible with every pre-suffix string).
     """
     import pytest
 
@@ -309,5 +310,10 @@ def test_golden_repr_not_injective_point_vs_area():
     area = MIA(_rustie.rust_mi_from_nested(nested, MAX_ORDER))
     point = MIA(_rustie.rust_mi_from_nested_point(nested))
     assert int(area._data[0]) != int(point._data[0])
-    assert area.decimal_repr() == point.decimal_repr()
-    assert _decimal_to_word(point.decimal_repr()[0]) == int(area._data[0])
+    area_s, point_s = area.decimal_repr()[0], point.decimal_repr()[0]
+    assert point_s == area_s + "p"
+    # Lossless round-trip for BOTH kinds (issue #120)...
+    assert _decimal_to_word(area_s) == int(area._data[0])
+    assert _decimal_to_word(point_s) == int(point._data[0])
+    # ...and the unmarked order-29 string keeps the area tie-break.
+    assert _decimal_to_word(point_s[:-1]) == int(area._data[0])

--- a/mortie/tests/test_point_suffix.py
+++ b/mortie/tests/test_point_suffix.py
@@ -1,0 +1,80 @@
+"""Decimal kind suffix ``p`` for point ids (issue #120; spec sections 2/4).
+
+Golden vectors for the espg-ruled grammar extension: point words render with
+a terminal ``p`` (lossless round-trip), unmarked strings keep the area
+tie-break, the suffix is illegal below order 29, and paths never carry it.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pandas")
+
+from mortie import MortonIndexArray  # noqa: E402
+from mortie.morton_index import _decimal_to_word  # noqa: E402
+
+
+def _pair():
+    """A (point, area) pair at the same location."""
+    lat, lon = np.array([45.0]), np.array([45.0])
+    point = MortonIndexArray.from_latlon(lat, lon, points=True)
+    area = MortonIndexArray.from_latlon(lat, lon)
+    return point, area
+
+
+class TestRender:
+    def test_point_renders_with_p(self):
+        point, area = _pair()
+        s = point.decimal_repr()[0]
+        assert s.endswith("p")
+        # Area words render unchanged -- no suffix at any order.
+        assert not area.decimal_repr()[0].endswith("p")
+
+    def test_scalar_str_carries_suffix(self):
+        point, _ = _pair()
+        assert str(point[0]).endswith("p")
+
+    def test_to_decimal_is_u32_and_untruncated(self):
+        point, _ = _pair()
+        out = point.to_decimal()
+        assert out.dtype == np.dtype("<U32")
+        assert out[0].endswith("p")
+        assert out[0] == point.decimal_repr()[0]
+
+
+class TestParse:
+    def test_marked_roundtrip_is_point_word(self):
+        point, _ = _pair()
+        word = int(np.asarray(point._data, dtype=np.uint64)[0])
+        s = point.decimal_repr()[0]
+        parsed = _decimal_to_word(s)
+        assert parsed == word
+        assert parsed & 0x3F >= 48  # point suffix region (spec section 1)
+
+    def test_unmarked_keeps_area_tiebreak(self):
+        point, area = _pair()
+        s = point.decimal_repr()[0][:-1]  # strip the mark
+        assert _decimal_to_word(s) == int(np.asarray(area._data, dtype=np.uint64)[0])
+
+    def test_suffix_illegal_below_order_29(self):
+        for bad in ("1231p", "-6p", "3p"):
+            with pytest.raises(ValueError, match="legal only"):
+                _decimal_to_word(bad)
+
+    def test_bare_or_doubled_suffix_malformed(self):
+        for bad in ("p", "-p", "31111pp"):
+            with pytest.raises(ValueError):
+                _decimal_to_word(bad)
+
+
+class TestPaths:
+    def test_hive_path_refuses_point_words(self):
+        point, _ = _pair()
+        with pytest.raises(ValueError, match="points do not live in paths"):
+            point.hive_path()
+
+    def test_from_hive_path_rejects_marked_leaf(self):
+        point, _ = _pair()
+        stem = point.decimal_repr()[0]
+        with pytest.raises(ValueError, match="points do not live in paths"):
+            MortonIndexArray.from_hive_path(f"root/{stem}.zarr")

--- a/mortie/tests/test_point_suffix.py
+++ b/mortie/tests/test_point_suffix.py
@@ -15,8 +15,14 @@ from mortie.morton_index import _decimal_to_word  # noqa: E402
 
 
 def _pair():
-    """A (point, area) pair at the same location."""
-    lat, lon = np.array([45.0]), np.array([45.0])
+    """A (point, area) pair at the same location.
+
+    A *southern* order-29 point renders in the widest 32-char form
+    (``-`` + base digit + 29 body digits + ``p``), so the untruncated-content
+    assertions actually exercise the ``<U31`` -> ``<U32`` width boundary the
+    kind suffix requires (a northern point fits in 31 chars and would not).
+    """
+    lat, lon = np.array([-45.0]), np.array([45.0])
     point = MortonIndexArray.from_latlon(lat, lon, points=True)
     area = MortonIndexArray.from_latlon(lat, lon)
     return point, area

--- a/mortie/tests/test_point_suffix.py
+++ b/mortie/tests/test_point_suffix.py
@@ -84,3 +84,14 @@ class TestPaths:
         stem = point.decimal_repr()[0]
         with pytest.raises(ValueError, match="points do not live in paths"):
             MortonIndexArray.from_hive_path(f"root/{stem}.zarr")
+
+    def test_split_children_refuses_point_words(self):
+        # The prefix trie is a path-domain structure; a point word's terminal
+        # 'p' would be miscounted as an extra order digit, so it is refused at
+        # the same contract hive_path enforces (issue #120).
+        from mortie import split_children
+
+        point, _ = _pair()
+        words = np.asarray(point._data, dtype=np.uint64)
+        with pytest.raises(ValueError, match="points do not live in paths"):
+            split_children(words)

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -1344,14 +1344,16 @@ mod tests {
     }
 
     #[test]
-    fn decimal_repr_point_matches_area_of_same_path() {
-        // The point/area flag is not part of the decimal repr: an order-29 point
-        // renders the same string as the area cell sharing its path.
+    fn decimal_repr_point_is_area_repr_plus_p_suffix() {
+        // The decimal repr is now lossless in the kind: a point word renders as
+        // the area repr of the same path plus a terminal 'p' kind suffix (spec
+        // section 4, issue #120). Same base + body, different kind.
         let base = 4u8;
         let tuples = sample_tuples(29, 123);
         let point = encode_point(base, &tuples);
         let area = encode(base, &tuples, 29);
-        assert_eq!(to_decimal_repr(point), to_decimal_repr(area));
+        let area_repr = to_decimal_repr(area).unwrap();
+        assert_eq!(to_decimal_repr(point).unwrap(), format!("{area_repr}p"));
     }
 
     #[test]

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -613,8 +613,9 @@ pub fn to_nested(word: u64) -> Option<(u8, u64)> {
 /// Render a packed word as its decode-through-kernel decimal string repr.
 ///
 /// Returns `None` for the empty sentinel or an invalid prefix (same rejection as
-/// [`decode`]). A `Kind::Point` renders identically to the order-29 area cell
-/// sharing its path -- the point/area flag is not part of the decimal repr.
+/// [`decode`]). A `Kind::Point` renders with a terminal `p` kind suffix
+/// (spec page section 2, issue #120): `-62...21p` -- making the decimal
+/// round-trip lossless across kinds. Area words render unchanged.
 pub fn to_decimal_repr(word: u64) -> Option<String> {
     let dec = decode(word).ok()?;
     let southern = dec.base_cell >= 6;
@@ -632,6 +633,12 @@ pub fn to_decimal_repr(word: u64) -> Option<String> {
     for &t in &dec.tuples {
         // decode guarantees every tuple is 0..=3; read as the digit 1..=4.
         s.push(char::from(b'1' + t));
+    }
+    if dec.kind == Kind::Point {
+        // Kind suffix (spec section 2, issue #120): point ids carry a
+        // terminal `p` in the render form; paths never do (the hive-path
+        // surface refuses point words instead).
+        s.push('p');
     }
     Some(s)
 }

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -166,6 +166,17 @@ fn split_children_rust(
     max_depth: Option<usize>,
 ) -> PyResult<PyObject> {
     let data = morton_array.to_vec()?;
+    // The prefix trie is a path-domain structure: it branches on the decimal
+    // repr, and a point word's terminal 'p' would be miscounted as an extra
+    // order digit (order-30 area -> 4x-off cell_area). Points do not live in
+    // paths (spec section 2, issue #120), so refuse them loudly here -- the
+    // same contract hive_path enforces -- rather than emit a corrupt trie.
+    if data.iter().any(|&w| decimal_morton::kind_of(w) == decimal_morton::Kind::Point) {
+        return Err(PyValueError::new_err(
+            "split_children is undefined for point ids: points do not live in \
+             paths (spec section 2, issue #120); pass area words only",
+        ));
+    }
     let (flat, perm) = py.allow_threads(|| prefix_trie::split_children_flat(&data, max_depth));
 
     // Node metadata: (characteristic, count, idx_start, idx_len, child_ids, depth)

--- a/src_rust/src/prefix_trie.rs
+++ b/src_rust/src/prefix_trie.rs
@@ -57,6 +57,12 @@ fn slot_char(slot: i8) -> char {
 /// A panic-free decode: the empty sentinel / an invalid prefix has no repr, so
 /// it maps to an empty string and lands in the all-pad row (it shares no prefix
 /// with any real cell and falls out as its own degenerate group).
+///
+/// This decode assumes area words. A point word's repr carries a terminal `p`
+/// kind suffix (issue #120) that this slot grid would miscount as an extra
+/// order digit, so point words are refused loudly at the Python binding
+/// (`split_children_rust`) before they ever reach here — points do not live in
+/// the trie's path domain.
 fn reprs(morton_array: &[u64]) -> Vec<String> {
     morton_array
         .par_iter()


### PR DESCRIPTION
Closes #120. Refs #62 (normative grammar in PR #118, `docs/specification.md` §2/§4).

Implements the espg-ruled decimal **kind suffix `p`**: point ids render with a terminal `p` (e.g. `-62…21p`), the parser accepts marked and unmarked forms, and the decimal round-trip becomes **lossless for both kinds**. Unmarked strings keep the area tie-break — fully backward compatible (every pre-suffix string is an area context).

## What changed

- `src_rust/src/decimal_morton.rs::to_decimal_repr` — appends `p` when `Decoded.kind == Kind::Point`; area words render byte-identically to before.
- `mortie/morton_index.py::_decimal_to_word` — accepts the marked form: strip `p`, require order 29 (`p` below 29 is malformed), emit the **point** word (same prefix+body as the area parse; suffix `48 + t28·4 + t29` per the spec §1/§4 formulas). Unmarked strings parse to the area word, unchanged.
- `MortonIndexArray.to_decimal` — fixed width `<U31` → `<U32` (the marked form is one char wider); stale non-injectivity docstrings refreshed (`decimal_repr` is now injective across kinds).
- `MortonIndexArray.hive_path` — **refuses point words** with a pointed error (paths never carry the suffix; points don't live in paths — spec §2). `from_hive_path` likewise rejects a `p`-marked leaf stem.
- Golden vectors: new `mortie/tests/test_point_suffix.py` (marked point round-trip, unmarked backward-compat tie-break, sub-29 `p` rejection, path refusals, `<U32` untruncated emit, scalar `str()` carries the suffix).

## Phases

- [x] Phase 1 — repr emit + parse accept + surface updates + golden vectors

## Consumers pinning the old behavior (updated in this PR)

- `mortie/tests/test_packed_golden.py::test_golden_repr_not_injective_point_vs_area` — pinned identical point/area renders and point-string→area-word; now pins the lossless two-kind round-trip plus the unmarked tie-break.
- `mortie/tests/test_packed_golden.py::test_golden_string_emit_layer` and `test_morton_index.py::test_to_decimal_fixed_width` — pinned `<U31`; now `<U32`.
- zagg: **unaffected** — every string zagg renders or parses is an area word (shard keys/paths by construction), unmarked and byte-identical; verified by grep on the zagg tree.

## Testing

- Full `pytest mortie/tests`: **680 passed, 11 skipped** against a local `pip install -e .` (maturin) build with the Rust change compiled in; `flake8 mortie --select=E9,F63,F7,F82` clean.
- `cargo test --lib`: **198 passed, 0 failed** in the review worktree — the earlier "cannot link locally" caveat no longer applies here. This also caught a Rust unit test (`decimal_repr_point_matches_area_of_same_path`) that still pinned the old identical-render behavior; it is renamed and updated to the lossless point == area + `p` contract (review fold F1). CI's Rust jobs remain the authority.

## Questions for review

1. `hive_path` refusing point words is new behavior (previously a point word silently produced an area-looking path — the pre-suffix ambiguity). Loud refusal matches "points don't live in paths"; confirm vs silently rendering the unmarked area form.

