### PR TITLE
Public decimal→word parse API (issue #114)

### DIFF
--- a/docs/morton_index_datatype.md
+++ b/docs/morton_index_datatype.md
@@ -121,6 +121,43 @@ print(arr.decimal_repr())   # ['11', '12', '13', '14']
 print(arr.to_decimal())     # ['11' '12' '13' '14']   dtype='<U32'
 ```
 
+### Parsing decimal ids back — the other direction
+
+The inverse of the emit surface. Two of the three entry points are
+**numpy-only**: they import no pandas and build no `ExtensionArray`, so they
+suit hot per-key parse paths (parsing shard ids out of store paths, status
+keys, CLI arguments):
+
+```python
+import mortie
+
+mortie.decimal_to_word("-31123")                    # np.uint64, the packed word
+mortie.decimal_to_word("-31123", dtype=int)         # a Python int
+mortie.decimal_to_word("-31123", dtype=mortie.morton_index.MortonIndexScalar)
+mortie.decimals_to_words(["11", "12", "13", "14"])  # vectorized, uint64 array
+```
+
+`decimals_to_words` is the exact inverse of `to_decimal()`, so the array
+round-trips:
+
+```python
+from mortie import MortonIndexArray
+
+assert (MortonIndexArray.from_decimal(arr.to_decimal())._data == arr._data).all()
+```
+
+`MortonIndexArray.from_decimal` is the pandas-side sugar for the same parse.
+All three raise `ValueError` naming the first malformed id, in input order.
+
+**One caveat, at order 29 only.** The decimal string carries the *path*, not
+the kind, so an order-29 id is ambiguous between the area cell and the
+max-encoded point on that path. The rule (spec §4) is that a `p`-marked id
+parses to the point word and an **unmarked** id always parses to the area
+word. Emit marks point words, so `to_decimal` → `from_decimal` is lossless
+end to end — but any channel that strips the marker (path components above
+all, which never carry it) hands back the area word for what may have been a
+point. Orders 0–28 have no ambiguity: points exist only at order 29.
+
 ### Order-aware accessors
 
 Because each word self-encodes its HEALPix order, the array exposes order and

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -232,6 +232,28 @@ always implemented, golden-pinned by `mortie/tests/test_spec_page.py`; the
 [PR #121](https://github.com/espg/mortie/pull/121) (issue #120), with
 golden vectors.
 
+<!-- parse:api:begin -->
+#### Parse-side API (normative surface)
+
+The tie-break above is a **parse-side** contract, so it is worth stating in
+the terms a parse caller sees. The public entry points, all implementing the
+same kernel (`decimal_morton::from_decimal_repr`):
+
+| Entry point | Shape |
+|---|---|
+| `mortie.decimal_to_word(s, dtype=np.uint64)` | scalar; numpy-only (no pandas import), `dtype` selects `np.uint64` / `int` / `MortonIndexScalar` |
+| `mortie.decimals_to_words(arr)` | vectorized; the inverse of `MortonIndexArray.to_decimal()`, shape-preserving, `uint64` out |
+| `MortonIndexArray.from_decimal(arr)` | the same parse as an ExtensionArray constructor, the inverse of `.to_decimal()` |
+
+What a parse-side caller must know: **an unmarked order-29 id parses to the
+area word, so a point word does not round-trip through an unmarked string.**
+Emit renders point words `p`-marked, so `word → to_decimal → from_decimal`
+*is* the identity end to end — but any channel that strips the marker (a
+path component, a legacy render, a hand-typed id) returns the area word for
+what may have been a point. At orders 0–28 there is no ambiguity to resolve.
+Pinned by `mortie/tests/test_decimal_parse.py`.
+<!-- parse:api:end -->
+
 ### Points at coarser levels (informative)
 
 Membership of a point in a coarser cell is the ordinary truncation

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -133,9 +133,10 @@ from . import (
     morton_index,  # noqa: F401
 )
 
-# The decimal parse surface (issue #114) is the exception to the laziness
-# above: it needs only numpy and the Rust extension -- no pandas -- so it is a
-# plain eager export, keeping per-key parse paths free of a pandas import.
+# The decimal parse surface (issue #114). Unlike the ExtensionArray/Arrow names
+# below, these two need only numpy and the Rust extension, so they are bound
+# eagerly rather than through __getattr__ -- and they stay callable (and
+# pandas-free) in a numpy-only install, where the lazy names would raise.
 from .morton_index import (  # noqa: F401
     decimal_to_word,
     decimals_to_words,

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -133,6 +133,14 @@ from . import (
     morton_index,  # noqa: F401
 )
 
+# The decimal parse surface (issue #114) is the exception to the laziness
+# above: it needs only numpy and the Rust extension -- no pandas -- so it is a
+# plain eager export, keeping per-key parse paths free of a pandas import.
+from .morton_index import (  # noqa: F401
+    decimal_to_word,
+    decimals_to_words,
+)
+
 _ARROW_NAMES = (
     "MortonIndexType",
     "MortonIndexExtArray",
@@ -151,6 +159,7 @@ def __getattr__(name):
 
 
 __all__ += ['MortonIndexDtype', 'MortonIndexArray', 'morton_index']
+__all__ += ['decimal_to_word', 'decimals_to_words']
 __all__ += list(_ARROW_NAMES) + ['arrow']
 
 # The Rust extension is imported and used internally by the tools.py encoders

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -314,6 +314,20 @@ def _build_classes():
             return cls(words)
 
         @classmethod
+        def from_decimal(cls, decimals):
+            """Parse decimal Morton strings into an array (issue #114).
+
+            The inverse of :meth:`to_decimal`, and sugar over the numpy-only
+            :func:`decimals_to_words` for pandas users -- ``to_decimal()``
+            output round-trips straight back through it. An unmarked order-29
+            id yields the AREA word; only a ``p``-marked one yields the POINT
+            word (spec section 4), so point-ness does not survive a round-trip
+            through an unmarked string. Raises ``ValueError`` naming the first
+            malformed id.
+            """
+            return cls(decimals_to_words(decimals))
+
+        @classmethod
         def from_arrow(cls, source):
             """Build a ``MortonIndexArray`` from any Arrow C-Data array (#93).
 

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -26,61 +26,10 @@ from . import _rustie
 # ``MortonIndexDtype`` / ``MortonIndexArray`` are provided via module-level
 # ``__getattr__`` (built lazily so a numpy-only install can import this module),
 # so they are intentionally not named in ``__all__`` here.
-__all__ = ["MortonIndexScalar"]
+__all__ = ["MortonIndexScalar", "decimal_to_word", "decimals_to_words"]
 
 # HEALPix orders this datatype reaches (0 = base cell, 29 = max resolution).
 MAX_ORDER = 29
-
-
-def _decimal_to_word(s):
-    """Parse a decimal Morton string back to its packed word (issue #104).
-
-    The inverse of the decode-through-kernel repr: sign + leading base digit
-    (``1..6``), one ``1..4`` digit per order, and an optional terminal ``p``
-    kind suffix (spec section 4, issue #120). Parse rules: a ``p``-marked
-    string (legal only at order 29) yields the POINT word; an unmarked
-    string always yields the AREA word -- the tie-break for the one
-    ambiguous form, and fully backward compatible (every pre-suffix string
-    is unmarked). Raises ``ValueError`` on any malformed id.
-    """
-    point = s.endswith("p")
-    text = s[:-1] if point else s
-    body = text[1:] if text.startswith("-") else text
-    if not (body.isdigit() and body.isascii()):
-        raise ValueError(f"malformed decimal Morton id {s!r}")
-    lead, digits = int(body[0]), body[1:]
-    if not 1 <= lead <= 6:
-        raise ValueError(
-            f"decimal Morton id {s!r}: base digit {lead} outside 1..6"
-        )
-    order = len(digits)
-    if order > MAX_ORDER:
-        raise ValueError(
-            f"decimal Morton id {s!r}: order {order} exceeds {MAX_ORDER}"
-        )
-    if point and order != MAX_ORDER:
-        raise ValueError(
-            f"decimal Morton id {s!r}: the kind suffix 'p' is legal only on "
-            f"full order-{MAX_ORDER} point ids (points exist only at order "
-            f"{MAX_ORDER})"
-        )
-    within = 0
-    for d in digits:
-        if not "1" <= d <= "4":
-            raise ValueError(
-                f"decimal Morton id {s!r}: digit {d} outside 1..4"
-            )
-        within = (within << 2) | (int(d) - 1)
-    base = lead + 5 if text.startswith("-") else lead - 1
-    nested = np.asarray([(base << (2 * order)) | within], dtype=np.uint64)
-    if point:
-        # Delegate the point-suffix layout to the kernel rather than
-        # reimplement it here: `nested` is the full order-29 NESTED id (order
-        # == MAX_ORDER is guaranteed above), and the kernel packs the point
-        # word directly (suffix = 48 + t28*4 + t29, spec section 1/section 4
-        # tie-break). Keeping the formula in one place -- the kernel.
-        return int(_rustie.rust_mi_from_nested_point(nested)[0])
-    return int(_rustie.rust_mi_from_nested(nested, order)[0])
 
 
 class MortonIndexScalar(np.uint64):
@@ -121,6 +70,84 @@ class MortonIndexScalar(np.uint64):
         # bare np.uint64 and would silently drop the decimal display on any
         # process boundary (multiprocessing/dask); rebuild the wrapper instead.
         return (type(self), (int(self),))
+
+
+def decimal_to_word(s, dtype=np.uint64):
+    """Parse one decimal Morton string into its packed word (issue #114).
+
+    The scalar inverse of the decode-through-kernel repr, and the public
+    counterpart to :meth:`MortonIndexArray.decimal_repr`: sign column +
+    leading base digit (``1..6``), one ``1..4`` digit per order, and an
+    optional terminal ``p`` kind suffix (spec section 4, issue #120). A
+    ``p``-marked string (legal only at order 29) yields the POINT word; an
+    unmarked string always yields the AREA word -- the tie-break for the one
+    ambiguous form, and fully backward compatible (every pre-suffix string
+    is unmarked). Raises ``ValueError`` on any malformed id.
+
+    numpy-only: calling this imports no pandas, so it is usable from hot
+    per-key parse paths. Use :func:`decimals_to_words` for arrays.
+
+    Parameters
+    ----------
+    s : str
+        The decimal Morton id, e.g. ``"-31123"``.
+    dtype : type, optional
+        The return shape. ``np.uint64`` (default) returns the bare packed
+        word, staying numpy-native for hot loops; ``int`` returns a Python
+        int; :class:`MortonIndexScalar` returns a word that displays back as
+        its decimal string. ``"uint64"`` / ``np.dtype("uint64")`` are
+        accepted spellings of the default.
+    """
+    word = int(_rustie.rust_mi_from_decimal([s])[0])
+    if dtype is int:
+        return word
+    if dtype is MortonIndexScalar:
+        return MortonIndexScalar(word)
+    try:
+        requested = np.dtype(dtype)
+    except TypeError:
+        requested = None
+    if requested == np.uint64:
+        return np.uint64(word)
+    raise TypeError(
+        f"decimal_to_word dtype must be np.uint64 (the default), int, or "
+        f"MortonIndexScalar; got {dtype!r}"
+    )
+
+
+def decimals_to_words(decimals):
+    """Parse an array of decimal Morton strings into packed words (issue #114).
+
+    The vectorized inverse of :meth:`MortonIndexArray.to_decimal`, parsed in
+    Rust in one pass. Shape is preserved; the result is always ``uint64``.
+    numpy-only, like :func:`decimal_to_word`.
+
+    Raises ``ValueError`` naming the first malformed id, in input order.
+    """
+    arr = np.asarray(decimals)
+    if arr.size == 0:
+        # An empty list arrives as float64 (numpy's default for []), which the
+        # dtype guard below would reject; there is nothing to parse either way.
+        return np.empty(arr.shape, dtype=np.uint64)
+    if arr.dtype.kind not in ("U", "O"):
+        # Do not let numpy's str-coercion silently turn e.g. the integer 1
+        # into the order-0 id "1"; a parse surface takes strings only.
+        raise TypeError(
+            f"decimals_to_words expects decimal Morton strings, got an array "
+            f"of dtype {arr.dtype!r}"
+        )
+    words = _rustie.rust_mi_from_decimal(arr.ravel().tolist())
+    return words.reshape(arr.shape)
+
+
+def _decimal_to_word(s):
+    """Deprecated private alias for :func:`decimal_to_word` (issue #114).
+
+    Kept through a deprecation cycle because downstream code (zagg's parse
+    boundary) imports this name; returns a Python ``int`` exactly as it
+    always has. New code should use the public :func:`decimal_to_word`.
+    """
+    return decimal_to_word(s, dtype=int)
 
 
 def _require_pandas():

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -101,14 +101,19 @@ def decimal_to_word(s, dtype=np.uint64):
     word = int(_rustie.rust_mi_from_decimal([s])[0])
     if dtype is int:
         return word
-    if dtype is MortonIndexScalar:
-        return MortonIndexScalar(word)
-    try:
-        requested = np.dtype(dtype)
-    except TypeError:
-        requested = None
-    if requested == np.uint64:
-        return np.uint64(word)
+    # `issubclass`, not `is`: a MortonIndexScalar subclass must round-trip as
+    # itself rather than silently downgrading to a bare uint64.
+    if isinstance(dtype, type) and issubclass(dtype, MortonIndexScalar):
+        return dtype(word)
+    # Only a dtype *spelling* is accepted here -- `np.dtype(np.uint64(0))`
+    # happens to succeed on an instance, which would let a stray value through.
+    if isinstance(dtype, (type, str, np.dtype)):
+        try:
+            requested = np.dtype(dtype)
+        except TypeError:
+            requested = None
+        if requested == np.uint64:
+            return np.uint64(word)
     raise TypeError(
         f"decimal_to_word dtype must be np.uint64 (the default), int, or "
         f"MortonIndexScalar; got {dtype!r}"
@@ -122,13 +127,22 @@ def decimals_to_words(decimals):
     Rust in one pass. Shape is preserved; the result is always ``uint64``.
     numpy-only, like :func:`decimal_to_word`.
 
-    Raises ``ValueError`` naming the first malformed id, in input order.
+    Raises ``ValueError`` naming the first malformed id, in input order, and
+    ``TypeError`` for non-string input -- a scalar string included, since
+    ``np.asarray`` would make it a 0-d array; use :func:`decimal_to_word`.
     """
+    if isinstance(decimals, str):
+        raise TypeError(
+            "decimals_to_words expects a sequence of decimal Morton strings; "
+            "for a single id use decimal_to_word"
+        )
+    if isinstance(decimals, (list, tuple)) and len(decimals) == 0:
+        # numpy types an empty list as float64, which the dtype guard below
+        # would reject. Handled here, ahead of the guard, so that the guard
+        # stays purely dtype-driven -- an empty *array* of the wrong dtype is
+        # still a wrong dtype, and must not pass just because it has no data.
+        return np.empty(0, dtype=np.uint64)
     arr = np.asarray(decimals)
-    if arr.size == 0:
-        # An empty list arrives as float64 (numpy's default for []), which the
-        # dtype guard below would reject; there is nothing to parse either way.
-        return np.empty(arr.shape, dtype=np.uint64)
     if arr.dtype.kind not in ("U", "O"):
         # Do not let numpy's str-coercion silently turn e.g. the integer 1
         # into the order-0 id "1"; a parse surface takes strings only.
@@ -136,8 +150,16 @@ def decimals_to_words(decimals):
             f"decimals_to_words expects decimal Morton strings, got an array "
             f"of dtype {arr.dtype!r}"
         )
-    words = _rustie.rust_mi_from_decimal(arr.ravel().tolist())
-    return words.reshape(arr.shape)
+    flat = arr.ravel().tolist()
+    if arr.dtype.kind == "O" and not all(isinstance(s, str) for s in flat):
+        # Object arrays can hold anything; name the surface and the offender
+        # rather than leaking a bare PyO3 extraction message.
+        bad = next(s for s in flat if not isinstance(s, str))
+        raise TypeError(
+            f"decimals_to_words expects decimal Morton strings, got "
+            f"{type(bad).__name__} ({bad!r})"
+        )
+    return _rustie.rust_mi_from_decimal(flat).reshape(arr.shape)
 
 
 def _decimal_to_word(s):
@@ -145,7 +167,12 @@ def _decimal_to_word(s):
 
     Kept through a deprecation cycle because downstream code (zagg's parse
     boundary) imports this name; returns a Python ``int`` exactly as it
-    always has. New code should use the public :func:`decimal_to_word`.
+    always has, and rejects exactly the same strings. New code should use the
+    public :func:`decimal_to_word`.
+
+    One deliberate difference: a non-``str`` argument now raises ``TypeError``
+    (from the Rust binding) where the old pure-Python body raised
+    ``AttributeError`` from ``s.endswith``. String behavior is unchanged.
     """
     return decimal_to_word(s, dtype=int)
 
@@ -642,13 +669,13 @@ def _build_classes():
             descent) raises ``ValueError``. A bare ``{full_id}.zarr``, or one
             under an arbitrary root without the digit chain, skips the check.
             Order-29 ids parse to the *area* word (see
-            :func:`_decimal_to_word`).
+            :func:`decimal_to_word`).
             """
             import pathlib
 
             if isinstance(paths, (str, os.PathLike)):
                 paths = [paths]
-            words = []
+            decs = []
             for p in paths:
                 if isinstance(p, pathlib.PurePath):
                     # honor the path's own flavor: a WindowsPath splits on
@@ -668,7 +695,6 @@ def _build_classes():
                         f"points do not live in paths (spec section 2, issue "
                         f"#120)"
                     )
-                word = _decimal_to_word(dec)
                 head = 2 if dec.startswith("-") else 1
                 levels = [dec[:head], *dec[head:]]
                 # Enforce the directory cross-check only when the chain is
@@ -689,8 +715,10 @@ def _build_classes():
                             f"hive path {p!r} directories {'/'.join(got)!r} "
                             f"do not match leaf id {dec!r}"
                         )
-                words.append(word)
-            return cls(np.asarray(words, dtype=np.uint64))
+                decs.append(dec)
+            # One vectorized Rust parse for the whole batch rather than a
+            # per-leaf scalar call (issue #114): ~13x on large path lists.
+            return cls(decimals_to_words(decs))
 
         # -- repr ------------------------------------------------------------
 

--- a/mortie/tests/test_decimal_parse.py
+++ b/mortie/tests/test_decimal_parse.py
@@ -1,0 +1,187 @@
+"""Public decimal->word parse surface (issue #114).
+
+The emit direction (``decimal_repr`` / ``to_decimal`` / ``hive_path``) has
+been public since issue #104; these are the pins for its public inverse:
+``mortie.decimal_to_word`` (scalar, with the ``dtype`` return-shape flag),
+``mortie.decimals_to_words`` (vectorized, Rust-backed), and the retained
+private ``_decimal_to_word`` alias.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+import mortie
+from mortie.morton_index import (
+    MAX_ORDER,
+    MortonIndexScalar,
+    _decimal_to_word,
+    decimal_to_word,
+    decimals_to_words,
+)
+
+
+class TestPublicSurface:
+    def test_exported_from_package_root(self):
+        assert mortie.decimal_to_word is decimal_to_word
+        assert mortie.decimals_to_words is decimals_to_words
+        assert "decimal_to_word" in mortie.__all__
+        assert "decimals_to_words" in mortie.__all__
+
+    def test_parses_with_pandas_unavailable(self):
+        # The point of the numpy-only path (issue #114): zagg's per-shard key
+        # parse must not need pandas. `import mortie` *does* touch pandas when
+        # it is installed -- deliberately, to register the dtype eagerly
+        # (morton_index.py, the `_build_classes()` probe) -- so proving the
+        # claim means running with pandas made unimportable, not just checking
+        # sys.modules. A fresh interpreter with a meta_path blocker does that.
+        code = (
+            "import sys\n"
+            "class Block:\n"
+            "    def find_spec(self, name, path=None, target=None):\n"
+            "        if name == 'pandas' or name.startswith('pandas.'):\n"
+            "            raise ImportError('pandas blocked for this test')\n"
+            "        return None\n"
+            "sys.meta_path.insert(0, Block())\n"
+            "import mortie\n"
+            "assert 'pandas' not in sys.modules\n"
+            "w = mortie.decimal_to_word('-31123')\n"
+            "a = mortie.decimals_to_words(['3', '-6', '31123'])\n"
+            "assert 'pandas' not in sys.modules\n"
+            "print(int(w), a.dtype)\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.split()[-1] == "uint64"
+        assert int(out.stdout.split()[0]) == decimal_to_word("-31123", dtype=int)
+
+    def test_private_alias_still_works_and_returns_int(self):
+        # zagg imports the private name; espg asked to keep both through a
+        # deprecation cycle, so the old return type must not drift.
+        word = _decimal_to_word("-31123")
+        assert type(word) is int
+        assert word == int(decimal_to_word("-31123"))
+
+
+class TestScalarDtypeFlag:
+    def test_default_is_numpy_uint64(self):
+        word = decimal_to_word("-31123")
+        assert isinstance(word, np.uint64)
+        assert not isinstance(word, MortonIndexScalar)
+
+    def test_python_int(self):
+        word = decimal_to_word("-31123", dtype=int)
+        assert type(word) is int
+
+    def test_morton_index_scalar_displays_as_the_decimal_string(self):
+        word = decimal_to_word("-31123", dtype=MortonIndexScalar)
+        assert isinstance(word, MortonIndexScalar)
+        assert str(word) == "-31123"
+
+    @pytest.mark.parametrize("spelling", ["uint64", np.dtype("uint64")])
+    def test_uint64_spellings_accepted(self, spelling):
+        assert decimal_to_word("3123", dtype=spelling) == decimal_to_word("3123")
+
+    @pytest.mark.parametrize("bad", [float, "float64", np.int64, object()])
+    def test_unsupported_dtype_raises(self, bad):
+        with pytest.raises(TypeError, match="dtype must be"):
+            decimal_to_word("3123", dtype=bad)
+
+
+class TestVectorized:
+    def test_matches_the_scalar_elementwise(self):
+        ids = ["1", "-6", "3123", "-31123", "2" + "4" * MAX_ORDER]
+        got = decimals_to_words(ids)
+        assert got.dtype == np.uint64
+        assert list(got) == [decimal_to_word(s) for s in ids]
+
+    def test_shape_is_preserved(self):
+        arr = np.array([["1", "-6"], ["3123", "-31123"]])
+        assert decimals_to_words(arr).shape == (2, 2)
+
+    def test_empty_input(self):
+        out = decimals_to_words([])
+        assert out.shape == (0,)
+        assert out.dtype == np.uint64
+
+    def test_object_array_of_strings(self):
+        arr = np.array(["3123", "-6"], dtype=object)
+        assert list(decimals_to_words(arr)) == [
+            decimal_to_word("3123"),
+            decimal_to_word("-6"),
+        ]
+
+    def test_non_string_input_rejected_not_coerced(self):
+        # np.asarray([1, 2], dtype=str) would silently become the order-0 ids
+        # "1"/"2"; a parse surface must not invent input.
+        with pytest.raises(TypeError, match="expects decimal Morton strings"):
+            decimals_to_words([1, 2])
+
+    def test_error_names_the_first_bad_id_in_input_order(self):
+        with pytest.raises(ValueError, match="'0123'"):
+            decimals_to_words(["3123", "0123", "7123"])
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize("order", [0, 1, 13, 27, 28, MAX_ORDER])
+    def test_word_to_decimal_to_word_identity(self, order):
+        pytest.importorskip("pandas")
+        from mortie import MortonIndexArray
+
+        lats = np.array([-70.0, -20.0, 0.0, 20.0, 70.0])
+        lons = np.array([-170.0, -45.0, 0.0, 45.0, 170.0])
+        arr = MortonIndexArray.from_latlon(lats, lons, order=order)
+        words = np.asarray(arr._data, dtype=np.uint64)
+        assert np.array_equal(decimals_to_words(arr.to_decimal()), words)
+
+    def test_malformed_ids_raise(self):
+        for bad in ("", "-", "0123", "7123", "31023", "3125", "x123",
+                    "3" + "1" * 30, "p", "-p", "31111pp"):
+            with pytest.raises(ValueError):
+                decimal_to_word(bad)
+
+
+class TestPointAreaNonInjectivity:
+    """Order-29 ids do not distinguish point from area unless marked.
+
+    The parse-side statement of the spec section 4 tie-break: an *unmarked*
+    order-29 string always yields the AREA word, so a point word does not
+    round-trip through the unmarked decimal form. Only the ``p`` marker
+    recovers it.
+    """
+
+    def test_marked_and_unmarked_order29_parse_to_different_words(self):
+        pytest.importorskip("pandas")
+        from mortie import MortonIndexArray
+
+        point = MortonIndexArray.from_latlon(
+            np.array([45.0]), np.array([45.0]), points=True
+        )
+        point_word = int(np.asarray(point._data, dtype=np.uint64)[0])
+        marked = point.decimal_repr()[0]
+        assert marked.endswith("p")
+        unmarked = marked[:-1]
+
+        assert decimal_to_word(marked, dtype=int) == point_word
+        area_word = decimal_to_word(unmarked, dtype=int)
+        assert area_word != point_word
+        # Same path (prefix + body), different kind (suffix) -- section 1.
+        assert area_word >> 6 == point_word >> 6
+        assert point_word & 0x3F >= 48  # point suffix region
+        assert area_word & 0x3F < 48    # area suffix region
+
+        # And the area word renders that same unmarked string, so the parse
+        # is genuinely non-injective over the unmarked form.
+        area = MortonIndexArray.from_words(
+            np.asarray([area_word], dtype=np.uint64)
+        )
+        assert area.decimal_repr()[0] == unmarked
+
+    def test_marker_is_illegal_below_order_29(self):
+        for bad in ("1231p", "-6p", "3p"):
+            with pytest.raises(ValueError, match="legal only"):
+                decimal_to_word(bad)

--- a/mortie/tests/test_decimal_parse.py
+++ b/mortie/tests/test_decimal_parse.py
@@ -67,6 +67,14 @@ class TestPublicSurface:
         assert type(word) is int
         assert word == int(decimal_to_word("-31123"))
 
+    @pytest.mark.parametrize("bad", [None, 3123, 1.5, ["3123"], np.uint64(3)])
+    def test_private_alias_rejects_non_str_with_type_error(self, bad):
+        # Deliberate difference from the old pure-Python body, which raised
+        # AttributeError from `s.endswith`. Pinned so the change is a decision
+        # rather than a surprise for the downstream that imports this name.
+        with pytest.raises(TypeError):
+            _decimal_to_word(bad)
+
 
 class TestScalarDtypeFlag:
     def test_default_is_numpy_uint64(self):
@@ -85,12 +93,28 @@ class TestScalarDtypeFlag:
 
     @pytest.mark.parametrize("spelling", ["uint64", np.dtype("uint64")])
     def test_uint64_spellings_accepted(self, spelling):
-        assert decimal_to_word("3123", dtype=spelling) == decimal_to_word("3123")
+        got = decimal_to_word("3123", dtype=spelling)
+        # Assert the *type*, not just the value: a lossy float64 return would
+        # compare equal here while silently truncating large words.
+        assert isinstance(got, np.uint64)
+        assert int(got) == decimal_to_word("3123", dtype=int)
 
-    @pytest.mark.parametrize("bad", [float, "float64", np.int64, object()])
+    @pytest.mark.parametrize(
+        "bad", [float, "float64", np.int64, object(), None, bool, np.uint32,
+                np.uint64(0)]
+    )
     def test_unsupported_dtype_raises(self, bad):
+        # np.uint64(0) is an *instance*: np.dtype() accepts it, so without an
+        # explicit spelling check a stray value would be read as the default.
         with pytest.raises(TypeError, match="dtype must be"):
             decimal_to_word("3123", dtype=bad)
+
+    def test_morton_index_scalar_subclass_is_preserved(self):
+        class MyScalar(MortonIndexScalar):
+            pass
+
+        got = decimal_to_word("3123", dtype=MyScalar)
+        assert type(got) is MyScalar
 
 
 class TestVectorized:
@@ -105,9 +129,31 @@ class TestVectorized:
         assert decimals_to_words(arr).shape == (2, 2)
 
     def test_empty_input(self):
-        out = decimals_to_words([])
-        assert out.shape == (0,)
-        assert out.dtype == np.uint64
+        for empty in ([], (), np.array([], dtype="<U32")):
+            out = decimals_to_words(empty)
+            assert out.shape == (0,)
+            assert out.dtype == np.uint64
+
+    @pytest.mark.parametrize(
+        "empty",
+        [np.array([], dtype=np.int64), np.zeros((0, 3), dtype=complex)],
+    )
+    def test_empty_but_wrong_dtype_still_rejected(self, empty):
+        # The type guard must be dtype-driven, not size-driven: an array that
+        # merely happens to be empty is still the wrong type, and accepting it
+        # would mean the check only bites once there is data.
+        with pytest.raises(TypeError, match="expects decimal Morton strings"):
+            decimals_to_words(empty)
+
+    def test_bare_string_is_rejected_not_treated_as_one_element(self):
+        # np.asarray("3123") is a 0-d array, so this would otherwise return a
+        # 0-d word -- a silent trap on the singular/plural name pair.
+        with pytest.raises(TypeError, match="use decimal_to_word"):
+            decimals_to_words("3123")
+
+    def test_object_array_non_string_names_the_offender(self):
+        with pytest.raises(TypeError, match="got int"):
+            decimals_to_words(np.array(["3123", 7], dtype=object))
 
     def test_object_array_of_strings(self):
         arr = np.array(["3123", "-6"], dtype=object)

--- a/mortie/tests/test_decimal_parse.py
+++ b/mortie/tests/test_decimal_parse.py
@@ -145,6 +145,58 @@ class TestRoundTrip:
                 decimal_to_word(bad)
 
 
+class TestExtensionArrayClassmethod:
+    """``MortonIndexArray.from_decimal`` -- the pandas-side sugar."""
+
+    def test_round_trips_to_decimal(self):
+        pytest.importorskip("pandas")
+        from mortie import MortonIndexArray
+
+        arr = MortonIndexArray.from_latlon(
+            np.array([-45.0, 12.5, 78.0]), np.array([170.0, -3.0, 45.0]),
+            order=11,
+        )
+        back = MortonIndexArray.from_decimal(arr.to_decimal())
+        assert isinstance(back, MortonIndexArray)
+        assert np.array_equal(
+            np.asarray(back._data, dtype=np.uint64),
+            np.asarray(arr._data, dtype=np.uint64),
+        )
+
+    def test_accepts_a_plain_list_and_matches_the_module_function(self):
+        pytest.importorskip("pandas")
+        from mortie import MortonIndexArray
+
+        ids = ["3123", "-31123", "6"]
+        arr = MortonIndexArray.from_decimal(ids)
+        assert np.array_equal(
+            np.asarray(arr._data, dtype=np.uint64), decimals_to_words(ids)
+        )
+
+    def test_malformed_id_raises(self):
+        pytest.importorskip("pandas")
+        from mortie import MortonIndexArray
+
+        with pytest.raises(ValueError, match="'0123'"):
+            MortonIndexArray.from_decimal(["3123", "0123"])
+
+    def test_hive_path_leaves_round_trip(self):
+        # from_hive_path already parses leaves; from_decimal is the direct
+        # form of the same parse, so the two must agree on the leaf ids.
+        pytest.importorskip("pandas")
+        from mortie import MortonIndexArray
+
+        arr = MortonIndexArray.from_latlon(
+            np.array([10.0, -60.0]), np.array([20.0, -140.0]), order=6
+        )
+        paths = arr.hive_path(root="data")
+        leaves = [p.rsplit("/", 1)[-1][: -len(".zarr")] for p in paths]
+        assert np.array_equal(
+            np.asarray(MortonIndexArray.from_decimal(leaves)._data, dtype=np.uint64),
+            np.asarray(MortonIndexArray.from_hive_path(paths)._data, dtype=np.uint64),
+        )
+
+
 class TestPointAreaNonInjectivity:
     """Order-29 ids do not distinguish point from area unless marked.
 

--- a/mortie/tests/test_decimal_parse.py
+++ b/mortie/tests/test_decimal_parse.py
@@ -9,6 +9,7 @@ private ``_decimal_to_word`` alias.
 
 import subprocess
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -237,3 +238,51 @@ class TestPointAreaNonInjectivity:
         for bad in ("1231p", "-6p", "3p"):
             with pytest.raises(ValueError, match="legal only"):
                 decimal_to_word(bad)
+
+
+class TestSpecPageParseSection:
+    """Drift pin for the spec page's parse-side API block (issue #114).
+
+    The section-4 tie-break is a parse-side contract, so the page names the
+    public parse entry points; if one is renamed or dropped the page must be
+    updated with it, and this catches the drift.
+    """
+
+    BEGIN = "<!-- parse:api:begin -->"
+    END = "<!-- parse:api:end -->"
+
+    def _block(self):
+        page = (
+            Path(__file__).resolve().parents[2] / "docs" / "specification.md"
+        ).read_text()
+        assert self.BEGIN in page and self.END in page, (
+            "parse-api markers missing from the spec page"
+        )
+        block = page.split(self.BEGIN, 1)[1].split(self.END, 1)[0]
+        # Normalize markdown wrapping so a reflow does not fail the pin.
+        return " ".join(block.replace("**", "").split())
+
+    def test_page_names_every_public_entry_point(self):
+        block = self._block()
+        for name in (
+            "mortie.decimal_to_word",
+            "mortie.decimals_to_words",
+            "MortonIndexArray.from_decimal",
+        ):
+            assert name in block, f"spec page does not name {name}"
+
+    def test_named_entry_points_exist(self):
+        pytest.importorskip("pandas")
+        from mortie import MortonIndexArray
+
+        assert callable(mortie.decimal_to_word)
+        assert callable(mortie.decimals_to_words)
+        assert callable(MortonIndexArray.from_decimal)
+
+    def test_page_states_the_unmarked_order29_rule(self):
+        # The one thing a parse-side caller can get wrong; the prose claim and
+        # the behavior are pinned together so neither can drift alone.
+        assert "unmarked order-29 id parses to the area word" in self._block()
+
+        arr = mortie.decimals_to_words(["3" + "1" * MAX_ORDER])
+        assert int(arr[0]) & 0x3F < 48  # area suffix region, not point

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -714,6 +714,126 @@ pub fn from_legacy_decimal(legacy: i64) -> u64 {
     from_nested(nested, depth)
 }
 
+// ---------------------------------------------------------------------------
+// decimal string -> packed word (issue #114)
+// ---------------------------------------------------------------------------
+//
+// The exact inverse of [`to_decimal_repr`], and the single implementation of the
+// parse grammar (spec section 2):
+//
+// ```text
+// morton-decimal = ["-"] base-digit *order-digit [kind-suffix]
+// base-digit     = "1" / "2" / "3" / "4" / "5" / "6"
+// order-digit    = "1" / "2" / "3" / "4"
+// kind-suffix    = "p"    ; POINT ids only, order 29 only
+// ```
+//
+// The order is the order-digit count, so the parse is a single left-to-right
+// scan with no lookahead. The one ambiguity in the convention is the order-29
+// string (spec section 4): a `p`-marked id yields the POINT word, an unmarked id
+// always yields the AREA word -- so point-ness does not round-trip through an
+// unmarked string, and every pre-suffix (unmarked) id keeps its old meaning.
+
+/// Why a decimal Morton string failed to parse ([`from_decimal_repr`]).
+///
+/// Each variant carries the offending id so the rendered message names it; the
+/// wording matches the Python surface these errors surface through.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    /// Not a well-formed `["-"] base-digit *order-digit ["p"]` string.
+    Malformed(String),
+    /// Leading base digit outside `1..=6`.
+    BaseDigit(String, u8),
+    /// More order digits than [`MAX_ORDER`].
+    OrderTooDeep(String, usize),
+    /// A terminal `p` on anything but a full order-[`MAX_ORDER`] id.
+    PointSuffixOrder(String, usize),
+    /// An order digit outside `1..=4`.
+    OrderDigit(String, char),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::Malformed(s) => write!(f, "malformed decimal Morton id '{}'", s),
+            ParseError::BaseDigit(s, d) => write!(
+                f,
+                "decimal Morton id '{}': base digit {} outside 1..6",
+                s, d
+            ),
+            ParseError::OrderTooDeep(s, order) => write!(
+                f,
+                "decimal Morton id '{}': order {} exceeds {}",
+                s, order, MAX_ORDER
+            ),
+            ParseError::PointSuffixOrder(s, _) => write!(
+                f,
+                "decimal Morton id '{}': the kind suffix 'p' is legal only on \
+                 full order-{} point ids (points exist only at order {})",
+                s, MAX_ORDER, MAX_ORDER
+            ),
+            ParseError::OrderDigit(s, d) => {
+                write!(f, "decimal Morton id '{}': digit {} outside 1..4", s, d)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse a decimal Morton string back into its packed word.
+///
+/// The inverse of [`to_decimal_repr`]: sign column + leading base digit
+/// (`1..=6`), one `1..=4` digit per order, and an optional terminal `p` kind
+/// suffix. A `p`-marked string (legal only at order [`MAX_ORDER`]) yields the
+/// POINT word; an unmarked string always yields the AREA word -- the spec
+/// section 4 tie-break for the one ambiguous form.
+///
+/// Rejects every malformed id with a [`ParseError`] rather than panicking; the
+/// base digit range guarantees a base cell of `0..=11`, so the [`from_nested`]
+/// / [`from_nested_point`] asserts are unreachable from here.
+pub fn from_decimal_repr(s: &str) -> Result<u64, ParseError> {
+    let point = s.ends_with('p');
+    let text = if point { &s[..s.len() - 1] } else { s };
+    let southern = text.starts_with('-');
+    let body = if southern { &text[1..] } else { text };
+    // ASCII digits only: Python's `str.isdigit()` also accepts superscripts and
+    // other unicode numerics, which are not part of the grammar.
+    if body.is_empty() || !body.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(ParseError::Malformed(s.to_string()));
+    }
+    let bytes = body.as_bytes();
+    let lead = bytes[0] - b'0';
+    if !(1..=6).contains(&lead) {
+        return Err(ParseError::BaseDigit(s.to_string(), lead));
+    }
+    let digits = &bytes[1..];
+    let order = digits.len();
+    if order > MAX_ORDER as usize {
+        return Err(ParseError::OrderTooDeep(s.to_string(), order));
+    }
+    if point && order != MAX_ORDER as usize {
+        return Err(ParseError::PointSuffixOrder(s.to_string(), order));
+    }
+    // Digits are the stored tuples read as `1..=4`; the accumulator is the
+    // within-base NESTED address (2 bits per order, at most 58 bits at order 29).
+    let mut within: u64 = 0;
+    for &d in digits {
+        if !(b'1'..=b'4').contains(&d) {
+            return Err(ParseError::OrderDigit(s.to_string(), d as char));
+        }
+        within = (within << 2) | ((d - b'1') as u64);
+    }
+    // Sign column folds back into the base cell: north `lead-1`, south `lead+5`.
+    let base = if southern { lead + 5 } else { lead - 1 } as u64;
+    let nested = (base << (2 * order as u32)) | within;
+    Ok(if point {
+        from_nested_point(nested)
+    } else {
+        from_nested(nested, order as u8)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1571,6 +1691,124 @@ mod tests {
                 let legacy = legacy_encode(order, normed, parent);
                 let packed = from_legacy_decimal(legacy);
                 assert_eq!(to_decimal_repr(packed).unwrap(), legacy.to_string());
+            }
+        }
+    }
+
+    // -- from_decimal_repr (issue #114) -----------------------------------
+
+    #[test]
+    fn from_decimal_repr_round_trips_every_base_and_order() {
+        // The parse is the exact inverse of the render across the whole domain:
+        // all 12 base cells (both hemispheres, so both sign columns) x orders
+        // 0..=29, area kind.
+        for base in 0..=11u8 {
+            for order in 0..=MAX_ORDER {
+                let tuples = sample_tuples(order, base as u64 * 31 + order as u64 + 5);
+                let word = encode(base, &tuples, order);
+                let repr = to_decimal_repr(word).unwrap();
+                assert_eq!(from_decimal_repr(&repr), Ok(word), "repr {repr}");
+            }
+        }
+    }
+
+    #[test]
+    fn from_decimal_repr_marked_yields_point_unmarked_yields_area() {
+        // The spec section 4 tie-break, at the bit level: the same order-29 path
+        // parses to the POINT word when marked and the AREA word when not.
+        for base in [0u8, 5, 6, 11] {
+            let tuples = sample_tuples(MAX_ORDER, base as u64 + 17);
+            let point = encode_point(base, &tuples);
+            let area = encode(base, &tuples, MAX_ORDER);
+            let marked = to_decimal_repr(point).unwrap();
+            assert!(marked.ends_with('p'));
+            let unmarked = marked.strip_suffix('p').unwrap();
+            assert_eq!(from_decimal_repr(&marked), Ok(point));
+            assert_eq!(from_decimal_repr(unmarked), Ok(area));
+            // Non-injectivity: the area word renders that same unmarked string,
+            // so point-ness cannot round-trip through an unmarked id.
+            assert_eq!(to_decimal_repr(area).unwrap(), unmarked);
+        }
+    }
+
+    #[test]
+    fn from_decimal_repr_order_zero_is_base_cell_digit() {
+        // Order 0 has no order digits: the string is just sign + base digit.
+        for base in 0..=11u8 {
+            let word = encode(base, &[], 0);
+            let repr = to_decimal_repr(word).unwrap();
+            assert_eq!(repr.len(), if base >= 6 { 2 } else { 1 });
+            assert_eq!(from_decimal_repr(&repr), Ok(word));
+        }
+    }
+
+    #[test]
+    fn from_decimal_repr_rejects_malformed() {
+        // Body is not a run of ASCII digits (empty, bare sign, bare/doubled
+        // suffix, non-digit, and a unicode numeric that Python's `isdigit`
+        // would otherwise accept).
+        for bad in ["", "-", "p", "-p", "31111pp", "x123", "3\u{00b2}1"] {
+            assert_eq!(
+                from_decimal_repr(bad),
+                Err(ParseError::Malformed(bad.to_string())),
+                "expected malformed for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_decimal_repr_rejects_out_of_range_components() {
+        assert_eq!(
+            from_decimal_repr("0123"),
+            Err(ParseError::BaseDigit("0123".into(), 0))
+        );
+        assert_eq!(
+            from_decimal_repr("7123"),
+            Err(ParseError::BaseDigit("7123".into(), 7))
+        );
+        assert_eq!(
+            from_decimal_repr("31023"),
+            Err(ParseError::OrderDigit("31023".into(), '0'))
+        );
+        assert_eq!(
+            from_decimal_repr("3125"),
+            Err(ParseError::OrderDigit("3125".into(), '5'))
+        );
+        let deep: String = std::iter::once('3')
+            .chain(std::iter::repeat_n('1', 30))
+            .collect();
+        assert_eq!(
+            from_decimal_repr(&deep),
+            Err(ParseError::OrderTooDeep(deep.clone(), 30))
+        );
+    }
+
+    #[test]
+    fn from_decimal_repr_rejects_point_suffix_below_max_order() {
+        // Points exist only at order 29, so the marker is illegal anywhere else.
+        for bad in ["1231p", "-6p", "3p"] {
+            let order = bad.len() - 1 - usize::from(bad.starts_with('-')) - 1;
+            assert_eq!(
+                from_decimal_repr(bad),
+                Err(ParseError::PointSuffixOrder(bad.to_string(), order))
+            );
+            assert!(from_decimal_repr(bad)
+                .unwrap_err()
+                .to_string()
+                .contains("legal only"));
+        }
+    }
+
+    #[test]
+    fn from_decimal_repr_agrees_with_from_nested_bridge() {
+        // Parse must land on the same word the (nested, depth) bridge produces
+        // for the cell the string names -- the two encode paths cannot drift.
+        for base in [1u8, 7] {
+            for order in [1u8, 13, 27, 28, MAX_ORDER] {
+                let tuples = sample_tuples(order, base as u64 + order as u64);
+                let nested = nested_from_tuples(base, &tuples, order);
+                let repr = to_decimal_repr(encode(base, &tuples, order)).unwrap();
+                assert_eq!(from_decimal_repr(&repr), Ok(from_nested(nested, order)));
             }
         }
     }

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -747,34 +747,50 @@ pub enum ParseError {
     /// More order digits than [`MAX_ORDER`].
     OrderTooDeep(String, usize),
     /// A terminal `p` on anything but a full order-[`MAX_ORDER`] id.
-    PointSuffixOrder(String, usize),
+    PointSuffixOrder(String),
     /// An order digit outside `1..=4`.
     OrderDigit(String, char),
 }
 
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Every arm escapes the offending id (`escape_debug`), matching what
+        // Python's `{s!r}` did: malformed ids arrive from untrusted channels
+        // (store paths, shard keys, CLI args), and an embedded newline would
+        // otherwise split one log record into several.
         match self {
-            ParseError::Malformed(s) => write!(f, "malformed decimal Morton id '{}'", s),
+            ParseError::Malformed(s) => write!(
+                f,
+                "malformed decimal Morton id '{}'",
+                s.escape_debug()
+            ),
             ParseError::BaseDigit(s, d) => write!(
                 f,
                 "decimal Morton id '{}': base digit {} outside 1..6",
-                s, d
+                s.escape_debug(),
+                d
             ),
             ParseError::OrderTooDeep(s, order) => write!(
                 f,
                 "decimal Morton id '{}': order {} exceeds {}",
-                s, order, MAX_ORDER
+                s.escape_debug(),
+                order,
+                MAX_ORDER
             ),
-            ParseError::PointSuffixOrder(s, _) => write!(
+            ParseError::PointSuffixOrder(s) => write!(
                 f,
                 "decimal Morton id '{}': the kind suffix 'p' is legal only on \
                  full order-{} point ids (points exist only at order {})",
-                s, MAX_ORDER, MAX_ORDER
+                s.escape_debug(),
+                MAX_ORDER,
+                MAX_ORDER
             ),
-            ParseError::OrderDigit(s, d) => {
-                write!(f, "decimal Morton id '{}': digit {} outside 1..4", s, d)
-            }
+            ParseError::OrderDigit(s, d) => write!(
+                f,
+                "decimal Morton id '{}': digit {} outside 1..4",
+                s.escape_debug(),
+                d
+            ),
         }
     }
 }
@@ -793,8 +809,13 @@ impl std::error::Error for ParseError {}
 /// base digit range guarantees a base cell of `0..=11`, so the [`from_nested`]
 /// / [`from_nested_point`] asserts are unreachable from here.
 pub fn from_decimal_repr(s: &str) -> Result<u64, ParseError> {
-    let point = s.ends_with('p');
-    let text = if point { &s[..s.len() - 1] } else { s };
+    // `strip_suffix` rather than a manual `&s[..len-1]`: the byte index would
+    // only be a char boundary because `'p'` is ASCII, and that reasoning is too
+    // easy for a later edit to invalidate.
+    let (text, point) = match s.strip_suffix('p') {
+        Some(t) => (t, true),
+        None => (s, false),
+    };
     let southern = text.starts_with('-');
     let body = if southern { &text[1..] } else { text };
     // ASCII digits only: Python's `str.isdigit()` also accepts superscripts and
@@ -813,7 +834,7 @@ pub fn from_decimal_repr(s: &str) -> Result<u64, ParseError> {
         return Err(ParseError::OrderTooDeep(s.to_string(), order));
     }
     if point && order != MAX_ORDER as usize {
-        return Err(ParseError::PointSuffixOrder(s.to_string(), order));
+        return Err(ParseError::PointSuffixOrder(s.to_string()));
     }
     // Digits are the stored tuples read as `1..=4`; the accumulator is the
     // within-base NESTED address (2 bits per order, at most 58 bits at order 29).
@@ -1747,12 +1768,89 @@ mod tests {
         // Body is not a run of ASCII digits (empty, bare sign, bare/doubled
         // suffix, non-digit, and a unicode numeric that Python's `isdigit`
         // would otherwise accept).
-        for bad in ["", "-", "p", "-p", "31111pp", "x123", "3\u{00b2}1"] {
+        for bad in [
+            "", "-", "p", "-p", "31111pp", "x123",
+            // A unicode numeric Python's `str.isdigit()` would accept.
+            "3\u{00b2}1",
+            // Trailing multi-byte chars: the parse byte-slices off a terminal
+            // 'p', which is only sound because no multi-byte char ends in
+            // 0x70 -- these pin that the boundary case stays a clean reject.
+            "3\u{00e9}", "3\u{1f600}", "3\u{1e55}",
+            // The kind suffix is lower-case only (spec section 2 grammar).
+            "3111P",
+        ] {
             assert_eq!(
                 from_decimal_repr(bad),
                 Err(ParseError::Malformed(bad.to_string())),
                 "expected malformed for {bad:?}"
             );
+        }
+    }
+
+    #[test]
+    fn from_decimal_repr_escapes_control_characters_in_messages() {
+        // Malformed ids arrive from untrusted channels; an unescaped newline
+        // would split one log record into several.
+        let msg = from_decimal_repr("\t5\n466").unwrap_err().to_string();
+        assert!(!msg.contains('\n') && !msg.contains('\t'), "{msg}");
+        assert!(msg.contains("\\t5\\n466"), "{msg}");
+    }
+
+    #[test]
+    fn from_decimal_repr_order_check_precedes_the_suffix_check() {
+        // An over-deep *and* p-marked id reports the depth, not the suffix.
+        // Nothing else pins the order of the two guards, so swapping them
+        // would silently change the message a user sees.
+        let deep_point: String = std::iter::once('3')
+            .chain(std::iter::repeat_n('1', 30))
+            .chain(std::iter::once('p'))
+            .collect();
+        assert_eq!(
+            from_decimal_repr(&deep_point),
+            Err(ParseError::OrderTooDeep(deep_point.clone(), 30))
+        );
+    }
+
+    #[test]
+    fn from_decimal_repr_rejects_signed_and_leading_zero_base_digits() {
+        // The sign column feeds the `lead + 5` / `lead - 1` base fold, so the
+        // signed forms of the base-digit rejection need their own pin.
+        for bad in ["-0", "01", "-01", "0", "-7", "-0123"] {
+            assert!(
+                matches!(from_decimal_repr(bad), Err(ParseError::BaseDigit(_, 0 | 7))),
+                "expected a base-digit rejection for {bad:?}, got {:?}",
+                from_decimal_repr(bad)
+            );
+        }
+    }
+
+    #[test]
+    fn from_decimal_repr_round_trips_a_wide_random_sweep() {
+        // The per-(base, order) sweep above draws one path each; this widens
+        // it to many paths per order so the round-trip claim is a property,
+        // not a spot check. Deterministic LCG -- no rand dependency.
+        let mut seed = 0x2545_F491_4F6C_DD1Du64;
+        let mut next = move || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        for order in 0..=MAX_ORDER {
+            for _ in 0..64 {
+                let r = next();
+                let base = (r % 12) as u8;
+                let tuples: Vec<u8> = (0..order)
+                    .map(|i| ((next() >> (i % 32)) & 3) as u8)
+                    .collect();
+                for word in [encode(base, &tuples, order)]
+                    .into_iter()
+                    .chain((order == MAX_ORDER).then(|| encode_point(base, &tuples)))
+                {
+                    let repr = to_decimal_repr(word).unwrap();
+                    assert_eq!(from_decimal_repr(&repr), Ok(word), "repr {repr}");
+                }
+            }
         }
     }
 
@@ -1787,10 +1885,9 @@ mod tests {
     fn from_decimal_repr_rejects_point_suffix_below_max_order() {
         // Points exist only at order 29, so the marker is illegal anywhere else.
         for bad in ["1231p", "-6p", "3p"] {
-            let order = bad.len() - 1 - usize::from(bad.starts_with('-')) - 1;
             assert_eq!(
                 from_decimal_repr(bad),
-                Err(ParseError::PointSuffixOrder(bad.to_string(), order))
+                Err(ParseError::PointSuffixOrder(bad.to_string()))
             );
             assert!(from_decimal_repr(bad)
                 .unwrap_err()

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -171,10 +171,7 @@ fn split_children_rust(
     // order digit (order-30 area -> 4x-off cell_area). Points do not live in
     // paths (spec section 2, issue #120), so refuse them loudly here -- the
     // same contract hive_path enforces -- rather than emit a corrupt trie.
-    if data
-        .iter()
-        .any(|&w| decimal_morton::kind_of(w) == decimal_morton::Kind::Point)
-    {
+    if data.iter().any(|&w| decimal_morton::kind_of(w) == decimal_morton::Kind::Point) {
         return Err(PyValueError::new_err(
             "split_children is undefined for point ids: points do not live in \
              paths (spec section 2, issue #120); pass area words only",
@@ -1148,9 +1145,15 @@ fn rust_mi_decimal_repr(py: Python<'_>, morton_array: PyReadonlyArray1<u64>) -> 
 /// word, an unmarked one the AREA word (the spec section 4 tie-break). Raises
 /// `ValueError` naming the first malformed id, in input order.
 ///
-/// Serial like the emit side rather than rayon-parallel: the per-id work is a
-/// short string scan, and a serial fold keeps the reported error deterministic
-/// (the *first* bad id, not whichever thread failed first).
+/// Serial like the emit side rather than rayon-parallel, for two reasons. The
+/// reported error stays deterministic (the *first* bad id, not whichever thread
+/// failed first); and parallelism has little to win here anyway -- extracting
+/// `Vec<String>` copies every id into Rust memory *while holding the GIL*,
+/// before `allow_threads` runs, and that extraction dominates. Measured at
+/// N=200k order-29 ids: 57 ms from a `<U32` numpy array vs 27 ms from a Python
+/// list, where the delta is pure `str` boxing, so the parse `par_iter` would
+/// split is a minority of the total. Cutting the extraction (reading the
+/// fixed-width UCS-4 buffer directly) is the win worth having; see issue #114.
 #[pyfunction]
 fn rust_mi_from_decimal(py: Python<'_>, decimals: Vec<String>) -> PyResult<PyObject> {
     let result: Result<Vec<u64>, String> = py.allow_threads(|| {

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -171,7 +171,10 @@ fn split_children_rust(
     // order digit (order-30 area -> 4x-off cell_area). Points do not live in
     // paths (spec section 2, issue #120), so refuse them loudly here -- the
     // same contract hive_path enforces -- rather than emit a corrupt trie.
-    if data.iter().any(|&w| decimal_morton::kind_of(w) == decimal_morton::Kind::Point) {
+    if data
+        .iter()
+        .any(|&w| decimal_morton::kind_of(w) == decimal_morton::Kind::Point)
+    {
         return Err(PyValueError::new_err(
             "split_children is undefined for point ids: points do not live in \
              paths (spec section 2, issue #120); pass area words only",
@@ -1138,6 +1141,30 @@ fn rust_mi_decimal_repr(py: Python<'_>, morton_array: PyReadonlyArray1<u64>) -> 
     }
 }
 
+/// Vectorized decimal-string -> packed word parse (issue #114).
+///
+/// The inverse of [`rust_mi_decimal_repr`]: parses each decimal Morton id back
+/// to its packed word (u64 numpy array out). A `p`-marked id yields the POINT
+/// word, an unmarked one the AREA word (the spec section 4 tie-break). Raises
+/// `ValueError` naming the first malformed id, in input order.
+///
+/// Serial like the emit side rather than rayon-parallel: the per-id work is a
+/// short string scan, and a serial fold keeps the reported error deterministic
+/// (the *first* bad id, not whichever thread failed first).
+#[pyfunction]
+fn rust_mi_from_decimal(py: Python<'_>, decimals: Vec<String>) -> PyResult<PyObject> {
+    let result: Result<Vec<u64>, String> = py.allow_threads(|| {
+        decimals
+            .iter()
+            .map(|s| decimal_morton::from_decimal_repr(s).map_err(|e| e.to_string()))
+            .collect()
+    });
+    match result {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(msg) => Err(PyValueError::new_err(msg)),
+    }
+}
+
 /// Dissolve a morton cover into the classified planar rings of its outline.
 ///
 /// Returns `(shells, holes)`: two Python lists of `(N, 2)` f64 arrays of
@@ -1210,6 +1237,7 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_mi_decode, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_from_legacy, m)?)?;
     m.add_function(wrap_pyfunction!(rust_mi_decimal_repr, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_mi_from_decimal, m)?)?;
     m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_export_c_schema, m)?)?;
     m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_export_c_array, m)?)?;
     m.add_function(wrap_pyfunction!(arrow_ffi::rust_mi_import_c_array, m)?)?;


### PR DESCRIPTION
Closes #114

Implements the shape you signed off on in [this comment](https://github.com/espg/mortie/issues/114#issuecomment-5080387406): public scalar `decimal_to_word` returning `np.uint64` **with an optional `dtype` flag** for all three return shapes, a **vectorized Rust** `decimals_to_words`, a `MortonIndexArray.from_decimal` classmethod for pandas users, the private `_decimal_to_word` alias kept for a later deprecation cycle, and the order-29 point/area non-injectivity documented on the parse side.

## The gap this closes

On `main` the emit direction is fully public — `decimal_repr()`, `to_decimal()`, `hive_path()` — while the parse direction was the private Python scalar `_decimal_to_word` (`mortie/morton_index.py:35`), not in any `__all__`. zagg's parse boundary reaches into that private name, so an internal rename breaks it silently. There was also **no vectorized parse path anywhere**: `_decimal_to_word` built a 1-element array per call and unwrapped `[0]`, so per-shard key parsing was a Python loop.

## Phases — all four complete

- [x] **Phase 1** — the Rust parse kernel: `decimal_morton::from_decimal_repr` + the vectorized `rust_mi_from_decimal` binding.
- [x] **Phase 2** — the public numpy-only surface: `decimal_to_word(s, dtype=...)`, `decimals_to_words(arr)`, exported from `mortie`; `_decimal_to_word` retained as a private alias.
- [x] **Phase 3** — `MortonIndexArray.from_decimal`, the inverse of `.to_decimal()`.
- [x] **Phase 4** — parse-side non-injectivity doc rider in the spec page (#62) and the datatype guide, with a drift pin.

## Phase 1 — the Rust kernel

`pub fn from_decimal_repr(s: &str) -> Result<u64, ParseError>` in `src_rust/src/decimal_morton.rs`, the exact inverse of `to_decimal_repr` and now the single implementation of the grammar from `docs/specification.md:93-98`:

```text
morton-decimal = ["-"] base-digit *order-digit [kind-suffix]
base-digit     = "1" / "2" / "3" / "4" / "5" / "6"
order-digit    = "1" / "2" / "3" / "4"
kind-suffix    = "p"    ; POINT ids only, order 29 only
```

A single left-to-right scan (the order *is* the digit count, so no lookahead), returning a typed `ParseError` on every malformed id rather than panicking — the base-digit range guarantees a base cell of `0..=11`, so the `from_nested` / `from_nested_point` asserts are unreachable from here. Error wording is carried over verbatim from the Python original, so the user-visible `ValueError` text does not change.

`rust_mi_from_decimal` mirrors the emit-side `rust_mi_decimal_repr`: list of `str` in, `uint64` numpy array out, under `py.allow_threads`. Deliberately **serial**, like the emit side — the per-id work is a short string scan, and a serial fold makes the reported error deterministic (the *first* bad id in input order, not whichever thread failed first).

## Phase 2 — the public numpy-only surface

```python
mortie.decimal_to_word("-31123")                        # np.uint64  (default)
mortie.decimal_to_word("-31123", dtype=int)             # Python int
mortie.decimal_to_word("-31123", dtype=MortonIndexScalar)  # displays as "-31123"
mortie.decimals_to_words(["11", "12", "13"])            # vectorized, uint64 array
```

Both are plain eager exports from `mortie/__init__.py` (they need only numpy and the Rust extension), so a per-key parse path never touches pandas. `_decimal_to_word` becomes a three-line alias returning a Python `int` exactly as before, so nothing in-tree or in zagg changes behavior.

Two things worth calling out, both found by writing the tests:

- **`decimals_to_words` refuses non-string input rather than coercing.** `np.asarray([1, 2], dtype=str)` would silently turn the integer `1` into the valid order-0 id `"1"`. A parse surface must not invent input, so the dtype kind is checked (`U`/`O` only) and anything else raises `TypeError`.
- **The "numpy-only" claim needed a real test, not a `sys.modules` check.** `import mortie` *does* import pandas when pandas is installed — deliberately, via the eager `_build_classes()` dtype-registration probe in `morton_index.py`. So the test runs a fresh interpreter with a `meta_path` blocker that makes `pandas` unimportable, then imports `mortie` and parses. That actually pins the property zagg cares about.

## Phase 3 — the pandas classmethod

`MortonIndexArray.from_decimal(decimals)`, sugar over `decimals_to_words`, mirroring `.to_decimal()`. Tested for round-trip against `to_decimal()`, agreement with `from_hive_path` on the same leaf ids, and the malformed-id error.

## Phase 4 — the doc rider

A `#### Parse-side API (normative surface)` block in `docs/specification.md` §4 (between `<!-- parse:api:begin/end -->` markers) tabling the three entry points and stating the caveat in parse-side terms, plus a "Parsing decimal ids back" section in `docs/morton_index_datatype.md` with runnable examples.

The caveat, stated the way a parse caller needs it: **an unmarked order-29 id parses to the area word, so a point word does not round-trip through an unmarked string.** Emit renders point words `p`-marked, so `word → to_decimal → from_decimal` *is* the identity end to end — but any channel that strips the marker (a path component above all, which never carries it) returns the area word for what may have been a point. Orders 0–28 are unambiguous.

Per the acceptance criterion this is pinned by tests, not just prose: `TestPointAreaNonInjectivity` asserts the bit-level tie-break (same prefix+body, area suffix `< 48` vs point suffix `>= 48`), and `TestSpecPageParseSection` is a drift pin asserting the page names every public entry point, that those entry points exist and are callable, and that the prose rule and the actual behavior agree.

## How it was tested

- `cargo test`: **205 passed, 0 failed, 1 ignored** (6 new). `cargo fmt` clean.
- `cargo clippy --all-targets`: 46 warnings vs 45 on `main` — the one new warning is the macro-generated `useless_conversion` that fires on *every* `#[pyfunction]` (the known false positive tracked as #108 Group A item 2, suppressed on PR #111). No other new lint.
- `maturin develop --release` + full `pytest -v`: **743 passed, 11 skipped** (34 new, in `mortie/tests/test_decimal_parse.py`), up from 709 on `main`.
- `flake8 mortie --select=E9,F63,F7,F82`: clean. The non-blocking `--max-line-length=88` pass reports nothing in any file this PR touches.
- The new Rust tests cover the domain rather than a handful of vectors: round-trip over all 12 base cells × orders 0–29 (both sign columns), the section-4 tie-break at the bit level, order 0 (bare base digit), the malformed table, the out-of-range component table, and agreement with the `(nested, depth)` bridge so the two encode paths cannot drift.

## Questions for review

1. **Serial vs parallel parse.** Chosen serial for deterministic error reporting (see phase 1). Parsing ~30 chars per id is cheap, so the Rust-vs-Python win should dominate either way — but you asked for vectorized Rust specifically because the round-trip is load-bearing in per-shard hot paths, so say the word if you'd rather have `par_iter` and accept a nondeterministic *which-id-failed* message.
2. **`dtype` flag domain.** Your ask was "any of the three, default `np.uint64`". Implemented as `np.uint64` (default), `int`, and `MortonIndexScalar`, with `"uint64"` / `np.dtype("uint64")` accepted as spellings of the default and anything else raising `TypeError`. Reasonable, or do you want it strictly the three literals?
3. **`_decimal_to_word` on non-`str` input.** The old pure-Python parser raised `AttributeError` for e.g. `None` or an `int` (it called `.endswith`); routed through the Rust binding it now raises `TypeError`. Better error, but technically a changed exception type on a name zagg imports. Fine, or should the alias keep the old shape until the deprecation cycle ends?
4. **Error-message quoting.** The Rust messages use `'id'` where the Python original used Python's `repr` (identical for ordinary ascii ids, differing only for an id containing a quote). Non-issue in practice; flagging since it is technically user-visible text.
5. **Should this `Closes #114` outright**, or stay `Refs` until you've confirmed zagg has moved off the private name?