### PR TITLE
convert tools / coverage / prefix_trie / linestring docstrings to numpydoc

### DIFF
--- a/docs/morton_index_datatype.md
+++ b/docs/morton_index_datatype.md
@@ -32,9 +32,9 @@ import time:
 import mortie
 mortie.MortonIndexArray          # -> ImportError:
 # "the morton_index ExtensionArray requires pandas, which is not installed.
-#  Install it directly with `pip install pandas`, or declare it as a mortie
-#  extra with `pip install mortie[pandas]`, which pins pandas as a mortie
-#  dependency so it is loaded whenever mortie is imported."
+#  Install it with `pip install pandas`, or with `pip install mortie[pandas]`
+#  to declare it as a mortie extra so it is installed alongside mortie in
+#  future environments."
 
 from mortie import arrow
 arrow.morton_index_type()        # -> ImportError:

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -304,7 +304,8 @@ def morton_coverage_moc(lats, lons, order=18, tolerance=None, max_cells=None):
     ------
     ValueError
         If ``order`` lies outside 1-29, both ``tolerance`` and ``max_cells``
-        are given, the ring's lats and lons have different lengths, there are
+        are given, the multipart form's lats and lons hold different numbers
+        of rings, a ring's lats and lons have different lengths, a ring has
         fewer than 3 vertices, or a coordinate is NaN/infinity.
 
     See Also

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -28,7 +28,20 @@ _FLAT_COVER_WARN_THRESHOLD = 1 << 20  # ~1.05M cells (~8 MB of uint64)
 
 
 def _warn_large_flat(n_cells, order):
-    """Warn when a flat cover is large enough to be a memory hazard."""
+    """Warn when a flat cover is large enough to be a memory hazard.
+
+    Parameters
+    ----------
+    n_cells : int
+        Number of cells in the materialized flat cover.
+    order : int
+        HEALPix order the cover was built at (reported in the warning).
+
+    Warns
+    -----
+    UserWarning
+        If ``n_cells`` exceeds ``_FLAT_COVER_WARN_THRESHOLD``.
+    """
     if n_cells > _FLAT_COVER_WARN_THRESHOLD:
         warnings.warn(
             f"flat morton_coverage returned {n_cells} cells at order {order}; "
@@ -41,7 +54,19 @@ def _warn_large_flat(n_cells, order):
 
 
 def _is_multipart(lats):
-    """Check if *lats* is a sequence of sequences (multipart polygon)."""
+    """Check if *lats* is a sequence of sequences (multipart polygon).
+
+    Parameters
+    ----------
+    lats : array_like or list of array_like
+        Candidate vertex latitudes, single-ring or multipart.
+
+    Returns
+    -------
+    bool
+        ``True`` when *lats* holds one entry per ring rather than one per
+        vertex.
+    """
     if isinstance(lats, np.ndarray):
         return lats.ndim == 2
     if isinstance(lats, (list, tuple)) and len(lats) > 0:
@@ -50,7 +75,25 @@ def _is_multipart(lats):
 
 
 def _prep_rings(lats, lons):
-    """Validate and convert a ring-set to parallel lists of float64 arrays."""
+    """Validate and convert a ring-set to parallel lists of float64 arrays.
+
+    Parameters
+    ----------
+    lats, lons : list of array_like
+        One entry per ring of vertex latitudes / longitudes in degrees.
+
+    Returns
+    -------
+    la_rings, lo_rings : list of numpy.ndarray
+        The same rings as contiguous 1-D ``float64`` arrays.
+
+    Raises
+    ------
+    ValueError
+        If the ring counts differ, a ring's lats and lons have different
+        lengths, a ring has fewer than 3 vertices, or a coordinate is
+        NaN/infinity.
+    """
     if len(lats) != len(lons):
         raise ValueError("lats and lons must have the same number of rings")
     la_rings, lo_rings = [], []
@@ -69,7 +112,31 @@ def _prep_rings(lats, lons):
 
 
 def _single_coverage(lats, lons, order, normalize=True):
-    """Coverage for one polygon ring."""
+    """Coverage for one polygon ring.
+
+    Parameters
+    ----------
+    lats, lons : array_like
+        Vertex latitudes / longitudes in degrees for a single ring. A repeated
+        closing vertex is stripped before the ring is handed to Rust.
+    order : int
+        HEALPix depth / tessellation order.
+    normalize : bool, optional
+        Ring-orientation handling. Identical in meaning to
+        :func:`morton_coverage`'s ``normalize`` — see that function for the
+        full ring-winding contract, including the hemisphere-plus caveat.
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted 1-D array of unique morton indices (``uint64``).
+
+    Raises
+    ------
+    ValueError
+        If lats and lons have different lengths, there are fewer than 3
+        vertices, or a coordinate is NaN/infinity.
+    """
     lats = np.asarray(lats, dtype=np.float64).ravel()
     lons = np.asarray(lons, dtype=np.float64).ravel()
 
@@ -205,12 +272,18 @@ def morton_coverage_moc(lats, lons, order=18, tolerance=None, max_cells=None):
     array — typically far smaller than the flat cover.
 
     Optional **adaptive stop criteria** (mutually exclusive) trade boundary
-    precision for fewer cells and faster runtime:
+    precision for fewer cells and faster runtime — the ``tolerance`` and
+    ``max_cells`` parameters below.
+
+    For **multipart / holes** (lists of rings), all rings are covered by one
+    even-odd descent — disjoint parts union with no internal seam, and nested
+    rings carve holes (a donut is ``[outer, hole]``).
 
     Parameters
     ----------
     lats, lons : array_like
-        Vertex latitudes / longitudes in degrees (single polygon ring).
+        Vertex latitudes / longitudes in degrees (single polygon ring), or a
+        list of such arrays for the multipart form.
     order : int, optional
         Finest HEALPix order (1–29).  Default 18.
     tolerance : float, optional
@@ -227,9 +300,12 @@ def morton_coverage_moc(lats, lons, order=18, tolerance=None, max_cells=None):
     numpy.ndarray
         Sorted 1-D array of mixed-order morton indices (``uint64``).
 
-    For **multipart / holes** (lists of rings), all rings are covered by one
-    even-odd descent — disjoint parts union with no internal seam, and nested
-    rings carve holes (a donut is ``[outer, hole]``).
+    Raises
+    ------
+    ValueError
+        If ``order`` lies outside 1-29, both ``tolerance`` and ``max_cells``
+        are given, the ring's lats and lons have different lengths, there are
+        fewer than 3 vertices, or a coordinate is NaN/infinity.
 
     See Also
     --------
@@ -284,7 +360,6 @@ def compress_moc(morton):
     numpy.ndarray
         Sorted, compacted morton indices (``uint64``).
     """
-
     morton = np.asarray(morton, dtype=np.uint64).ravel()
     return np.asarray(_rustie.rust_moc_normalize(morton))
 
@@ -328,7 +403,6 @@ def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD):
     --------
     morton_coverage : flat single-order cover (post-hoc large-cover warning).
     """
-
     morton = np.asarray(morton, dtype=np.uint64).ravel()
     if max_cells is not None:
         estimated = int(_rustie.rust_moc_to_order_count(morton, order))
@@ -343,7 +417,7 @@ def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD):
 
 
 def moc_or(a, b):
-    """Union of two morton covers (the cells in ``a`` or ``b``).
+    r"""Union of two morton covers (the cells in ``a`` or ``b``).
 
     Equivalent to ``compress_moc(concatenate([a, b]))``, but computed by the
     healpix-crate BMOC ``or`` rather than a concatenate-then-compress pass.
@@ -361,17 +435,16 @@ def moc_or(a, b):
     See Also
     --------
     moc_and : intersection of two covers.
-    moc_minus : difference ``a \\ b``.
+    moc_minus : difference ``a \ b``.
     compress_moc : ``moc_or(a, b) == compress_moc(concatenate([a, b]))``.
     """
-
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
     return np.asarray(_rustie.rust_moc_or(a, b))
 
 
 def moc_and(a, b):
-    """Intersection of two morton covers (the cells in both ``a`` and ``b``).
+    r"""Intersection of two morton covers (the cells in both ``a`` and ``b``).
 
     Parameters
     ----------
@@ -386,18 +459,17 @@ def moc_and(a, b):
     See Also
     --------
     moc_or : union of two covers.
-    moc_minus : difference ``a \\ b``.
+    moc_minus : difference ``a \ b``.
     """
-
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
     return np.asarray(_rustie.rust_moc_and(a, b))
 
 
 def moc_minus(a, b):
-    """Difference of two morton covers (the cells in ``a`` but not ``b``).
+    r"""Difference of two morton covers (the cells in ``a`` but not ``b``).
 
-    Computes ``a \\ b``.
+    Computes ``a \ b``.
 
     Parameters
     ----------
@@ -414,14 +486,13 @@ def moc_minus(a, b):
     moc_or : union of two covers.
     moc_and : intersection of two covers.
     """
-
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
     return np.asarray(_rustie.rust_moc_minus(a, b))
 
 
 def moc_xor(a, b):
-    """Symmetric difference of two morton covers (cells in exactly one).
+    r"""Symmetric difference of two morton covers (cells in exactly one).
 
     Computes ``a △ b`` — the cells in ``a`` or ``b`` but not both, i.e.
     ``moc_minus(moc_or(a, b), moc_and(a, b))``.  Useful for "what changed"
@@ -442,32 +513,35 @@ def moc_xor(a, b):
     --------
     moc_or : union of two covers.
     moc_and : intersection of two covers.
-    moc_minus : difference ``a \\ b`` (the directional half of ``xor``).
+    moc_minus : difference ``a \ b`` (the directional half of ``xor``).
     """
-
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
     return np.asarray(_rustie.rust_moc_xor(a, b))
 
 
 def _whole_sphere():
-    """The 12 order-0 HEALPix base cells as a morton cover (the whole sphere).
+    """Return the 12 order-0 HEALPix base cells as a morton cover.
 
-    Built via :func:`norm2mort` so it tracks the packed-u64 encoding (issue #58),
-    not a hand-rolled constant.
+    That cover is the whole sphere. Built via :func:`norm2mort` so it tracks
+    the packed-u64 encoding (issue #58), not a hand-rolled constant.
+
+    Returns
+    -------
+    numpy.ndarray
+        The 12 order-0 base cells as packed morton words (``uint64``).
     """
-
     base = np.arange(12, dtype=np.int64)
     return np.asarray(norm2mort(np.zeros(12, dtype=np.int64), base, 0), dtype=np.uint64)
 
 
 def moc_not(cover, domain=None):
-    """Complement of a morton cover within a domain (the cells in ``domain`` but
-    not ``cover``).
+    r"""Complement a morton cover within a domain.
 
-    A complement is only well-defined relative to a bounded domain, so
-    ``moc_not`` is a domain-bounded difference: it returns ``domain \\ cover``,
-    i.e. ``moc_minus(domain, cover)``.
+    The result is the cells in ``domain`` but not ``cover``. A complement is
+    only well-defined relative to a bounded domain, so ``moc_not`` is a
+    domain-bounded difference: it returns ``domain \ cover``, i.e.
+    ``moc_minus(domain, cover)``.
 
     Parameters
     ----------
@@ -482,19 +556,19 @@ def moc_not(cover, domain=None):
     Returns
     -------
     numpy.ndarray
-        Sorted, compacted complement ``domain \\ cover`` (``uint64``).
+        Sorted, compacted complement ``domain \ cover`` (``uint64``).
 
     Warns
     -----
     UserWarning
         If ``cover`` contains cells outside ``domain``.  Such cells cannot be
         complemented within the domain, so they are **clipped**: the result is
-        ``domain \\ (cover ∩ domain)``, which equals ``domain \\ cover`` whenever
+        ``domain \ (cover ∩ domain)``, which equals ``domain \ cover`` whenever
         ``cover ⊆ domain``.
 
     See Also
     --------
-    moc_minus : difference ``a \\ b`` (``moc_not`` is ``moc_minus`` against a
+    moc_minus : difference ``a \ b`` (``moc_not`` is ``moc_minus`` against a
         domain, with the whole-sphere default and an out-of-domain warning).
 
     Examples
@@ -507,7 +581,6 @@ def moc_not(cover, domain=None):
     >>> enumerated = mortie.morton_coverage_moc(lats, lons, order=6)  # doctest: +SKIP
     >>> gaps = mortie.moc_not(enumerated, domain=shard)               # doctest: +SKIP
     """
-
     cover = np.asarray(cover, dtype=np.uint64).ravel()
     if domain is None:
         domain = _whole_sphere()
@@ -580,7 +653,6 @@ def common_ancestor(morton):
     >>> int(mortie.common_ancestor(kids)) == int(parent)
     True
     """
-
     morton = np.asarray(morton, dtype=np.uint64).ravel()
     return np.uint64(_rustie.rust_moc_min(morton))
 
@@ -590,9 +662,9 @@ moc_min = common_ancestor
 
 
 def split_base_cells(words, sort=False):
-    """Partition a morton set by HEALPix base cell, keyed by each group's
-    :func:`moc_min`.
+    """Partition a morton set by HEALPix base cell.
 
+    Each group is keyed by its own :func:`moc_min`.
     The companion to :func:`moc_min` for the cross-base-cell case it refuses:
     where ``moc_min`` reduces a *single* base cell's words to one ancestor and
     raises on mixed base cells, ``split_base_cells`` groups the words by base
@@ -638,7 +710,6 @@ def split_base_cells(words, sort=False):
     >>> sorted(int(np.uint64(k) >> np.uint64(60)) - 1 for k in groups)
     [2, 5]
     """
-
     words = np.asarray(words, dtype=np.uint64).ravel()
     if words.size == 0:
         return {}

--- a/mortie/linestring.py
+++ b/mortie/linestring.py
@@ -10,7 +10,19 @@ import numpy as np
 
 
 def _is_multi(lats):
-    """Return True if *lats* is a sequence of sequences (multi-linestring)."""
+    """Return True if *lats* is a sequence of sequences (multi-linestring).
+
+    Parameters
+    ----------
+    lats : array_like or list of array_like
+        Candidate vertex latitudes, single-line or multi-line.
+
+    Returns
+    -------
+    bool
+        ``True`` when *lats* holds one entry per line rather than one per
+        vertex.
+    """
     if isinstance(lats, np.ndarray):
         return lats.ndim == 2
     if isinstance(lats, (list, tuple)) and len(lats) > 0:
@@ -19,7 +31,28 @@ def _is_multi(lats):
 
 
 def _single_linestring_coverage(lats, lons, order):
-    """Coverage for one open polyline."""
+    """Coverage for one open polyline.
+
+    Parameters
+    ----------
+    lats, lons : array_like
+        Vertex latitudes / longitudes in degrees for a single line, at least
+        2 vertices.
+    order : int
+        HEALPix depth / tessellation order. Validated by the caller,
+        :func:`linestring_coverage`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted 1-D array of unique morton indices (``uint64``).
+
+    Raises
+    ------
+    ValueError
+        If lats and lons have different lengths, there are fewer than 2
+        vertices, or a coordinate is NaN/infinity.
+    """
     lats = np.ascontiguousarray(np.asarray(lats, dtype=np.float64).ravel())
     lons = np.ascontiguousarray(np.asarray(lons, dtype=np.float64).ravel())
 
@@ -73,19 +106,20 @@ def linestring_coverage(lats, lons, order=18):
 
     Examples
     --------
-    Single linestring::
+    Single linestring:
 
-        >>> import mortie
-        >>> lats = [40.0, 50.0, 45.0]
-        >>> lons = [-120.0, -110.0, -100.0]
-        >>> cells = mortie.linestring_coverage(lats, lons, order=6)
+    >>> import mortie
+    >>> lats = [40.0, 50.0, 45.0]
+    >>> lons = [-120.0, -110.0, -100.0]
+    >>> cells = mortie.linestring_coverage(lats, lons, order=6)
 
-    Multi-linestring (list of arrays; lengths may differ)::
+    Multi-linestring (list of arrays; lengths may differ):
 
-        >>> lats_parts = [[40.0, 50.0], [10.0, 20.0, 15.0]]
-        >>> lons_parts = [[-120.0, -120.0], [-80.0, -70.0, -60.0]]
-        >>> per_line = mortie.linestring_coverage(lats_parts, lons_parts, order=6)
-        >>> [arr.shape for arr in per_line]
+    >>> lats_parts = [[40.0, 50.0], [10.0, 20.0, 15.0]]
+    >>> lons_parts = [[-120.0, -120.0], [-80.0, -70.0, -60.0]]
+    >>> per_line = mortie.linestring_coverage(lats_parts, lons_parts, order=6)
+    >>> [arr.shape for arr in per_line]
+    [(10,), (27,)]
     """
     if not 1 <= order <= 29:
         raise ValueError("Order must be between 1 and 29")

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -288,10 +288,9 @@ def _require_pandas():
     except ImportError as exc:  # pragma: no cover - exercised via message only
         raise ImportError(
             "the morton_index ExtensionArray requires pandas, which is not "
-            "installed. Install it directly with `pip install pandas`, or "
-            "declare it as a mortie extra with `pip install mortie[pandas]`, "
-            "which pins pandas as a mortie dependency so it is loaded whenever "
-            "mortie is imported."
+            "installed. Install it with `pip install pandas`, or with "
+            "`pip install mortie[pandas]` to declare it as a mortie extra so "
+            "it is installed alongside mortie in future environments."
         ) from exc
     return pd
 

--- a/mortie/prefix_trie.py
+++ b/mortie/prefix_trie.py
@@ -95,9 +95,9 @@ class MortonChild:
     Raises
     ------
     ValueError
-        If *mask* selects no rows, or the masked rows do not share the
-        expected leading character (an uncompressible mix of signs or base
-        cells).
+        If *mask* selects no rows, or — for a non-root node, i.e. one built
+        with ``start_col > 0`` — the masked rows do not share the expected
+        leading character (an uncompressible mix of signs or base cells).
     """
 
     __slots__ = (
@@ -360,7 +360,8 @@ def geo_morton_polygon(lats, lons, n_cells, order=18, max_depth=None):
     lats, lons : array-like
         Latitude and longitude values in degrees.
     n_cells : int
-        Maximum number of cells in the returned list.
+        Cell budget for the refinement (see Returns for the root-count
+        floor).
     order : int
         Morton tessellation order.  Default is 18.
     max_depth : int or None
@@ -370,7 +371,10 @@ def geo_morton_polygon(lats, lons, n_cells, order=18, max_depth=None):
     Returns
     -------
     list of MortonChild
-        Refined prefix-cells (len <= *n_cells*).
+        Refined prefix-cells, at most *n_cells* of them — unless the trie
+        already has more root-level children than that, which are returned
+        as they stand (:func:`morton_polygon` only ever expands roots, never
+        merges them, so the root count is a floor on the result).
     """
     if max_depth is None:
         max_depth = _auto_max_depth(n_cells)
@@ -386,7 +390,8 @@ def morton_polygon_from_array(morton_array, n_cells, max_depth=None):
     morton_array : array-like of int
         Morton indices (packed ``uint64`` words; base cells 7-11 set bit 63).
     n_cells : int
-        Maximum number of cells in the returned list.
+        Cell budget for the refinement (see Returns for the root-count
+        floor).
     max_depth : int or None
         Maximum branching depth.  When *None* (default), automatically
         derived from *n_cells* as ``ceil(log2(n_cells)) + 1``.
@@ -394,7 +399,10 @@ def morton_polygon_from_array(morton_array, n_cells, max_depth=None):
     Returns
     -------
     list of MortonChild
-        Refined prefix-cells (len <= *n_cells*).
+        Refined prefix-cells, at most *n_cells* of them — unless the trie
+        already has more root-level children than that, which are returned
+        as they stand (:func:`morton_polygon` only ever expands roots, never
+        merges them, so the root count is a floor on the result).
     """
     if max_depth is None:
         max_depth = _auto_max_depth(n_cells)
@@ -417,8 +425,10 @@ def _expansion_efficiency(node):
     Parameters
     ----------
     node : MortonChild
-        An expandable node (``nchildren > 1``; ``cost`` is zero for a single
-        child and undefined for a leaf).
+        An expandable node. ``_compact`` only branches on two or more distinct
+        characters, so every non-leaf has ``nchildren >= 2`` and ``cost >= 1``;
+        a leaf would give ``cost == -1`` and a meaningless negative
+        efficiency, so callers screen leaves out first.
 
     Returns
     -------
@@ -459,12 +469,16 @@ def morton_polygon(roots, n_cells):
     roots : list of MortonChild
         Root-level children from :func:`split_children`.
     n_cells : int
-        Maximum number of cells in the returned list.
+        Cell budget for the refinement (see Returns for the root-count
+        floor).
 
     Returns
     -------
     list of MortonChild
-        Refined prefix-cells (len <= *n_cells*).
+        Refined prefix-cells, at most *n_cells* of them — unless *roots* is
+        already longer than that, in which case it is returned as it stands
+        (roots are only ever expanded, never merged, so ``len(roots)`` is a
+        floor on the result).
     """
     # `current` holds the live frontier; expanding a node swaps it for its
     # children in place.  The heap mirrors the expandable nodes, keyed by

--- a/mortie/prefix_trie.py
+++ b/mortie/prefix_trie.py
@@ -1,5 +1,4 @@
-"""
-Prefix trie with greedy spanning-tree refinement for morton indices.
+"""Prefix trie with greedy spanning-tree refinement for morton indices.
 
 Builds a compacted prefix trie over the string representations of morton
 indices and uses a greedy algorithm to select the fewest prefix-cells
@@ -31,6 +30,16 @@ def _auto_max_depth(n_cells):
     such that ``2**d >= n_cells``, i.e. ``d = ceil(log2(n_cells))``.
     We add one extra level of headroom so that ``morton_polygon`` has
     good candidates to choose from.
+
+    Parameters
+    ----------
+    n_cells : int
+        Cell budget the caller will refine to.
+
+    Returns
+    -------
+    int
+        Trie depth guaranteeing at least *n_cells* leaf candidates.
     """
     if n_cells <= 1:
         return 1
@@ -71,6 +80,24 @@ class MortonChild:
         Maximum branching depth (None = unlimited).
     _depth : int
         Current branching depth (0 at root level).
+
+    Attributes
+    ----------
+    characteristic : str
+        Common prefix shared by every morton index under this node.
+    len : int
+        Number of morton indices under this node.
+    children : list of MortonChild
+        Child nodes, empty for a leaf.
+    nchildren : int
+        ``len(children)``.
+
+    Raises
+    ------
+    ValueError
+        If *mask* selects no rows, or the masked rows do not share the
+        expected leading character (an uncompressible mix of signs or base
+        cells).
     """
 
     __slots__ = (
@@ -125,7 +152,19 @@ class MortonChild:
         self._compact(start_col)
 
     def _compact(self, col):
-        """Walk columns, extending characteristic while unique, branching on divergence."""
+        """Walk columns, extending characteristic while unique.
+
+        Branch on divergence: while every masked row agrees on a column that
+        character is appended to ``characteristic``; at the first column where
+        they disagree a child is created per distinct character, unless
+        ``_max_depth`` has been reached.
+
+        Parameters
+        ----------
+        col : int
+            Column index in the shared character array at which to resume
+            scanning.
+        """
         char_array = self._char_array
         mask = self._mask
         ncols = char_array.shape[1]
@@ -158,7 +197,13 @@ class MortonChild:
 
     @property
     def mantissa_array(self):
-        """The original morton indices belonging to this node."""
+        """The original morton indices belonging to this node.
+
+        Returns
+        -------
+        ndarray
+            The slice of the original integer morton array under this node.
+        """
         if self._original_indices is not None:
             return self._original_array[self._original_indices]
         return self._original_array[self._mask]
@@ -168,7 +213,7 @@ class MortonChild:
         """HEALPix cell area implied by this node's characteristic (cached).
 
         The characteristic encodes sign + digits; the *order* is the number of
-        digits (excluding a leading '-'):
+        digits (excluding a leading '-')::
 
             1 digit  → base cell    → area = 1
             2 digits → area = 1/4
@@ -177,6 +222,11 @@ class MortonChild:
         The characteristic is fixed once compaction finishes, so the area is
         computed once and cached (the greedy expansion in
         :func:`morton_polygon` reads it per node every iteration).
+
+        Returns
+        -------
+        float
+            Cell area in units of one order-0 base cell.
         """
         if self._cell_area is None:
             ndigits = len(self.characteristic.lstrip("-"))
@@ -184,6 +234,13 @@ class MortonChild:
         return self._cell_area
 
     def __repr__(self):
+        """Return a debug representation naming the node's read surface.
+
+        Returns
+        -------
+        str
+            ``MortonChild(characteristic=..., len=..., nchildren=...)``.
+        """
         return (
             f"MortonChild(characteristic={self.characteristic!r}, "
             f"len={self.len}, nchildren={self.nchildren})"
@@ -195,8 +252,9 @@ def _rebuild_tree_from_flat(flat_nodes, permutation, morton_array):
 
     Parameters
     ----------
-    flat_nodes : list of
-        (characteristic, count, idx_start, idx_len, child_node_ids, depth)
+    flat_nodes : list of tuple
+        One entry per node, ``(characteristic, count, idx_start, idx_len,
+        child_node_ids, depth)``.
     permutation : ndarray of int
         Shared buffer of original positions; each node owns the slice
         ``permutation[idx_start : idx_start + idx_len]`` (issue #34 item 8).
@@ -249,6 +307,11 @@ def split_children(morton_array, max_depth=4):
     -------
     list of MortonChild
         One root-level child per (sign, first-digit) group.
+
+    Raises
+    ------
+    ValueError
+        If *morton_array* is empty or not 1-D.
     """
     morton_array = np.ascontiguousarray(np.asarray(morton_array, dtype=np.uint64))
     if morton_array.ndim != 1 or len(morton_array) == 0:
@@ -275,6 +338,7 @@ def split_children_geo(lats, lons, order=18, max_depth=4):
     Returns
     -------
     list of MortonChild
+        One root-level child per (sign, first-digit) group.
     """
     from .tools import geo2mort
     morton_array = geo2mort(lats, lons, order=order)
@@ -306,6 +370,7 @@ def geo_morton_polygon(lats, lons, n_cells, order=18, max_depth=None):
     Returns
     -------
     list of MortonChild
+        Refined prefix-cells (len <= *n_cells*).
     """
     if max_depth is None:
         max_depth = _auto_max_depth(n_cells)
@@ -329,6 +394,7 @@ def morton_polygon_from_array(morton_array, n_cells, max_depth=None):
     Returns
     -------
     list of MortonChild
+        Refined prefix-cells (len <= *n_cells*).
     """
     if max_depth is None:
         max_depth = _auto_max_depth(n_cells)
@@ -339,12 +405,25 @@ def morton_polygon_from_array(morton_array, n_cells, max_depth=None):
 def _expansion_efficiency(node):
     """Area saved per net cell added by expanding *node* into its children.
 
+    ::
+
         benefit  = parent_area - sum(child_areas)
         cost     = nchildren - 1        (net new cells added)
         efficiency = benefit / cost
 
     Both terms depend only on the (cached) per-node cell areas, so the value is
     fixed for the life of the node.
+
+    Parameters
+    ----------
+    node : MortonChild
+        An expandable node (``nchildren > 1``; ``cost`` is zero for a single
+        child and undefined for a leaf).
+
+    Returns
+    -------
+    float
+        Area saved per net cell added.
     """
     cost = node.nchildren - 1
     benefit = node.cell_area - sum(c.cell_area for c in node.children)
@@ -397,6 +476,13 @@ def morton_polygon(roots, n_cells):
     heap = []
 
     def _maybe_push(node):
+        """Push *node* onto the frontier heap if its expansion fits the budget.
+
+        Parameters
+        ----------
+        node : MortonChild
+            Candidate for expansion.
+        """
         # Only nodes whose expansion still fits the budget are scored: scoring
         # calls `_expansion_efficiency`, which sums every child's area, so it is
         # the dominant per-node cost.  `count` never decreases, so a node that

--- a/mortie/tests/test_pandas_module.py
+++ b/mortie/tests/test_pandas_module.py
@@ -187,7 +187,7 @@ class TestPandasAbsent:
             "    raise AssertionError('expected ImportError')\n"
         )
         assert out.returncode == 0, out.stderr
-        assert "pins pandas as a mortie dependency" in out.stdout
+        assert "installed alongside mortie" in out.stdout
 
     @pytest.mark.parametrize(
         "stmt",
@@ -210,7 +210,7 @@ class TestPandasAbsent:
             "    raise AssertionError('expected ImportError')\n"
         )
         assert out.returncode == 0, out.stderr
-        assert "pins pandas as a mortie dependency" in out.stdout
+        assert "installed alongside mortie" in out.stdout
 
     def test_message_is_identical_on_every_path(self):
         # One definition (`morton_index._require_pandas`), so the wording
@@ -239,7 +239,7 @@ class TestPandasAbsent:
         assert "requires pandas, which is not installed" in message
         assert "`pip install pandas`" in message
         assert "`pip install mortie[pandas]`" in message
-        assert "pins pandas as a mortie dependency" in message
+        assert "installed alongside mortie" in message
         # The message is only ever raised once `import pandas` has failed, so
         # it must point at installing rather than at importing.
         assert "import pandas to use" not in message

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -40,6 +40,21 @@ def order2res(order):
 
     ``order`` may be a scalar (returns a ``float``) or an array of orders such
     as :func:`orders_of` yields (returns an ``ndarray``).
+
+    Parameters
+    ----------
+    order : int or array-like
+        HEALPix tessellation order(s).
+
+    Returns
+    -------
+    float or ndarray
+        Approximate cell scale in kilometres (scalar in -> ``float`` out,
+        array in -> ``ndarray`` out).
+
+    See Also
+    --------
+    res2display : the same ladder as display-ready records, order by order.
     """
     # Exponentiate in float so 4**order does not overflow an integer dtype at
     # high orders (an ``orders_of`` uint8 array wraps 4**29 to 0 -> div-by-zero).
@@ -73,6 +88,15 @@ def res2display(max_order=MAX_ORDER):
         ascending order. ``value``/``unit`` are the display pair; ``km``
         is the unrounded resolution in kilometres for further arithmetic.
 
+    Raises
+    ------
+    ValueError
+        If ``max_order`` lies outside ``0..MAX_ORDER``.
+
+    See Also
+    --------
+    order2res : the raw kilometres for a single order.
+
     Examples
     --------
     >>> from mortie import res2display
@@ -82,10 +106,6 @@ def res2display(max_order=MAX_ORDER):
     >>> for lvl in res2display(max_order=2):
     ...     print(f"{lvl.value} {lvl.unit} at tessellation order {lvl.order}")
     ... # doctest: +SKIP
-
-    See Also
-    --------
-    order2res : the raw kilometres for a single order.
     """
     if not 0 <= max_order <= MAX_ORDER:
         raise ValueError(
@@ -362,7 +382,7 @@ def geo2uniq(lats, lons, order=MAX_ORDER):
 
 
 def geo2mort(lats, lons, order=None, points=None):
-    """Calculates morton indices from geographic coordinates
+    """Compute morton indices from geographic coordinates.
 
     The entire pipeline runs in Rust via the ``healpix`` crate — no
     Python HEALPix backend is needed.
@@ -400,8 +420,13 @@ def geo2mort(lats, lons, order=None, points=None):
     -------
     ndarray
         Packed ``uint64`` morton word(s), same shape family as the input
-        (scalar in -> length-1 ndarray)."""
+        (scalar in -> length-1 ndarray).
 
+    Raises
+    ------
+    ValueError
+        If ``points=True`` is combined with an explicit ``order != 29``.
+    """
     # Resolve the point/area mode: a bare call encodes points; an explicit order
     # implies an area cell at that resolution unless the caller forces points.
     if points is None:
@@ -562,7 +587,7 @@ def validate_morton(morton, order=None):
 
 
 def mort2norm(morton):
-    """Convert morton index back to normalized address and parent cell
+    """Convert morton index back to normalized address and parent cell.
 
     Parameters
     ----------
@@ -577,6 +602,12 @@ def mort2norm(morton):
         Parent base cell (0-11)
     order : int or array
         HEALPix order inferred from morton index
+
+    Raises
+    ------
+    ValueError
+        If the words are at mixed orders — the return contract carries a single
+        scalar order, so use :func:`orders_of` for per-element orders.
 
     Notes
     -----
@@ -739,7 +770,7 @@ def uniq2geo(uniq):
 
 
 def mort2geo(morton):
-    """Convert morton index to lat/lon of pixel center
+    """Convert morton index to lat/lon of pixel center.
 
     This is the inverse of geo2mort, returning the center coordinates
     of the HEALPix cell identified by the morton index.
@@ -794,7 +825,7 @@ def mort2geo(morton):
 
 
 def mort2bbox(morton):
-    """Convert morton index to bounding box of the pixel
+    """Convert morton index to bounding box of the pixel.
 
     For pixels touching the antimeridian, vertex longitudes at ±180° are
     normalized to use consistent representation based on hemisphere voting,
@@ -906,8 +937,7 @@ def mort2bbox(morton):
 
 
 def _normalize_antimeridian_polygon(vertices):
-    """
-    Fix polygons that touch (but don't cross) the antimeridian.
+    """Fix polygons that touch (but don't cross) the antimeridian.
 
     When a polygon touches the antimeridian, vertices at ±180° should be
     normalized to match the hemisphere containing most other vertices.
@@ -1106,8 +1136,7 @@ def clip2order(clip_order, midx):
 
 
 def generate_morton_children(parent_morton, target_order):
-    """
-    Generate all child morton indices at a target order.
+    """Generate all child morton indices at a target order.
 
     Parameters
     ----------
@@ -1121,6 +1150,11 @@ def generate_morton_children(parent_morton, target_order):
     children : ndarray
         Array of child packed morton words at target_order.
         If target_order equals parent_order, returns array with parent_morton.
+
+    Raises
+    ------
+    ValueError
+        If ``target_order`` is coarser than the parent word's own order.
 
     Notes
     -----
@@ -1260,8 +1294,7 @@ def morton_buffer_meters(morton_indices, width_m):
 
 
 def mort2healpix(morton):
-    """
-    Convert morton index to HEALPix cell ID and order.
+    """Convert morton index to HEALPix cell ID and order.
 
     Parameters
     ----------
@@ -1275,18 +1308,18 @@ def mort2healpix(morton):
     order : int
         HEALPix order (resolution level)
 
-    Examples
-    --------
-    >>> import mortie
-    >>> m = mortie.geo2mort(-80.0, 120.0, order=6)[0]
-    >>> cell_id, order = mort2healpix(m)
-    >>> print(f"HEALPix cell {cell_id} at order {order}")
-    HEALPix cell 37010 at order 6
-
     Notes
     -----
     The function converts morton indices to HEALPix NESTED scheme cell IDs.
     All input morton indices must be at the same order.
+
+    Examples
+    --------
+    >>> import mortie
+    >>> m = mortie.geo2mort(-80.0, 120.0, order=6)[0]
+    >>> cell_id, order = mortie.mort2healpix(m)
+    >>> print(f"HEALPix cell {cell_id} at order {order}")
+    HEALPix cell 37010 at order 6
     """
     # Check if input is scalar before converting to array
     is_scalar = np.isscalar(morton)

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -1308,6 +1308,12 @@ def mort2healpix(morton):
     order : int
         HEALPix order (resolution level)
 
+    Raises
+    ------
+    ValueError
+        If the words are at mixed orders (propagated from :func:`mort2norm`,
+        which enforces the same-order precondition below).
+
     Notes
     -----
     The function converts morton indices to HEALPix NESTED scheme cell IDs.


### PR DESCRIPTION
Closes #135. Refs #68.

Phase 2 of the repo-wide numpydoc sweep: the four modules deferred from phase 1 (PR #141) to avoid colliding with PR #130 and PR #139. Both of those have merged, so the contention is gone. CLAUDE.md §7 now mandates numpydoc, so this brings the last of `mortie/` in line with it and with mkdocstrings' `docstring_style: numpy`.

Every public function, class and method in the four modules now carries a one-line imperative summary, then `Parameters` / `Returns` / `Raises` / `Warns` where applicable, with the existing design rationale preserved verbatim in the Extended Summary rather than compressed into parameter tables.

## Phases

- [x] `mortie/tools.py` — `convert tools docstrings to numpydoc (issue #135)`
- [x] `mortie/coverage.py` — `convert coverage docstrings to numpydoc (issue #135)`
- [x] `mortie/prefix_trie.py` — `convert prefix_trie docstrings to numpydoc (issue #135)`
- [x] `mortie/linestring.py` — `convert linestring docstrings to numpydoc (issue #135)`
- [x] Missing-pandas `ImportError` wording correction (own commit, see below)
- [x] Adversarial self-review, findings folded in (`address self-review findings (issue #135)`)

## Per-module before/after

Two metrics, read together — neither alone is the finish line. `ruff` never requires a `Parameters` section to *exist*, so a file can be ruff-green with no numpydoc structure at all (that was `linestring.py`'s starting state). Conversely `tools.py` and `coverage.py` were largely sectioned but carried the highest `D` counts: formatting defects inside already-structured docstrings.

| module | defs+classes | `Parameters` blocks before → after | ruff `D` before → after |
|---|---|---|---|
| `mortie/tools.py` | 24 | 23 → 24 | 7 → 0 |
| `mortie/coverage.py` | 16 | 11 → 15 | 18 → 0 |
| `mortie/prefix_trie.py` | 15 | 7 → 11 | 1 → 0 |
| `mortie/linestring.py` | 3 | 1 → 3 | 0 → 0 |

The counts that stop short of the def count are correct, not gaps:

- `coverage.py` 15/16 — `_whole_sphere()` takes no arguments, so it has `Returns` and no `Parameters`.
- `prefix_trie.py` 11/15 — the four without a `Parameters` block are `MortonChild.__init__` (constructor arguments are documented on the class, per numpydoc), the `mantissa_array` and `cell_area` properties, and `__repr__`. None takes a documentable argument; all now have summaries, and `Returns` where they return something.

## What changed beyond adding sections

- **`coverage.py` — narrative parsed as parameters.** `morton_coverage_moc` had its multipart/holes paragraph sitting *after* the `Returns` header, which numpydoc reads as further return entries. Moved into the Extended Summary, above `Parameters`. This was a **live rendering bug, not a style nit**: the self-review confirmed griffe's numpy parser emits **four** `returns` entries for that function on `main` — one real, three bogus, one per line of the stranded paragraph. On the branch it emits one `returns` plus one `raises`. The adaptive-stop-criteria lead-in also dangled on a colon directly before the `Parameters` header; it now names `tolerance` and `max_cells` and ends in a period. No words dropped.
- **`coverage.py` — five docstrings converted to `r"""`** (`moc_or`, `moc_and`, `moc_minus`, `moc_xor`, `moc_not`) so the `a \ b` set-difference notation stops needing `\\` (ruff `D301`). The *runtime* docstring text is byte-identical to `main` for four of them, and differs only in the summary rewrite for `moc_not` — the escape change is purely how the literal is spelled, not what it says.
- **`coverage.py` — two two-line summaries collapsed** (`moc_not`, `split_base_cells`, ruff `D205`); the displaced clause moved to the first line of the Extended Summary, intact.
- **`tools.py` — `geo2mort`'s summary was `Calculates ...`, with no period and with the closing quotes on the content line** (`D400`/`D401`/`D209`); it is now `Compute morton indices from geographic coordinates.` Three more summaries gained their missing period (`mort2norm`, `mort2geo`, `mort2bbox`).
- **`tools.py` — section order fixed** in `res2display` and `mort2healpix`, which had `Examples` before `See Also` / `Notes`. numpydoc renders `Examples` last.
- **`linestring.py` — the multi-linestring example did not run.** `>>> [arr.shape for arr in per_line]` had no expected output, so it failed under `doctest`. It now carries the real output, `[(10,), (27,)]`, and both examples moved out of `::` literal blocks into plain doctest blocks matching `morton_coverage`'s style.
- **Cross-references kept as cross-references.** `coverage._single_coverage`'s `normalize` defers to `morton_coverage` **by name** for the full ring-winding contract rather than restating an abridged version — the failure mode PR #141's review caught on `from_wkb`/`from_wkt`, where an apparently-complete table quietly dropped a caveat.

## Substantively wrong prose found

Flagged separately from the formatting work, because this is a docstring that says something false rather than one that is merely unstructured.

`morton_polygon`'s `Returns` on `main` reads `Refined prefix-cells (len <= *n_cells*).`, and its `n_cells` parameter reads `Maximum number of cells in the returned list.` **Neither holds.** `morton_polygon` seeds the frontier with the roots and only ever grows it:

```python
current = list(roots)
count = len(current)
...
while count < n_cells and heap:
```

so when the trie has more root-level children than the budget, the budget is simply ignored. Reproduced on a 7-root trie: `morton_polygon_from_array(m, n_cells=n)` returns 7 cells for every `n` in 1..7. Roots are expanded, never merged, so `len(roots)` is a floor on the result.

I hit this because I had propagated the same sentence onto `geo_morton_polygon` and `morton_polygon_from_array` while filling in their missing return descriptions; the self-review caught it there. All three now describe the root-count floor, and the `n_cells` lines no longer claim a maximum.

**The behavioural question is open and left for review** (see "Questions for review" (1)): whether the floor is intended, or `morton_polygon` should reject `n_cells < len(roots)` rather than silently overshoot. No code changed either way.

## Missing-pandas `ImportError` wording

Separate commit, `correct the missing-pandas ImportError wording (issue #135)`, so it can be reviewed or reverted independently of the conversion.

The message introduced in PR #141 was **factually wrong**, not merely unclear. Its final clause:

```
... or declare it as a mortie extra with `pip install mortie[pandas]`, which
pins pandas as a mortie dependency so it is loaded whenever mortie is imported.
```

made two false claims. (1) "pins" — the extra is `pandas>=2.0` in `pyproject.toml`, a lower bound, not a pin. (2) "so it is loaded whenever mortie is imported" — equally true after a plain `pip install pandas`; the eager probe at the bottom of `morton_index.py` keys off whether pandas is *importable*, not how it was installed. The clause therefore invented a difference between the two remedies it offered, and could read as implying the bare install leaves the ExtensionArray unavailable. Replaced with:

```
the morton_index ExtensionArray requires pandas, which is not installed.
Install it with `pip install pandas`, or with `pip install mortie[pandas]` to
declare it as a mortie extra so it is installed alongside mortie in future
environments.
```

which states the real difference — the extra records the dependency in mortie's metadata, so a fresh install, a lockfile, or another machine picks pandas up automatically.

Updated in all three places that carry it, and re-grepped afterwards to confirm nothing else quotes it (the only remaining hits are in the gitignored `htmlcov/` coverage artifacts):

- `mortie/morton_index.py` — the single string literal. That property is preserved: `mortie/pandas.py` still reaches it through `_require_pandas()` rather than duplicating it.
- `mortie/tests/test_pandas_module.py` — the three assertions matching `"pins pandas as a mortie dependency"` re-pointed at `"installed alongside mortie"`. Assertions kept, not deleted, and still substring matches rather than whole-paragraph matches, which would be brittle.
- `docs/morton_index_datatype.md` — the verbatim quote updated to match exactly (verified character for character, 244 chars).

`test_message_is_identical_on_every_path` already asserts that all three raise paths (`mortie.MortonIndexArray`, `from mortie.morton_index import ...`, `from mortie.pandas import ...`) produce the *same* string (`len(set(msgs)) == 1`); it passes.

## How it was tested

**The diff on the four converted modules is docstring-only, proved two ways per file** (the AST check alone is blind to comments — PR #141 found six comment blocks that had migrated into docstrings):

1. Parse both the `origin/main` version and the branch version, delete every docstring `Expr` node, `ast.unparse` both, compare.
2. Extract the `tokenize.COMMENT` token stream (text only, position ignored) from both and compare.

```
tools.py:       ast_code_identical=True comments_identical=True (n_comments 123 -> 123)
coverage.py:    ast_code_identical=True comments_identical=True (n_comments  17 ->  17)
prefix_trie.py: ast_code_identical=True comments_identical=True (n_comments  20 ->  20)
linestring.py:  ast_code_identical=True comments_identical=True (n_comments   0 ->   0)
```

The only non-docstring lines in the four-file diff are eight `D202` blank-line deletions in `coverage.py` (a blank line between a docstring and the first statement).

The `ImportError` commit is deliberately *not* docstring-only — it changes a string literal, its assertions and its doc quote — which is why it is a separate commit.

Other gates, all run in a clean venv on this branch, and all re-run after the self-review fixes:

- `pytest` — **804 passed, 12 skipped**, exactly the baseline measured on `origin/main` @ `3f306a8` before any edit (**804 passed, 12 skipped**). No movement, so no logic was touched.
- `ruff check --select D` on each of the four files — clean, exit 0.
- `flake8 mortie --select=E9,F63,F7,F82` — clean, exit 0.
- `mkdocs build --strict` — **exit 0**, zero warnings. Exit code read directly from the build, not through a pipe.
- `doctest.testmod` on all four modules — 37 examples, 0 failures. On `main` `linestring.py` had 1 failure; it is fixed here.

An independent fresh-context adversarial review re-ran every one of those and reproduced the same numbers, and found nothing on lost rationale (a token-level audit found four `main` words absent, all deliberate summary rewrites; every issue ref and `§` link survives), lost or moved comments, the docstring-only claim, non-running examples, `r"""` text neutrality, or section ordering. Its five diff-scoped findings are folded into `389ce57` and itemised in the [review-response comment](https://github.com/espg/mortie/pull/143#issuecomment-5081200324).

## Questions for review

**(1) Is `morton_polygon`'s root-count floor intended?** Per the "Substantively wrong prose" section above, `n_cells` is not honoured when the trie has more roots than the budget — you get `len(roots)` cells back with no error. The docstrings now describe that faithfully, but the two plausible intents point different ways: **(a)** the floor is inherent (you cannot describe the data in fewer cells than it has root groups) and the docs are now correct as written; **(b)** silently returning more cells than asked for is a bug and `morton_polygon` should raise when `n_cells < len(roots)`. I did not change behaviour. If **(b)**, it wants its own issue rather than a docs-only PR.

**(2) `_normalize_antimeridian_polygon` has an unused variable.** `ruff check mortie/tools.py` reports `F841` for `on_antimeridian` at line 975 — assigned from `np.sum(...)` and never read. It is **pre-existing on `main`** (line 945 there) and fixing it is a logic change, so it is deliberately untouched here to keep the diff docstring-only. The neighbouring `mort2bbox` computes the same quantity as a *mask* and uses it; this one computes a *count* and drops it, which looks like the vestige of an earlier version of the check. Worth its own issue?

**(3) `tools.py` is 1354 lines**, over CLAUDE.md §4's ~1000-line guidance. It was already 1315 on `main`; this PR adds 39 lines of docstring and no code. Flagging rather than splitting, since §4 asks for discussion first and a split here would be churn on top of a docs-only change.

**(4) `MortonChild` gained an `Attributes` section** listing the frozen 1.x read surface (`characteristic`, `len`, `children`, `nchildren`). The prose above it already enumerated those names; the section makes mkdocstrings render them as a table. Say the word if you would rather the prose stayed the single source and the section came out.

**(5) `mort2healpix`'s example now calls `mortie.mort2healpix(m)`** rather than the bare `mort2healpix(m)`. The bare form only worked because `doctest.testmod` runs in the defining module's globals; a reader copying the rendered example after `import mortie` would have hit a `NameError`. The example still runs and still prints `HEALPix cell 37010 at order 6`.

**(6) Doctest examples are not executed by CI.** The `[(10,), (27,)]` output now pinned in `linestring_coverage` is a behavioural assertion nothing runs — there is no `--doctest-modules` in `addopts` and no workflow invokes doctest. I verified all 37 examples by hand for this PR, but the next docstring change will not be checked. Adding `--doctest-modules` is a `pyproject.toml` change, which this PR is scoped out of; worth a separate issue?

**(7) Enforcement is still open from #135 itself** — whether to add a `numpydoc` validation pass to `lint.yml`, or leave the `ruff` `D` rules as the mechanical floor with numpydoc structure as convention. All of `mortie/` is converted now, so it is decidable; it is out of scope for this PR.
