### PR TITLE
Unify order2res Earth model with the spec-page sphere (R=6371.0088)

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -140,15 +140,15 @@ cell spacing `sqrt(4πR² / (12 · 4^order))`. The table below is regenerated
 from these formulas and pinned by `mortie/tests/test_spec_page.py` so it
 cannot drift.
 
-**Note — code vs. page.** These are the **normative, sphere-derived**
-values. `mortie.tools.order2res` in *code* retains the historical flat
-constant `111 km/deg × 58.6323 × 0.5^order` (an implied sphere `R ≈ 6366
-km`) for **behavioral compatibility** — it is consumed by `res2display` and
-by buffer-pad computations (e.g. `tests/test_coverage_boundary.py`, which
-scales the coverage pad by `order2res`) whose outputs would shift if the
-constant changed. The page's cell-scale column is therefore ~0.2% larger
-than `order2res` at every order. Unifying `order2res` onto this sphere is a
-behavioral change tracked separately in
+**Note — code and page unified.** These are the **normative, sphere-derived**
+values, and `mortie.tools.order2res` now derives from the same sphere:
+`order2res(order) = sqrt(4πR² / (12 · 4^order))` with the single
+`mortie.tools.EARTH_RADIUS_KM = 6371.0088` constant. Its consumers
+(`res2display` and the buffer-pad computation in
+`tests/test_coverage_boundary.py`) therefore read the cell-scale column
+below directly. This replaced the historical flat constant
+`111 km/deg × 58.6323 × 0.5^order` (an implied sphere `R ≈ 6366 km`), a
+behavioral change of ~0.2% at every order, per
 [mortie #119](https://github.com/espg/mortie/issues/119).
 
 <!-- table:order2res:begin -->

--- a/mortie/tests/test_spec_page.py
+++ b/mortie/tests/test_spec_page.py
@@ -5,10 +5,9 @@ HEALPix-sphere formulas the doc cites (issue #62: the table cannot drift).
 **Both** columns derive from the exact HEALPix sphere at mean radius
 ``EARTH_RADIUS_KM``: every order-k cell has identical area
 ``4*pi*R**2 / (12 * 4**k)``, and the cell scale is the square root of that
-area (RMS cell spacing). This is the sphere-derived normative value, not the
-historical ``order2res`` constant kept in ``mortie.tools`` for behavioral
-compatibility (spec §3 code-vs-page note; unification tracked as a mortie
-follow-up issue). This test compares every regenerated row literally against
+area (RMS cell spacing). ``mortie.tools.order2res`` is derived from this same
+``EARTH_RADIUS_KM`` sphere (issue #119), so the code and page now share one
+Earth model. This test compares every regenerated row literally against
 the rows between the ``table:order2res`` markers; to refresh the doc after a
 deliberate formula change, paste the rows this module's ``table_rows()``
 produces.
@@ -17,13 +16,13 @@ produces.
 import math
 from pathlib import Path
 
-from mortie.tools import MAX_ORDER
+from mortie.tools import EARTH_RADIUS_KM, MAX_ORDER
 
 SPEC_PAGE = Path(__file__).resolve().parents[2] / "docs" / "specification.md"
 BEGIN = "<!-- table:order2res:begin -->"
 END = "<!-- table:order2res:end -->"
 # Exact HEALPix sphere, mean Earth radius (km); drives BOTH table columns.
-EARTH_RADIUS_KM = 6371.0088
+# order2res is now unified onto this same sphere (issue #119).
 
 
 def format_row(order):

--- a/mortie/tests/test_tools.py
+++ b/mortie/tests/test_tools.py
@@ -11,6 +11,8 @@ Key constraints:
 - Tests focus on consistency, determinism, and structural validation
 """
 
+import math
+
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -18,25 +20,30 @@ from numpy.testing import assert_array_equal, assert_allclose
 from mortie import tools
 
 
+def _sphere_res(order):
+    """Reference RMS cell spacing (km): sqrt of the equal-area cell area."""
+    R = tools.EARTH_RADIUS_KM
+    return math.sqrt(4 * math.pi * R**2 / (12 * 4**order))
+
+
 class TestOrder2Res:
     """Test order to resolution conversion"""
 
     def test_order2res_basic(self):
         """Test basic order to resolution calculations"""
-        # Order 0 should be largest resolution
+        # Order 0 is the RMS cell spacing on the unified HEALPix sphere.
         res0 = tools.order2res(0)
-        assert_allclose(res0, 111 * 58.6323, rtol=1e-10)
+        assert_allclose(res0, _sphere_res(0), rtol=1e-10)
 
-        # Order 1 should be half of order 0
+        # Each order halves the cell scale (area drops by 4).
         res1 = tools.order2res(1)
         assert_allclose(res1, res0 / 2.0, rtol=1e-10)
 
     def test_order2res_range(self):
-        """Test full range of valid orders"""
+        """Test full range of valid orders against the sphere formula"""
         for order in range(20):
             res = tools.order2res(order)
-            expected = 111 * 58.6323 * (0.5 ** order)
-            assert_allclose(res, expected, rtol=1e-10)
+            assert_allclose(res, _sphere_res(order), rtol=1e-10)
 
     def test_order2res_decreasing(self):
         """Test that resolution decreases with order"""
@@ -72,12 +79,12 @@ class TestRes2Display:
         tools.res2display()
         lines = capsys.readouterr().out.strip().split('\n')
         by_order = {int(line.rsplit(' ', 1)[1]): line for line in lines}
-        # order 12 = 1.589 km, order 13 = 794.456 m (the issue's examples)
-        assert by_order[12] == '1.589 km at tessellation order 12'
-        assert by_order[13] == '794.456 m at tessellation order 13'
+        # order 12 = 1.592 km, order 13 = 795.852 m (unified sphere, issue #119)
+        assert by_order[12] == '1.592 km at tessellation order 12'
+        assert by_order[13] == '795.852 m at tessellation order 13'
         # finest orders drop to cm rather than tiny km/m fractions
-        assert by_order[25] == '19.396 cm at tessellation order 25'
-        assert by_order[29] == '1.212 cm at tessellation order 29'
+        assert by_order[25] == '19.43 cm at tessellation order 25'
+        assert by_order[29] == '1.214 cm at tessellation order 29'
 
     def test_rounds_within_bracket(self, capsys):
         """Values are rounded to three decimals inside the chosen unit"""

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -7,6 +7,11 @@ import numpy as np
 from . import _healpix as hp
 from . import _rustie
 
+# Mean Earth radius (km), the exact HEALPix sphere the spec page's resolution
+# table (docs/specification.md §3) derives from. order2res is the RMS cell
+# spacing on this sphere; unified with the page in issue #119.
+EARTH_RADIUS_KM = 6371.0088
+
 # Rust-native geo2mort (uses healpix crate, no Python HEALPix backend)
 _rust_geo2mort = _rustie.rust_geo2mort
 # Packed-word kernel bridge: morton <-> HEALPix NESTED (vectorized).
@@ -20,8 +25,16 @@ MAX_ORDER = 29
 
 
 def order2res(order):
-    res = 111 * 58.6323 * .5**order
-    return res
+    """Approximate cell scale (km) at a HEALPix tessellation ``order``.
+
+    The exact RMS cell spacing on the mean-radius HEALPix sphere: every
+    order-k cell has identical area ``4*pi*R**2 / (12 * 4**order)`` (HEALPix is
+    equal-area), and the cell scale is the square root of that area. Derived
+    from :data:`EARTH_RADIUS_KM` so code and the spec page (§3) share one Earth
+    model (issue #119).
+    """
+    area = 4 * np.pi * EARTH_RADIUS_KM**2 / (12 * 4**order)  # km2
+    return float(np.sqrt(area))
 
 
 def res2display(max_order=MAX_ORDER):
@@ -32,7 +45,7 @@ def res2display(max_order=MAX_ORDER):
     Each resolution is rendered in the largest sensible unit -- km at coarse
     orders, m once it drops below 1 km, cm once it drops below 1 m -- and
     rounded to three decimals within that bracket, so fine orders read
-    naturally (e.g. order 12 -> ``1.589 km``, order 13 -> ``794.456 m``)
+    naturally (e.g. order 12 -> ``1.592 km``, order 13 -> ``795.852 m``)
     rather than as tiny km fractions.
 
     ``max_order`` must lie in 0..MAX_ORDER, the order range the packed-u64


### PR DESCRIPTION
Closes #119

## What & approach

`mortie.tools.order2res` no longer uses the historical flat constant
(`111 km/deg × 58.6323 × 0.5^order`, implied sphere `R ≈ 6366 km`). It now derives the resolution from the **exact HEALPix sphere** at mean radius `R = 6371.0088 km`, the same Earth model the spec page (`docs/specification.md` §3, PR #118) uses for both its cell-scale and cell-area columns:

```python
EARTH_RADIUS_KM = 6371.0088  # single module-level constant

def order2res(order):
    area = 4 * np.pi * EARTH_RADIUS_KM**2 / (12 * 4**order)  # km2
    return float(np.sqrt(area))  # RMS cell spacing (km)
```

Because HEALPix is equal-area, every order-*k* cell has area `4πR²/(12·4^order)`; the cell scale is `sqrt(area)`, the RMS cell spacing. Code and page now share one Earth model.

## Behavioral change

This is a **behavioral change**: `order2res` is ~0.2% **larger** at every order (order 0: `6508.19 km` → `6519.62 km`; order 29: `1.212 cm` → `1.214 cm`). Its consumers shift accordingly:
- `res2display` — per-order printout (order 12 now `1.592 km`, order 13 `795.852 m`);
- `tests/test_coverage_boundary.py` — coverage-buffer pad `pad_cells * order2res(order) / KM_PER_DEG`, now ~0.2% larger (more conservative — see Questions).

## Phases

- [x] **Phase 1** — add `EARTH_RADIUS_KM` constant + sphere-formula `order2res` in `mortie/tools.py`; update the `res2display` docstring examples; rewrite the `docs/specification.md` §3 "code vs. page" note to reflect that code is now unified onto the page sphere.
- [x] **Phase 2** — re-pin `test_tools.py` (`test_order2res_basic`/`_range` now compare against the sphere formula; `test_order2res_decreasing` unchanged — still valid); refresh `res2display` expected strings; switch `test_spec_page.py` to **import** `EARTH_RADIUS_KM` from `mortie.tools` instead of redefining it locally, and update its module docstring.

## How tested

- `maturin develop --release` (no Rust change here — `order2res` is pure Python — but the extension was rebuilt for the suite).
- `flake8 mortie --select=E9,F63,F7,F82` — clean.
- `pytest -v` — **683 passed, 11 skipped, 1 failed**. The single failure is the pre-existing, unrelated `test_spec_page.py::TestDecimalParseTieBreak::test_order29_string_parses_to_area_word` (issue #123, owned by a separate PR — not touched here). Every re-pinned test passes, including the full `test_coverage_boundary.py` matrix.

## Coordination note

This branch edits `mortie/tests/test_spec_page.py` (the `EARTH_RADIUS_KM` import + a module-docstring refresh). PRs for #123 and #124 also touch that file — flagging the potential merge-order/rebase conflict. This PR does **not** touch the `TestDecimalParseTieBreak` class that #123 owns; the overlap is confined to the imports block and the module docstring.

## Questions for review

- **Boundary pad tolerance.** The pad in `test_coverage_boundary.py` grew ~0.2% with `order2res`. A larger pad only *loosens* the "no-escape" bounds (`lo_bound`/`hi_bound`/`lon_slack` are additive tolerances), so it is strictly more conservative and the whole matrix still passes — no assertion was weakened. Flagging in case you'd prefer the pad decoupled from `order2res` and pinned to a fixed km value instead.
- **`_EARTH_RADIUS_M` (buffer path).** `morton_buffer_meters` keeps its own `_EARTH_RADIUS_M = 6_371_008.7714` (IUGG 2015 mean, m) — that is `6371.0087714 km`, vs the new `EARTH_RADIUS_KM = 6371.0088`. They agree to ~0.03 m and #119 scopes only `order2res`, so I left the buffer constant untouched. Say the word if you'd like them collapsed to one constant.

🤖 Generated with Claude Code