### PR TITLE
fix test_spec_page order-29 tie-break probe (issue #123)

### DIFF
--- a/mortie/tests/test_spec_page.py
+++ b/mortie/tests/test_spec_page.py
@@ -83,22 +83,31 @@ class TestDecimalParseTieBreak:
             np.array([45.0]), np.array([45.0]), points=True
         )
         word = int(np.asarray(arr._data, dtype=np.uint64)[0])
-        dec = arr.decimal_repr()[0]
+        # decimal_repr renders point words with the terminal 'p' kind suffix
+        # (spec §2, issue #120); the §4 tie-break concerns the *unmarked*
+        # order-29 string, so strip the marker to build the ambiguous probe.
+        marked = arr.decimal_repr()[0]
+        assert marked.endswith("p")
+        dec = marked.rstrip("p")
         t28, t29 = int(dec[-2]) - 1, int(dec[-1]) - 1
 
         # The point word sits in the point suffix region, at the documented
         # preorder slot 48 + t28*4 + t29 (§1).
         assert word & 0x3F == 48 + t28 * 4 + t29
 
-        # Tie-break: the parse yields the AREA word — same prefix+body (same
-        # path), area suffix 28 + t28*5 + t29 + 1 (§4).
+        # Tie-break: the unmarked parse yields the AREA word — same prefix+body
+        # (same path), area suffix 28 + t28*5 + t29 + 1 (§4).
         parsed = int(_decimal_to_word(dec))
         assert parsed & 0x3F == 28 + t28 * 5 + t29 + 1
         assert parsed >> 6 == word >> 6
         assert parsed != word
 
-        # Non-injectivity both ways: the area word renders the same string,
-        # so point-ness cannot round-trip through the decimal repr.
+        # The 'p'-marked string is unambiguous and round-trips to the POINT
+        # word (spec §2/§4, issue #120) — the marker is what disambiguates.
+        assert int(_decimal_to_word(marked)) == word
+
+        # Non-injectivity: the area word renders the same *unmarked* string,
+        # so point-ness cannot round-trip through the unmarked decimal repr.
         area = MortonIndexArray.from_words(np.asarray([parsed], dtype=np.uint64))
         assert area.decimal_repr()[0] == dec
 


### PR DESCRIPTION
Closes #123

## What / why

`main` was red: `TestDecimalParseTieBreak::test_order29_string_parses_to_area_word` failed with `ValueError: invalid literal for int() with base 10: 'p'`.

The test derives `t28, t29` from `dec[-2]` / `dec[-1]`, but issue #120's "delegate point suffix to kernel" made `decimal_repr()` terminate a point word with the `p` kind suffix (spec §2 — the render form carries `p` on point ids). So `dec[-1] == 'p'` and `int('p')` raises.

**The runtime is correct per spec — this is test-only.** §2 says the render carries `p`; §4 says an *unmarked* order-29 decimal string ties to the AREA word. The pin, not the behavior, was stale, so no kernel / `decimal_repr` change is warranted.

## Approach

Strip the marker to build the *unmarked* probe the tie-break is actually about (`dec = marked.rstrip("p")`), then keep the existing tie-break assertions on that well-formed string. Also, while there:
- assert the point repr `marked.endswith("p")` (documents #120's render form),
- keep the tie-break checks (`parsed & 0x3F == 28 + t28*5 + t29 + 1`, same-path prefix, `parsed != word`, non-injectivity of the *unmarked* string),
- add that the `p`-**marked** string is unambiguous and round-trips back to the POINT word (`_decimal_to_word(marked) == word`) — the marker is what disambiguates.

The non-injectivity assertion now compares the area word's repr against the unmarked `dec` (the area word renders without `p`), which is the correct pin.

## How tested

- `maturin develop --release` (rebuilt the Rust ext; no Rust change)
- `flake8 mortie --select=E9,F63,F7,F82` — clean
- `pytest -v`
  - before: `1 failed, 3 passed` in `test_spec_page.py` (full suite red)
  - after: `4 passed` in `test_spec_page.py`; full suite `684 passed, 11 skipped`

## Questions for review

None — the fix is faithful to the test's stated purpose (unmarked → area, marked → point) and leaves runtime behavior untouched. Flagging only that `main`-red is resolved by this single test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ziny2mbAruJjuNQTTaHip)_