### PR TITLE
rank_to_xy / xy_to_rank: rank-space (x, y) deinterleave (issue #149)

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -559,7 +559,11 @@ packed-word order is a Z-order (morton) curve over a `2^d × 2^d` block. The
 **rank** of a cell — its position `0..4^d − 1` within the subtree, the same
 base-4 digit-tail rank the §7.2 bitmaps index by — maps to a face-local
 `(x, y)` pair by pure bit deinterleave. Source of truth in code:
-`mortie/rank_xy.py` (`rank_to_xy` / `xy_to_rank`, the executable reference).
+`mortie/rank_xy.py` (`rank_to_xy` / `xy_to_rank`; the pure-numpy mask
+ladder retained there is the executable reference and golden-vector
+generator, while the shipped kernel is the thin Rust binding in
+`src_rust/src/rank_xy.rs` over the vendored healpix crate's z-order
+curve — equivalence is test-pinned elementwise across depths).
 
 - **Bit parity**: `x` is the gather of the rank's **even** bits (bit 0, 2,
   4, …), `y` the gather of its **odd** bits (bit 1, 3, 5, …). Equivalently

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -22,7 +22,8 @@ Contents:
 5. [Zarr DGGS convention block](#5-zarr-dggs-convention-block)
 6. [Morton-hive store layout](#6-morton-hive-store-layout)
 7. [Coverage MOC serializations](#7-coverage-moc-serializations)
-8. [Frozen for 1.x](#8-frozen-for-1x)
+8. [Rank-space (x, y) deinterleave](#8-rank-space-x-y-deinterleave)
+9. [Frozen for 1.x](#9-frozen-for-1x)
 
 ---
 
@@ -551,7 +552,51 @@ fields. Field semantics:
 - The carrier fields above are informative cache metadata; the ranges are a
   regenerable cache of the leaf-stamp truth.
 
-## 8. Frozen for 1.x
+## 8. Rank-space (x, y) deinterleave
+
+**Contract.** A depth-`d` subtree holds `4^d` cells whose ascending
+packed-word order is a Z-order (morton) curve over a `2^d × 2^d` block. The
+**rank** of a cell — its position `0..4^d − 1` within the subtree, the same
+base-4 digit-tail rank the §7.2 bitmaps index by — maps to a face-local
+`(x, y)` pair by pure bit deinterleave. Source of truth in code:
+`mortie/rank_xy.py` (`rank_to_xy` / `xy_to_rank`, the executable reference).
+
+- **Bit parity**: `x` is the gather of the rank's **even** bits (bit 0, 2,
+  4, …), `y` the gather of its **odd** bits (bit 1, 3, 5, …). Equivalently
+  `rank = interleave(x, y)` with `x` supplying the LSB.
+- **Orientation**: the origin `(0, 0)` is the subtree's **south corner**;
+  `x` increases toward the **north-east** edge, `y` toward the
+  **north-west** edge — the HEALPix face-coordinate frame.
+- **Subtree-locality**: the input is **rank-space, never a packed morton
+  word** (§1). A word carries base cell, order, and kind; strip the shard
+  prefix down to the digit-tail rank first. Whole-word `(base, x, y)`
+  decomposition is deliberately out of scope here and reserved for a
+  future layer that composes word → (prefix, rank) → this transform.
+- **healpy equivalence** (the community convention this attaches to): for
+  `nside = 2^d`, `rank_to_xy(r, d) == healpy.pix2xyf(nside, r, nest=True)[:2]`
+  and `xy_to_rank(x, y, d) == healpy.xyf2pix(nside, x, y, 0, nest=True)` —
+  i.e. HEALPix C++ `pix2xyf`/`xyf2pix` restricted to one face. The golden
+  vectors in `mortie/tests/test_rank_xy.py` pin this at depths 6 and 8.
+
+### 8.1 Worked example (depth 2)
+
+`rank = 6 = 0b0110`: even bits `(b0, b2) = (0, 1)` give `x = 0b10 = 2`; odd
+bits `(b1, b3) = (1, 0)` give `y = 0b01 = 1`. The full `4 × 4` block, `x`
+left→right and `y` bottom→top (origin at the lower-left / south corner):
+
+```text
+y=3 | 10 11 14 15
+y=2 |  8  9 12 13
+y=1 |  2  3  6  7
+y=0 |  0  1  4  5
+      x=0 x=1 x=2 x=3
+```
+
+Reading the ranks `0, 1, 2, 3, …` traces the familiar Z (self-similar
+across depths): child tuples order as `(x, y) = (0,0), (1,0), (0,1), (1,1)`
+at every level.
+
+## 9. Frozen for 1.x
 
 The 1.x contract guarantees, immutable within the major version:
 
@@ -574,7 +619,9 @@ The 1.x contract guarantees, immutable within the major version:
   character length cap), and the node invariant;
 - the §7 coverage contracts: the 4-slot null-padded box, the `encoding`
   discriminator values, the bitmap bit convention, and the root-MOC range
-  ordering (zstd level and other codec parameters stay non-normative).
+  ordering (zstd level and other codec parameters stay non-normative);
+- the §8 rank-space deinterleave: bit parity (x = even bits, y = odd bits),
+  the south-corner orientation, and the healpy `pix2xyf` equivalence.
 
 Extensions (new schedules, new `spec` versions, new encodings) are additive
 under new discriminator values; existing stores never reparse under new

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -47,6 +47,12 @@ from .prefix_trie import (
     split_children,
     split_children_geo,
 )
+
+# Rank-space (x, y) deinterleave for 2-D block views (issue #149)
+from .rank_xy import (
+    rank_to_xy,
+    xy_to_rank,
+)
 from .tools import (
     clip2order,
     generate_morton_children,
@@ -125,6 +131,8 @@ __all__ = [
     'geo_morton_polygon',
     'morton_polygon',
     'morton_polygon_from_array',
+    'rank_to_xy',
+    'xy_to_rank',
 ]
 
 # morton_index datatype (phase 5) + Arrow interop (phase 4) for issue #35. The

--- a/mortie/rank_xy.py
+++ b/mortie/rank_xy.py
@@ -1,0 +1,159 @@
+"""Subtree-local rank <-> face-local (x, y) bit deinterleave (issue #149).
+
+A depth-``d`` subtree holds ``4**d`` cells whose ascending packed-word order
+is a Z-order (morton) curve over a ``2**d x 2**d`` block. A cell's **rank**
+is its position ``0..4**d - 1`` within that subtree -- the same base-4
+digit-tail rank the coverage bitmaps index by (docs/specification.md §7.2)
+-- and it interleaves the bits of a face-local ``(x, y)`` pair: x occupies
+the even (LSB-side) interleave bits, y the odd bits, matching the healpy /
+HEALPix C++ ``pix2xyf`` convention (origin at the subtree's south corner, x
+toward north-east, y toward north-west). The input is rank-space, **not**
+packed morton words -- strip the shard prefix first (a word carries base
+cell, order, and kind that these pure bit transforms would scramble).
+
+Normative statement: docs/specification.md §8. These functions are its
+executable reference.
+"""
+
+import operator
+
+import numpy as np
+
+from .tools import MAX_ORDER
+
+# Mask ladder for the 64-bit even-bit gather/scatter (classic morton
+# de/interleave); depth <= 29 keeps ranks within 58 bits, so uint64 is safe.
+_MASKS = tuple(
+    np.uint64(m)
+    for m in (
+        0x5555555555555555,
+        0x3333333333333333,
+        0x0F0F0F0F0F0F0F0F,
+        0x00FF00FF00FF00FF,
+        0x0000FFFF0000FFFF,
+        0x00000000FFFFFFFF,
+    )
+)
+
+
+def _compact(v):
+    """Gather the even bits of uint64 ``v`` into its low half."""
+    v = v & _MASKS[0]
+    for i in range(5):
+        v = (v | (v >> np.uint64(1 << i))) & _MASKS[i + 1]
+    return v
+
+
+def _spread(v):
+    """Scatter the low 32 bits of uint64 ``v`` onto the even bits."""
+    v = v & _MASKS[5]
+    for i in range(4, -1, -1):
+        v = (v | (v << np.uint64(1 << i))) & _MASKS[i]
+    return v
+
+
+def _check_depth(depth):
+    """Validate ``depth`` and return it as a plain int."""
+    depth = operator.index(depth)
+    if not 0 <= depth <= MAX_ORDER:
+        raise ValueError(
+            f"depth must be between 0 and {MAX_ORDER}, got {depth!r}")
+    return depth
+
+
+def _as_uint64(values, name, bound):
+    """Validate integer input in ``[0, bound)`` and return it as uint64."""
+    arr = np.atleast_1d(np.asarray(values))
+    if arr.dtype.kind not in "iu":
+        raise ValueError(
+            f"{name} must be integer-typed, got dtype {arr.dtype}")
+    if arr.size and (np.any(arr < 0)
+                     or np.any(arr.astype(np.uint64) >= np.uint64(bound))):
+        raise ValueError(f"{name} must lie in [0, {bound})")
+    return arr.astype(np.uint64)
+
+
+def rank_to_xy(rank, depth):
+    """Deinterleave subtree-local ranks into face-local ``(x, y)``.
+
+    The rank's even bits (bit 0, 2, 4, ...) become ``x`` and its odd bits
+    become ``y`` -- the healpy / HEALPix C++ ``pix2xyf`` convention, so
+    ``rank_to_xy(r, d) == healpy.pix2xyf(2**d, r, nest=True)[:2]`` for
+    face-0 pixels. Input is the rank *within* a subtree (e.g. after
+    stripping a shard prefix), never a packed morton word.
+
+    Parameters
+    ----------
+    rank : int or array-like
+        Subtree-local rank(s), each in ``[0, 4**depth)``.
+    depth : int
+        Subtree depth (levels below the subtree root), 0-``MAX_ORDER``.
+
+    Returns
+    -------
+    x : int or ndarray
+        Column coordinate(s) in ``[0, 2**depth)``, ``uint64`` for array
+        input (scalar in -> ``int`` out, matching :func:`~.mort2healpix`).
+    y : int or ndarray
+        Row coordinate(s) in ``[0, 2**depth)``, same convention as ``x``.
+
+    Raises
+    ------
+    ValueError
+        If ``depth`` is outside ``0..MAX_ORDER``, or any rank is negative,
+        non-integer-typed, or ``>= 4**depth``.
+
+    See Also
+    --------
+    xy_to_rank : the inverse interleave.
+    """
+    depth = _check_depth(depth)
+    is_scalar = np.isscalar(rank)
+    r = _as_uint64(rank, "rank", 1 << (2 * depth))
+    x = _compact(r)
+    y = _compact(r >> np.uint64(1))
+    if is_scalar:
+        return int(x[0]), int(y[0])
+    return x, y
+
+
+def xy_to_rank(x, y, depth):
+    """Interleave face-local ``(x, y)`` into subtree-local ranks.
+
+    The exact inverse of :func:`rank_to_xy`: ``x`` supplies the even bits
+    of the rank, ``y`` the odd bits (healpy / HEALPix C++ ``xyf2pix``
+    convention). ``x`` and ``y`` broadcast against each other.
+
+    Parameters
+    ----------
+    x : int or array-like
+        Column coordinate(s), each in ``[0, 2**depth)``.
+    y : int or array-like
+        Row coordinate(s), each in ``[0, 2**depth)``.
+    depth : int
+        Subtree depth (levels below the subtree root), 0-``MAX_ORDER``.
+
+    Returns
+    -------
+    int or ndarray
+        Subtree-local rank(s) in ``[0, 4**depth)``, ``uint64`` for array
+        input (scalar in -> ``int`` out, matching :func:`~.mort2healpix`).
+
+    Raises
+    ------
+    ValueError
+        If ``depth`` is outside ``0..MAX_ORDER``, or any coordinate is
+        negative, non-integer-typed, or ``>= 2**depth``.
+
+    See Also
+    --------
+    rank_to_xy : the inverse deinterleave.
+    """
+    depth = _check_depth(depth)
+    is_scalar = np.isscalar(x) and np.isscalar(y)
+    xs = _spread(_as_uint64(x, "x", 1 << depth))
+    ys = _spread(_as_uint64(y, "y", 1 << depth))
+    rank = xs | (ys << np.uint64(1))
+    if is_scalar:
+        return int(rank[0])
+    return rank

--- a/mortie/rank_xy.py
+++ b/mortie/rank_xy.py
@@ -11,15 +11,24 @@ toward north-east, y toward north-west). The input is rank-space, **not**
 packed morton words -- strip the shard prefix first (a word carries base
 cell, order, and kind that these pure bit transforms would scramble).
 
-Normative statement: docs/specification.md §8. These functions are its
-executable reference.
+Normative statement: docs/specification.md §8. The pure-numpy mask/shift
+ladder kept here (:func:`_rank_to_xy_numpy` / :func:`_xy_to_rank_numpy`) is
+the spec's executable reference and the golden-vector generator; the public
+functions ship the Rust kernel (`src_rust/src/rank_xy.rs`, a thin binding
+over the vendored healpix crate's z-order curve) per the phase-2 gate
+decision on issue #149.
 """
 
 import operator
 
 import numpy as np
 
+from . import _rustie
 from .tools import MAX_ORDER
+
+# Rust-native kernels (healpix crate zoc::ZOrderCurve, LUT/BMI2 backed).
+_rust_rank_to_xy = _rustie.rust_rank_to_xy
+_rust_xy_to_rank = _rustie.rust_xy_to_rank
 
 # Mask ladder for the 64-bit even-bit gather/scatter (classic morton
 # de/interleave); depth <= 29 keeps ranks within 58 bits, so uint64 is safe.
@@ -50,6 +59,16 @@ def _spread(v):
     for i in range(4, -1, -1):
         v = (v | (v << np.uint64(1 << i))) & _MASKS[i]
     return v
+
+
+def _rank_to_xy_numpy(r):
+    """Deinterleave validated uint64 ranks in pure numpy (spec §8 reference)."""
+    return _compact(r), _compact(r >> np.uint64(1))
+
+
+def _xy_to_rank_numpy(xs, ys):
+    """Interleave validated uint64 coordinates in pure numpy (spec §8 reference)."""
+    return _spread(xs) | (_spread(ys) << np.uint64(1))
 
 
 def _check_depth(depth):
@@ -110,8 +129,8 @@ def rank_to_xy(rank, depth):
     depth = _check_depth(depth)
     is_scalar = np.isscalar(rank)
     r = _as_uint64(rank, "rank", 1 << (2 * depth))
-    x = _compact(r)
-    y = _compact(r >> np.uint64(1))
+    x, y = _rust_rank_to_xy(np.ascontiguousarray(r.ravel()), depth)
+    x, y = x.reshape(r.shape), y.reshape(r.shape)
     if is_scalar:
         return int(x[0]), int(y[0])
     return x, y
@@ -151,9 +170,11 @@ def xy_to_rank(x, y, depth):
     """
     depth = _check_depth(depth)
     is_scalar = np.isscalar(x) and np.isscalar(y)
-    xs = _spread(_as_uint64(x, "x", 1 << depth))
-    ys = _spread(_as_uint64(y, "y", 1 << depth))
-    rank = xs | (ys << np.uint64(1))
+    xs, ys = np.broadcast_arrays(_as_uint64(x, "x", 1 << depth),
+                                 _as_uint64(y, "y", 1 << depth))
+    rank = _rust_xy_to_rank(np.ascontiguousarray(xs.ravel()),
+                            np.ascontiguousarray(ys.ravel()), depth)
+    rank = rank.reshape(xs.shape)
     if is_scalar:
         return int(rank[0])
     return rank

--- a/mortie/tests/test_rank_xy.py
+++ b/mortie/tests/test_rank_xy.py
@@ -1,0 +1,193 @@
+"""
+Tests for the rank-space (x, y) deinterleave (issue #149).
+"""
+import numpy as np
+import pytest
+
+from mortie import rank_to_xy, xy_to_rank
+from mortie.tools import MAX_ORDER
+
+try:
+    import healpy as hp
+    HAVE_HEALPY = True
+except ImportError:
+    HAVE_HEALPY = False
+
+# Golden (rank, x, y) triples, healpy-independent. Provenance: generated
+# with healpy 1.20.0 via `x, y, f = healpy.pix2xyf(2**depth, rank,
+# nest=True)` (face f == 0 for every entry), rng seed 149 -- the normative
+# healpy/HEALPix C++ `pix2xyf` convention pinned by docs/specification.md
+# §8. Depth 6 = the 64x64 inner chunk, depth 8 = the 256x256 shard.
+GOLDEN_DEPTH6 = [
+    (0, 0, 0),
+    (1, 1, 0),
+    (2, 0, 1),
+    (3, 1, 1),
+    (335, 27, 3),
+    (907, 17, 27),
+    (1069, 35, 6),
+    (1265, 45, 12),
+    (1873, 61, 16),
+    (2048, 0, 32),
+    (2135, 15, 33),
+    (2511, 27, 43),
+    (3024, 28, 56),
+    (3369, 49, 38),
+    (3592, 32, 50),
+    (4095, 63, 63),
+]
+GOLDEN_DEPTH8 = [
+    (0, 0, 0),
+    (1, 1, 0),
+    (2, 0, 1),
+    (3, 1, 1),
+    (3149, 43, 34),
+    (13006, 74, 91),
+    (30094, 242, 75),
+    (32094, 254, 99),
+    (32768, 0, 128),
+    (35193, 29, 166),
+    (36422, 42, 177),
+    (45487, 83, 207),
+    (58565, 171, 200),
+    (61371, 181, 255),
+    (65052, 230, 242),
+    (65535, 255, 255),
+]
+
+
+class TestGoldenVectors:
+    """Committed healpy-provenance triples; no healpy needed to run."""
+
+    @pytest.mark.parametrize("depth,golden", [(6, GOLDEN_DEPTH6),
+                                              (8, GOLDEN_DEPTH8)])
+    def test_rank_to_xy_golden(self, depth, golden):
+        ranks, xs, ys = (np.array(col, dtype=np.uint64)
+                         for col in zip(*golden))
+        x, y = rank_to_xy(ranks, depth)
+        np.testing.assert_array_equal(x, xs)
+        np.testing.assert_array_equal(y, ys)
+
+    @pytest.mark.parametrize("depth,golden", [(6, GOLDEN_DEPTH6),
+                                              (8, GOLDEN_DEPTH8)])
+    def test_xy_to_rank_golden(self, depth, golden):
+        ranks, xs, ys = (np.array(col, dtype=np.uint64)
+                         for col in zip(*golden))
+        np.testing.assert_array_equal(xy_to_rank(xs, ys, depth), ranks)
+
+
+class TestRoundTrip:
+    """Exact round-trip at every depth the packed words reach."""
+
+    @pytest.mark.parametrize("depth", range(1, MAX_ORDER + 1))
+    def test_rank_round_trip(self, depth):
+        rng = np.random.default_rng(depth)
+        n = int(min(4**depth, 2048))
+        ranks = rng.integers(0, 4**depth, size=n, dtype=np.uint64)
+        x, y = rank_to_xy(ranks, depth)
+        assert x.max() < 2**depth and y.max() < 2**depth
+        np.testing.assert_array_equal(xy_to_rank(x, y, depth), ranks)
+
+    @pytest.mark.parametrize("depth", range(1, MAX_ORDER + 1))
+    def test_xy_round_trip(self, depth):
+        rng = np.random.default_rng(1000 + depth)
+        n = int(min(4**depth, 2048))
+        x = rng.integers(0, 2**depth, size=n, dtype=np.uint64)
+        y = rng.integers(0, 2**depth, size=n, dtype=np.uint64)
+        x2, y2 = rank_to_xy(xy_to_rank(x, y, depth), depth)
+        np.testing.assert_array_equal(x2, x)
+        np.testing.assert_array_equal(y2, y)
+
+
+@pytest.mark.skipif(not HAVE_HEALPY, reason="healpy not installed")
+class TestHealpyEquivalence:
+    """Pin the convention to healpy pix2xyf / xyf2pix (face 0)."""
+
+    @pytest.mark.parametrize("depth", [1, 2, 6, 8, 13, 20, MAX_ORDER])
+    def test_matches_pix2xyf(self, depth):
+        rng = np.random.default_rng(depth)
+        n = int(min(4**depth, 1024))
+        ranks = rng.integers(0, 4**depth, size=n, dtype=np.uint64)
+        hx, hy, hf = hp.pix2xyf(2**depth, ranks.astype(np.int64), nest=True)
+        assert np.all(hf == 0)
+        x, y = rank_to_xy(ranks, depth)
+        np.testing.assert_array_equal(x, hx.astype(np.uint64))
+        np.testing.assert_array_equal(y, hy.astype(np.uint64))
+
+    @pytest.mark.parametrize("depth", [1, 2, 6, 8, 13, 20, MAX_ORDER])
+    def test_matches_xyf2pix(self, depth):
+        rng = np.random.default_rng(2000 + depth)
+        n = int(min(4**depth, 1024))
+        x = rng.integers(0, 2**depth, size=n, dtype=np.uint64)
+        y = rng.integers(0, 2**depth, size=n, dtype=np.uint64)
+        hpix = hp.xyf2pix(2**depth, x.astype(np.int64),
+                          y.astype(np.int64), 0, nest=True)
+        np.testing.assert_array_equal(xy_to_rank(x, y, depth),
+                                      hpix.astype(np.uint64))
+
+
+class TestEdgeCases:
+    """Corners, empties, scalars, dtypes, and validation."""
+
+    def test_rank_zero_and_last(self):
+        for depth in (1, 6, 8, MAX_ORDER):
+            side = 2**depth
+            assert rank_to_xy(0, depth) == (0, 0)
+            assert rank_to_xy(4**depth - 1, depth) == (side - 1, side - 1)
+            assert xy_to_rank(0, 0, depth) == 0
+            assert xy_to_rank(side - 1, side - 1, depth) == 4**depth - 1
+
+    def test_depth_zero(self):
+        assert rank_to_xy(0, 0) == (0, 0)
+        assert xy_to_rank(0, 0, 0) == 0
+
+    def test_empty_arrays(self):
+        empty = np.array([], dtype=np.uint64)
+        x, y = rank_to_xy(empty, 8)
+        assert x.size == 0 and y.size == 0
+        assert x.dtype == np.uint64 and y.dtype == np.uint64
+        rank = xy_to_rank(empty, empty, 8)
+        assert rank.size == 0 and rank.dtype == np.uint64
+
+    def test_scalar_passthrough(self):
+        x, y = rank_to_xy(3, 6)
+        assert isinstance(x, int) and isinstance(y, int)
+        assert (x, y) == (1, 1)
+        rank = xy_to_rank(1, 1, 6)
+        assert isinstance(rank, int) and rank == 3
+
+    def test_output_dtype_uint64(self):
+        for dtype in (np.int32, np.int64, np.uint32, np.uint64):
+            ranks = np.arange(16, dtype=dtype)
+            x, y = rank_to_xy(ranks, 6)
+            assert x.dtype == np.uint64 and y.dtype == np.uint64
+            rank = xy_to_rank(x.astype(dtype), y.astype(dtype), 6)
+            assert rank.dtype == np.uint64
+
+    def test_broadcasting(self):
+        ranks = xy_to_rank(np.arange(4, dtype=np.uint64), 0, 6)
+        np.testing.assert_array_equal(ranks, [0, 1, 4, 5])
+
+    def test_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            rank_to_xy(4**6, 6)
+        with pytest.raises(ValueError):
+            rank_to_xy(-1, 6)
+        with pytest.raises(ValueError):
+            xy_to_rank(2**6, 0, 6)
+        with pytest.raises(ValueError):
+            xy_to_rank(0, -1, 6)
+
+    def test_bad_depth_raises(self):
+        with pytest.raises(ValueError):
+            rank_to_xy(0, -1)
+        with pytest.raises(ValueError):
+            rank_to_xy(0, MAX_ORDER + 1)
+        with pytest.raises(TypeError):
+            rank_to_xy(0, 6.5)
+
+    def test_float_input_raises(self):
+        with pytest.raises(ValueError):
+            rank_to_xy(np.array([1.5]), 6)
+        with pytest.raises(ValueError):
+            xy_to_rank(np.array([1.0]), np.array([1.0]), 6)

--- a/mortie/tests/test_rank_xy.py
+++ b/mortie/tests/test_rank_xy.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from mortie import rank_to_xy, xy_to_rank
+from mortie.rank_xy import _rank_to_xy_numpy, _xy_to_rank_numpy
 from mortie.tools import MAX_ORDER
 
 try:
@@ -124,6 +125,29 @@ class TestHealpyEquivalence:
                           y.astype(np.int64), 0, nest=True)
         np.testing.assert_array_equal(xy_to_rank(x, y, depth),
                                       hpix.astype(np.uint64))
+
+
+class TestRustNumpyEquivalence:
+    """The shipped Rust kernel matches the numpy spec reference elementwise."""
+
+    @pytest.mark.parametrize("depth", range(1, MAX_ORDER + 1))
+    def test_rank_to_xy_matches_numpy(self, depth):
+        rng = np.random.default_rng(3000 + depth)
+        n = int(min(4**depth, 2048))
+        ranks = rng.integers(0, 4**depth, size=n, dtype=np.uint64)
+        x, y = rank_to_xy(ranks, depth)
+        nx, ny = _rank_to_xy_numpy(ranks)
+        np.testing.assert_array_equal(x, nx)
+        np.testing.assert_array_equal(y, ny)
+
+    @pytest.mark.parametrize("depth", range(1, MAX_ORDER + 1))
+    def test_xy_to_rank_matches_numpy(self, depth):
+        rng = np.random.default_rng(4000 + depth)
+        n = int(min(4**depth, 2048))
+        x = rng.integers(0, 2**depth, size=n, dtype=np.uint64)
+        y = rng.integers(0, 2**depth, size=n, dtype=np.uint64)
+        np.testing.assert_array_equal(xy_to_rank(x, y, depth),
+                                      _xy_to_rank_numpy(x, y))
 
 
 class TestEdgeCases:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = [
   "shapely>=2.0",     # WKB/WKT geometry codec for the issue #71 I/O (test-only)
   "spherely>=0.1",    # geodesic (s2) sphere-truth oracle for polar/AM dissolve (test-only)
   "numpydoc>=1.10",   # docstring validation gate (issue #140); lint tooling only
+  "healpy>=1.16",     # pix2xyf convention oracle for rank_to_xy/xy_to_rank (issue #149); test-only, never runtime
 ]
 bench = [
   "pytest",

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -17,6 +17,7 @@ pub mod linestring;
 pub mod moc;
 pub mod morton;
 pub mod prefix_trie;
+pub mod rank_xy;
 pub mod sphere;
 
 use numpy::{
@@ -846,7 +847,7 @@ fn rust_descent_stats_take(py: Python<'_>) -> PyResult<PyObject> {
 
 /// Extract a readable message from a caught panic payload, falling back to
 /// `fallback` when the payload is neither a `String` nor a `&str`.
-fn panic_msg(e: Box<dyn std::any::Any + Send>, fallback: &str) -> String {
+pub(crate) fn panic_msg(e: Box<dyn std::any::Any + Send>, fallback: &str) -> String {
     if let Some(s) = e.downcast_ref::<String>() {
         s.clone()
     } else if let Some(s) = e.downcast_ref::<&str>() {
@@ -1428,6 +1429,8 @@ fn rust_dissolve(py: Python<'_>, morton: PyReadonlyArray1<u64>, step: u32) -> Py
 fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_mort2nested, m)?)?;
     m.add_function(wrap_pyfunction!(rust_nested2mort, m)?)?;
+    m.add_function(wrap_pyfunction!(rank_xy::rust_rank_to_xy, m)?)?;
+    m.add_function(wrap_pyfunction!(rank_xy::rust_xy_to_rank, m)?)?;
     m.add_function(wrap_pyfunction!(split_children_rust, m)?)?;
     m.add_function(wrap_pyfunction!(rust_geo2mort, m)?)?;
     m.add_function(wrap_pyfunction!(rust_ang2pix, m)?)?;

--- a/src_rust/src/rank_xy.rs
+++ b/src_rust/src/rank_xy.rs
@@ -1,0 +1,157 @@
+//! Subtree-local rank <-> face-local (x, y) deinterleave bindings (issue #149).
+//!
+//! Thin wrappers over the vendored healpix crate's z-order curve
+//! (`healpix::zoc` — the same LUT/BMI2 kernels the crate's own `Layer`
+//! decode routes through), so no new bit code lives here. Depth and range
+//! validation happen in the Python wrappers (`mortie/rank_xy.py`), whose
+//! pure-numpy ladder is the executable spec reference
+//! (docs/specification.md §8); these bindings are the shipped fast path.
+
+use healpix::zoc::get_zoc;
+use numpy::{IntoPyArray, PyArrayMethods, PyReadonlyArray1};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::panic_msg;
+
+/// Deinterleave subtree-local ranks into face-local (x, y) (vectorized).
+///
+/// # Arguments
+/// * `rank_array` - Subtree-local ranks (u64 NumPy array), each in `[0, 4^depth)`
+/// * `depth` - Subtree depth, `0..=29`
+///
+/// # Returns
+/// Tuple of two u64 NumPy arrays: (x, y), the even- and odd-bit gathers.
+#[pyfunction]
+pub fn rust_rank_to_xy(
+    py: Python<'_>,
+    rank_array: PyReadonlyArray1<u64>,
+    depth: u8,
+) -> PyResult<PyObject> {
+    // Borrow the contiguous numpy buffer directly (GIL-held, no copy); fall
+    // back to a copy only for the rare non-contiguous input.
+    let owned;
+    let data: &[u64] = match rank_array.as_slice() {
+        Ok(s) => s,
+        Err(_) => {
+            owned = rank_array.to_vec()?;
+            &owned
+        }
+    };
+
+    let result = std::panic::catch_unwind(|| {
+        let zoc = get_zoc(depth);
+        let mut xs = Vec::with_capacity(data.len());
+        let mut ys = Vec::with_capacity(data.len());
+        for &r in data {
+            let ij = zoc.h2ij(r);
+            xs.push(zoc.ij2i(ij) as u64);
+            ys.push(zoc.ij2j(ij) as u64);
+        }
+        (xs, ys)
+    });
+
+    match result {
+        Ok((xs, ys)) => {
+            let py_x = xs.into_pyarray_bound(py).into_any().unbind();
+            let py_y = ys.into_pyarray_bound(py).into_any().unbind();
+            let tuple = pyo3::types::PyTuple::new_bound(py, &[py_x, py_y]);
+            Ok(tuple.to_object(py))
+        }
+        Err(e) => Err(PyValueError::new_err(panic_msg(e, "rank_to_xy panicked"))),
+    }
+}
+
+/// Interleave face-local (x, y) into subtree-local ranks (vectorized).
+///
+/// # Arguments
+/// * `x_array` - Column coordinates (u64 NumPy array), each in `[0, 2^depth)`
+/// * `y_array` - Row coordinates (u64 NumPy array), same length
+/// * `depth` - Subtree depth, `0..=29`
+///
+/// # Returns
+/// Subtree-local ranks as a u64 NumPy array.
+#[pyfunction]
+pub fn rust_xy_to_rank(
+    py: Python<'_>,
+    x_array: PyReadonlyArray1<u64>,
+    y_array: PyReadonlyArray1<u64>,
+    depth: u8,
+) -> PyResult<PyObject> {
+    let x_owned;
+    let xs: &[u64] = match x_array.as_slice() {
+        Ok(s) => s,
+        Err(_) => {
+            x_owned = x_array.to_vec()?;
+            &x_owned
+        }
+    };
+    let y_owned;
+    let ys: &[u64] = match y_array.as_slice() {
+        Ok(s) => s,
+        Err(_) => {
+            y_owned = y_array.to_vec()?;
+            &y_owned
+        }
+    };
+
+    if xs.len() != ys.len() {
+        return Err(PyValueError::new_err(
+            "x and y arrays must have the same length",
+        ));
+    }
+
+    let result = std::panic::catch_unwind(|| {
+        let zoc = get_zoc(depth);
+        xs.iter()
+            .zip(ys.iter())
+            .map(|(&x, &y)| zoc.ij2h(x as u32, y as u32))
+            .collect::<Vec<u64>>()
+    });
+
+    match result {
+        Ok(ranks) => Ok(ranks.into_pyarray_bound(py).into_any().unbind()),
+        Err(e) => Err(PyValueError::new_err(panic_msg(e, "xy_to_rank panicked"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use healpix::zoc::get_zoc;
+
+    /// Reference even-bit gather (the mask ladder from mortie/rank_xy.py).
+    fn compact(mut v: u64) -> u64 {
+        v &= 0x5555555555555555;
+        v = (v | (v >> 1)) & 0x3333333333333333;
+        v = (v | (v >> 2)) & 0x0F0F0F0F0F0F0F0F;
+        v = (v | (v >> 4)) & 0x00FF00FF00FF00FF;
+        v = (v | (v >> 8)) & 0x0000FFFF0000FFFF;
+        (v | (v >> 16)) & 0x00000000FFFFFFFF
+    }
+
+    #[test]
+    fn zoc_matches_mask_ladder_across_depth_classes() {
+        // One depth per zoc size class (small/medium/large) plus the extremes.
+        for depth in [1u8, 6, 8, 9, 16, 17, 29] {
+            let zoc = get_zoc(depth);
+            let n_rank = 4u64.pow(depth as u32);
+            // Corners plus a fixed stride through the rank space.
+            let probes = [0, 1, 2, 3, n_rank / 3, n_rank / 2, n_rank - 1];
+            for &r in probes
+                .iter()
+                .chain((0..64).map(|k| n_rank * k / 64).collect::<Vec<_>>().iter())
+            {
+                let r = r.min(n_rank - 1);
+                let ij = zoc.h2ij(r);
+                let (x, y) = (zoc.ij2i(ij) as u64, zoc.ij2j(ij) as u64);
+                assert_eq!(x, compact(r), "x mismatch at depth {depth}, rank {r}");
+                assert_eq!(y, compact(r >> 1), "y mismatch at depth {depth}, rank {r}");
+                assert_eq!(
+                    zoc.ij2h(x as u32, y as u32),
+                    r,
+                    "round trip at depth {depth}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #149

Adds the subtree-local rank ↔ face-local `(x, y)` bit deinterleave, with the convention pinned to healpy / HEALPix C++ `pix2xyf` per the ruling on the issue thread (https://github.com/espg/mortie/issues/149#issuecomment-5124067733), under the ratified names `rank_to_xy(rank, depth)` / `xy_to_rank(x, y, depth)` (https://github.com/espg/mortie/issues/149#issuecomment-5124087407). The shipped kernel is a thin Rust binding over the vendored healpix crate's z-order curve, per the phase-2 gate decision (https://github.com/espg/mortie/pull/150#issuecomment-5124232200); the pure-numpy mask/shift ladder stays in `mortie/rank_xy.py` as the spec's executable reference and golden-vector generator.

## Phases

- [x] Phase 1 — numpy reference implementation (`mortie/rank_xy.py`: mask/shift ladder, uint64-safe, depths 0–29, array-in/array-out with scalar passthrough matching `mort2healpix`) + tests (round-trip at every depth 1–29, healpy `pix2xyf`/`xyf2pix` equivalence, committed healpy-independent golden triples at depths 6 and 8, edge/validation cases). healpy added to the `[test]` extra only, per the ruling on the issue (https://github.com/espg/mortie/issues/149#issuecomment-5124067733).
- [x] Phase 2 — numpy-vs-Rust gate decided for Rust (https://github.com/espg/mortie/pull/150#issuecomment-5124232200): thin PyO3 binding (`src_rust/src/rank_xy.rs`) over `healpix::zoc::ZOrderCurve::h2ij`/`ij2h` — no new bit code — exposed as `_rustie.rust_rank_to_xy`/`rust_xy_to_rank`; the public functions route through it, and the numpy ladder is retained as the executable spec reference. Elementwise Rust-vs-numpy equivalence tests across depths 1–29 join the suite, plus a `cargo test` unit pinning the zoc kernel against the mask ladder in all three zoc size classes.
- [x] Phase 3 — normative spec section (`docs/specification.md` §8): bit parity, orientation, subtree-locality, healpy equivalence, worked depth-2 example; §9 "Frozen for 1.x" gains the matching bullet.

## Benchmarks

Best of 5 timed repeats, macOS arm64 (Apple Silicon, LUT zoc path — x86-64 with BMI2 uses pdep/pext and should do better), numpy 2.2.2, Python 3.10. "numpy" columns are the phase-1 public path (mask ladder); "Rust" columns are the shipped public path after phase 2 (both include the same Python-side validation):

| n | depth | `rank_to_xy` numpy (ms) | `rank_to_xy` Rust (ms) | `xy_to_rank` numpy (ms) | `xy_to_rank` Rust (ms) |
|---|---|---|---|---|---|
| 4,096 (inner chunk) | 6 | 0.046 | 0.020 | 0.055 | 0.023 |
| 65,536 (shard) | 8 | 0.679 | 0.270 | 0.731 | 0.179 |
| 1,048,576 | 10 | 19.19 | 6.50 | 22.73 | 6.69 |

Rust is ~2.3–4× faster at the 65,536 shard scale and ~3× at 1M (and beats healpy's compiled `pix2xyf`, 0.433 ms at n = 65,536, measured for phase-1).

## Rust-surface findings (the phase-2 gate data, resolved)

- mortie's own `src_rust/` and the `_rustie` extension exposed no face-local xy decode before this PR.
- The `healpix` crate 0.3.3 (`Cargo.toml:18`) **publicly** ships the exact transform: `pub mod zoc` (`src/lib.rs:13`), `pub trait ZOrderCurve` (`src/zoc.rs:362`) with `h2ij(h) -> u64` packed `(i, j)` deinterleave (`src/zoc.rs:371`), accessors `ij2i`/`ij2j` (`src/zoc.rs:377-378`), and the inverse `ij2h` (`src/zoc.rs:363`), as LUT impls (BMI2 pdep/pext where available) selected by depth via `get_zoc` (`src/zoc.rs:1026`). The crate's own `Layer` decode already routes through it (`src/lib.rs:635-639`).
- Phase 2 binds exactly that — a serial loop over `zoc.h2ij`/`ij2h` per element in `src_rust/src/rank_xy.rs`, mirroring the `rust_mort2nested` binding style.

## Questions for review

- healpy is pinned `>=1.16` in `[test]` (first release with a stable `pix2xyf`); tighten or loosen at will.
- `panic_msg` in `src_rust/src/lib.rs` became `pub(crate)` so the new module can reuse it rather than duplicating.

## How it was tested

- `pytest -v` full suite: **1017 passed, 12 skipped** locally (after `maturin develop --release`), including 143 tests in `mortie/tests/test_rank_xy.py` (round-trip depths 1–29, healpy equivalence, committed depth-6/8 goldens, Rust-vs-numpy elementwise equivalence depths 1–29, edge/validation cases).
- healpy equivalence legs ran against healpy 1.20.0 locally; they skip cleanly when healpy is absent, and the golden triples (generated with healpy 1.20.0, provenance noted in the test file) keep the convention pinned without it.
- Rust: `cargo test` (new `zoc_matches_mask_ladder_across_depth_classes` unit passes), `cargo clippy` (no new findings), `cargo fmt`.
- `flake8 mortie --select=E9,F63,F7,F82`, `numpydoc lint mortie/*.py`, and `ruff check` on the touched files: all clean.

---
*This PR was prepared by a Claude agent run working issue #149 on branch `claude/149-rank-xy-deinterleave`.*
