### PR TITLE
common_ancestors + children_of: the dense-output batch pair (issue #156 phase 3)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -396,6 +396,39 @@ flat, flat_off = mortie.mocs_to_orders(mocs, off, 8)
 first = flat[flat_off[0]:flat_off[1]]    # flat cover of the first triangle
 ```
 
+### `common_ancestors(values, offsets)`
+
+Reduce **many** groups of words to their deepest common ancestors in one call —
+the batch twin of `common_ancestor` / `moc_min`. Ragged in (the same arrow list
+layout), **dense out**: one `uint64` per group, because the reduction is
+many→one per group. Result `i` is bit-identical to `common_ancestor` on group
+`i` alone; an empty group is an error naming its index, since the scalar refuses
+empty input.
+
+```python
+kids = np.concatenate([
+    np.asarray(mortie.norm2mort([11 * 4 + s for s in range(4)], [0] * 4, 5)),
+    np.asarray(mortie.norm2mort([7 * 4 + s for s in range(4)], [3] * 4, 5)),
+])
+parents = mortie.common_ancestors(kids, [0, 4, 8])    # -> 2 order-4 words
+```
+
+### `children_of(words, order)`
+
+Refine **many** parents to their children at `order` — the batch twin of
+`generate_morton_children`, which takes a single parent. Every parent must sit
+at one order `p <= order`, so each yields `4**d` children for `d = order - p`
+and the result is a dense `(n, 4**d)` block rather than a ragged pair. Row `i`
+is bit-identical to `generate_morton_children(words[i], order)`.
+
+```python
+parents = np.asarray(mortie.norm2mort([11, 7], [0, 3], 4), dtype=np.uint64)
+kids = mortie.children_of(parents, 6)     # shape (2, 16)
+```
+
+Size it before you call it: the result is `n * 4**d * 8` bytes, and there is no
+budget guard (the scalar has none either).
+
 ## Advanced Usage
 
 ### Integration with DataFrames

--- a/benchmarks/measure_children_of.py
+++ b/benchmarks/measure_children_of.py
@@ -8,12 +8,28 @@ expression, ``np.stack`` included, since a caller cannot get a dense block out
 of the scalar without it.
 
 Note the result grows as ``4**d``: at large ``d`` this is a memory-bandwidth
-measurement, not a boundary-cost one, and the speedup falls accordingly.
+measurement, not a boundary-cost one, and the speedup falls accordingly.  The
+decay does **not** flatten inside the small-``d`` range — it keeps going, so a
+figure quoted at ``d <= 4`` does not bound ``d = 8``, which is the shape zagg
+ships (65,536 cells/shard).  Measure the ``d`` you intend to run.
 
 Run:
     python benchmarks/measure_children_of.py [N] [parent_order] [target_order]
 
 Defaults: N=100_000 order-6 parents refined to order 8 (16 children each).
+
+Measured, 10 cores, macOS/arm64, **median of 5 runs** (single runs vary by up to
+20% on a loaded box, so a one-shot number reads high as often as low):
+
+===========================  ============  ==========  =========
+shape                        result        median      range
+===========================  ============  ==========  =========
+100k, 6 -> 7   (d=1)              3.1 MiB     74.2x     68.5-84.8
+100k, 6 -> 8   (d=2)             12.2 MiB     50.3x     48.1-55.9
+100k, 6 -> 9   (d=3)             48.8 MiB     28.2x     26.3-28.8
+100k, 6 -> 10  (d=4)            195.3 MiB     12.9x     12.3-13.1
+2k,   6 -> 14  (d=8)           1000.0 MiB      7.4x      7.1-7.5
+===========================  ============  ==========  =========
 """
 
 import os

--- a/benchmarks/measure_children_of.py
+++ b/benchmarks/measure_children_of.py
@@ -1,0 +1,71 @@
+"""Measure batch vs per-call scalar-loop child generation (issue #156).
+
+The loop this replaces is written down in moczarr's own source —
+``np.stack([generate_morton_children(int(w), level) for w in words])``
+(``dggs.py:310``) — and in zagg's per-sub-chunk refinement on every worker
+(``grids/healpix.py:199``).  So the scalar side timed here is exactly that
+expression, ``np.stack`` included, since a caller cannot get a dense block out
+of the scalar without it.
+
+Note the result grows as ``4**d``: at large ``d`` this is a memory-bandwidth
+measurement, not a boundary-cost one, and the speedup falls accordingly.
+
+Run:
+    python benchmarks/measure_children_of.py [N] [parent_order] [target_order]
+
+Defaults: N=100_000 order-6 parents refined to order 8 (16 children each).
+"""
+
+import os
+import sys
+import time
+
+import numpy as np
+
+import mortie
+from mortie import _rustie
+
+
+def parents(n, order, rng):
+    """N random parent words at `order`, scattered over all 12 base cells."""
+    span = 1 << (2 * order)
+    nested = rng.integers(0, 12 * span, n).astype(np.uint64)
+    depths = np.full(n, order, dtype=np.uint8)
+    return np.asarray(
+        _rustie.rust_nested2mort(np.ascontiguousarray(nested), depths), np.uint64
+    )
+
+
+def main():
+    """Time the scalar loop vs the batch call and print the comparison."""
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 100_000
+    parent_order = int(sys.argv[2]) if len(sys.argv) > 2 else 6
+    target_order = int(sys.argv[3]) if len(sys.argv) > 3 else 8
+    rng = np.random.default_rng(156)
+    words = parents(n, parent_order, rng)
+
+    t0 = time.perf_counter()
+    batch = mortie.children_of(words, target_order)
+    t_batch = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    loop = np.stack(
+        [mortie.generate_morton_children(int(w), target_order) for w in words]
+    )
+    t_loop = time.perf_counter() - t0
+
+    np.testing.assert_array_equal(batch, loop)
+
+    cores = os.cpu_count()
+    width = batch.shape[1]
+    mib = batch.nbytes / 2 ** 20
+    print(f"n={n} {parent_order} -> {target_order} (d={target_order - parent_order}, "
+          f"{width} children/parent) cores={cores}")
+    print(f"result      : {mib:8.1f} MiB")
+    print(f"scalar loop : {t_loop:8.2f} s  ({1e6 * t_loop / n:7.2f} us/parent)")
+    print(f"batch       : {t_batch:8.2f} s  ({1e6 * t_batch / n:7.2f} us/parent)")
+    print(f"speedup     : {t_loop / t_batch:8.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/measure_common_ancestors.py
+++ b/benchmarks/measure_common_ancestors.py
@@ -10,6 +10,17 @@ Run:
     python benchmarks/measure_common_ancestors.py [N] [group_size] [order]
 
 Defaults: N=100_000 groups of 3 order-9 words each.
+
+Measured, 10 cores, macOS/arm64, **median of 5 runs**.  The batch side is a few
+hundredths of a second here, so a single run is dominated by scheduling noise —
+quote the median and the range, not one number:
+
+=============================  ==========  ==========
+shape                          median      range
+=============================  ==========  ==========
+100k groups of 3, order 9         17.3x     15.0-18.3
+500k groups of 2, order 9         19.6x     18.1-19.9
+=============================  ==========  ==========
 """
 
 import os

--- a/benchmarks/measure_common_ancestors.py
+++ b/benchmarks/measure_common_ancestors.py
@@ -1,0 +1,70 @@
+"""Measure batch vs per-call scalar-loop common-ancestor reduction (issue #156).
+
+The consumer shape this exists for is zagg's t-digest merge, which reduces one
+tiny group per multi-member centroid inside a Python ``for`` loop
+(``stats/tdigest.py:198``) — many groups, each a handful of words.  So the
+default corpus is N small groups rather than a few large ones: the win being
+measured is the per-call boundary cost, not the reduction itself.
+
+Run:
+    python benchmarks/measure_common_ancestors.py [N] [group_size] [order]
+
+Defaults: N=100_000 groups of 3 order-9 words each.
+"""
+
+import os
+import sys
+import time
+
+import numpy as np
+
+import mortie
+from mortie import _rustie
+
+
+def groups(n, size, order, rng):
+    """N groups of `size` words, each group inside one random base cell."""
+    span = 1 << (2 * order)
+    base = rng.integers(0, 12, n).repeat(size).astype(np.uint64)
+    nested = base * np.uint64(span) + rng.integers(0, span, n * size).astype(np.uint64)
+    depths = np.full(n * size, order, dtype=np.uint8)
+    values = np.asarray(
+        _rustie.rust_nested2mort(np.ascontiguousarray(nested), depths), np.uint64
+    )
+    offsets = np.arange(0, n * size + 1, size, dtype=np.int64)
+    return values, offsets
+
+
+def main():
+    """Time the scalar loop vs the batch call and print the comparison."""
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 100_000
+    size = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+    order = int(sys.argv[3]) if len(sys.argv) > 3 else 9
+    rng = np.random.default_rng(156)
+    values, offsets = groups(n, size, order, rng)
+
+    t0 = time.perf_counter()
+    batch = mortie.common_ancestors(values, offsets)
+    t_batch = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    loop = np.array(
+        [
+            mortie.common_ancestor(values[offsets[i]:offsets[i + 1]])
+            for i in range(n)
+        ],
+        dtype=np.uint64,
+    )
+    t_loop = time.perf_counter() - t0
+
+    np.testing.assert_array_equal(batch, loop)
+
+    cores = os.cpu_count()
+    print(f"n={n} group_size={size} order={order} cores={cores}")
+    print(f"scalar loop : {t_loop:8.2f} s  ({1e6 * t_loop / n:7.2f} us/group)")
+    print(f"batch       : {t_batch:8.2f} s  ({1e6 * t_batch / n:7.2f} us/group)")
+    print(f"speedup     : {t_loop / t_batch:8.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api/moc.md
+++ b/docs/api/moc.md
@@ -18,4 +18,5 @@ names stay flat on the package (`mortie.moc_to_order`, `mortie.mocs_to_orders`).
         - moc_not
         - moc_min
         - common_ancestor
+        - common_ancestors
         - split_base_cells

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -19,6 +19,7 @@ Encoding, decoding, inspection, and buffering of packed morton words.
         - validate_morton
         - clip2order
         - generate_morton_children
+        - children_of
         - morton_buffer
         - morton_buffer_meters
         - order2res

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -32,6 +32,7 @@ from .linestring import linestring_coverage
 # Import MOC algebra (split out of coverage by domain, issue #156)
 from .moc import (
     common_ancestor,
+    common_ancestors,
     compress_moc,
     moc_and,
     moc_min,
@@ -60,6 +61,7 @@ from .rank_xy import (
     xy_to_rank,
 )
 from .tools import (
+    children_of,
     clip2order,
     generate_morton_children,
     geo2mort,
@@ -105,6 +107,7 @@ __all__ = [
     'geo2uniq',
     'clip2order',
     'generate_morton_children',
+    'children_of',
     'mort2healpix',
     'morton_buffer',
     'morton_buffer_meters',
@@ -123,6 +126,7 @@ __all__ = [
     'moc_xor',
     'moc_not',
     'common_ancestor',
+    'common_ancestors',
     'moc_min',
     'split_base_cells',
     'linestring_coverage',

--- a/mortie/moc.py
+++ b/mortie/moc.py
@@ -543,11 +543,16 @@ def common_ancestors(values, offsets):
     Raises
     ------
     ValueError
-        Fail-fast, naming the **lowest-index** offending group (e.g.
-        ``group 4217: inputs span multiple base cells ...``): a group that is
-        empty, holds an empty/invalid word, or spans more than one base cell;
-        or non-monotone / out-of-bounds offsets; or offsets that do not exactly
-        cover ``values`` (the message names which endpoint failed).
+        Fail-fast, naming the offending group (e.g. ``group 4217: inputs span
+        multiple base cells ...``): a *domain* failure — a group that is empty,
+        holds an empty/invalid word, or spans more than one base cell — or a
+        *layout* failure — non-monotone / out-of-bounds offsets, or offsets that
+        do not exactly cover ``values`` (the message names which endpoint
+        failed).  The index named is the **lowest-index** offender within its
+        kind.  Layout is checked for the whole batch first, so a layout failure
+        at a high index is reported ahead of a domain failure at a low one; that
+        ordering is deliberate, since the group indices a domain error is
+        reported by are themselves read out of ``offsets``.
 
     See Also
     --------

--- a/mortie/moc.py
+++ b/mortie/moc.py
@@ -457,6 +457,7 @@ def common_ancestor(morton):
     --------
     clip2order : coarsen each word to a fixed order (the elementwise form;
         ``common_ancestor`` is its reduce-by-common-coarsening reduction).
+    common_ancestors : the batch form (many groups in one call).
 
     Examples
     --------
@@ -474,6 +475,93 @@ def common_ancestor(morton):
 
 # ``moc_min`` is the MOC set-family alias for :func:`common_ancestor` (issue #61).
 moc_min = common_ancestor
+
+
+def common_ancestors(values, offsets):
+    """Reduce many groups of morton words to their common ancestors in one call.
+
+    The batch sibling of :func:`common_ancestor` (issue #156): the whole ragged
+    group set crosses the Python/Rust boundary **once**, the GIL is released for
+    the batch, and Rust parallelizes across groups.  Result ``i`` is
+    bit-identical to :func:`common_ancestor` on group ``i`` alone, the
+    single-word case included (it comes back verbatim, kind preserved).
+
+    Input is ragged in the arrow list layout :func:`polygons_to_morton_mocs`
+    and :func:`mocs_to_orders` use; the **output is dense** — one ``uint64`` per
+    group — because the reduction is many→one per group, so there are no output
+    offsets to carry.
+
+    The consumer this exists for is a per-worker inner loop, not a one-off:
+    zagg's t-digest reduction runs ``for j in np.flatnonzero(~single):`` over
+    every multi-member centroid (``stats/tdigest.py:198``) — once per centroid,
+    per cell, per build **and** per fold, on every Lambda worker, at 65,536
+    cells per shard in the shipped ATL03 configuration.  That module's own
+    docstring already calls it "the same O(n) Python-loop shape issue #279
+    removed".
+
+    Memory: the binding copies ``values`` and ``offsets`` before releasing the
+    GIL (a borrowed numpy slice cannot cross ``allow_threads``), so peak is
+    **the input copy + the result + one 64 KiB chunk** of per-group outcomes.
+    The result is one word per group, so for grouped input it is a fraction of
+    the input copy, and the input copy is the peak — measured over 5M groups of
+    3 order-9 words: 152.6 MiB of input, a 38.1 MiB result, a 191.9 MiB peak,
+    which is 1.01x the ``input + result`` model and **5.0x the result alone**.
+    Size a worker off ``input + result``, not the result.
+
+    Parameters
+    ----------
+    values : array_like
+        Flat ``uint64`` morton words, all groups concatenated.  Mixed orders
+        allowed within a group, as in the scalar form; every word in a group
+        must share one HEALPix base cell.
+    offsets : array_like
+        ``int64`` arrow list offsets: group ``i`` spans
+        ``[offsets[i], offsets[i + 1])``, so there are ``len(offsets) - 1``
+        groups.  The offsets must **exactly cover** ``values`` —
+        ``offsets[0] == 0`` and ``offsets[-1] == len(values)`` — so a sliced
+        arrow array must be re-based before it gets here; anything else is an
+        error naming the endpoint that failed.  Unlike the ragged-output
+        batches, an **empty group is an error**, not an empty slot: a
+        many→one reduction over no words has no answer, exactly as the scalar
+        refuses empty input.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``uint64`` array of ``len(offsets) - 1`` ancestor words, one per group.
+
+    Raises
+    ------
+    ValueError
+        Fail-fast, naming the **lowest-index** offending group (e.g.
+        ``group 4217: inputs span multiple base cells ...``): a group that is
+        empty, holds an empty/invalid word, or spans more than one base cell;
+        or non-monotone / out-of-bounds offsets; or offsets that do not exactly
+        cover ``values`` (the message names which endpoint failed).
+
+    See Also
+    --------
+    common_ancestor : the scalar (one group) form.
+    split_base_cells : partitions a mixed-base-cell set into groups this accepts.
+
+    Examples
+    --------
+    Two groups of order-5 siblings reduce to their two order-4 parents:
+
+    >>> import mortie, numpy as np
+    >>> kids = np.concatenate([
+    ...     np.asarray(mortie.norm2mort([11 * 4 + s for s in range(4)], [0] * 4, 5)),
+    ...     np.asarray(mortie.norm2mort([7 * 4 + s for s in range(4)], [3] * 4, 5)),
+    ... ])
+    >>> got = mortie.common_ancestors(kids, [0, 4, 8])
+    >>> [int(got[0]), int(got[1])] == [
+    ...     int(mortie.norm2mort(11, 0, 4)), int(mortie.norm2mort(7, 3, 4))
+    ... ]
+    True
+    """
+    values = np.ascontiguousarray(np.asarray(values, dtype=np.uint64).ravel())
+    offsets = np.ascontiguousarray(np.asarray(offsets, dtype=np.int64).ravel())
+    return np.asarray(_rustie.rust_common_ancestors(values, offsets))
 
 
 def split_base_cells(words, sort=False):

--- a/mortie/moc.py
+++ b/mortie/moc.py
@@ -501,12 +501,22 @@ def common_ancestors(values, offsets):
 
     Memory: the binding copies ``values`` and ``offsets`` before releasing the
     GIL (a borrowed numpy slice cannot cross ``allow_threads``), so peak is
-    **the input copy + the result + one 64 KiB chunk** of per-group outcomes.
-    The result is one word per group, so for grouped input it is a fraction of
-    the input copy, and the input copy is the peak — measured over 5M groups of
-    3 order-9 words: 152.6 MiB of input, a 38.1 MiB result, a 191.9 MiB peak,
-    which is 1.01x the ``input + result`` model and **5.0x the result alone**.
-    Size a worker off ``input + result``, not the result.
+    **the input copy + the result + one 64 KiB chunk** of per-group outcomes
+    **+ the reduction's own scratch**.  That last term is
+    :func:`common_ancestor`'s internal buffer, 16 bytes per non-first word in
+    the group being reduced, held for that whole reduction and one per group in
+    flight — so it is ``min(threads, n_groups) * 16 * max_group_size`` bytes.
+    It scales with the **largest single group**, not with the total word count.
+
+    For small groups it is invisible and the input copy is the peak: over 5M
+    groups of 3 order-9 words, 152.6 MiB of input, a 38.1 MiB result, a 191.9
+    MiB peak — 1.01x the ``input + result`` model, **5.0x the result alone**,
+    and under a kilobyte of scratch.  For large groups it dominates: 40 groups
+    of 1M words peaks at 458.6 MiB against a 305.2 MiB model (**1.50x**), and a
+    single 20M-word group at 460.0 MiB against 152.7 MiB (**3.01x**) — in both
+    cases the excess is the scratch term to within 2 MiB.  Size a worker off
+    ``input + result`` for many small groups, and off the largest group when
+    groups are large.
 
     Parameters
     ----------

--- a/mortie/tests/test_dense_batch.py
+++ b/mortie/tests/test_dense_batch.py
@@ -485,6 +485,110 @@ def test_children_large_but_servable_result_still_works():
     )
 
 
+def test_children_max_cells_unset_is_byte_identical_to_today():
+    """``max_cells=None`` (the default) changes nothing at all.
+
+    The point of the opt-in default is that adopters see no behaviour change,
+    so the existing parity fixtures run both ways and must be byte-equal —
+    including passing the parameter explicitly as ``None``.
+    """
+    for order, target in [(6, 8), (9, 11), (4, 4)]:
+        words = _basin_cells(24, order=order, limit=500)
+        default = mortie.children_of(words, target)
+        np.testing.assert_array_equal(
+            default, mortie.children_of(words, target, max_cells=None)
+        )
+        _assert_children_parity(words[:50], target)
+    empty = np.asarray([], np.uint64)
+    assert mortie.children_of(empty, 6).shape == (0, 1)
+    assert mortie.children_of(empty, 6, max_cells=None).shape == (0, 1)
+
+
+def test_children_max_cells_boundary_in_both_directions():
+    """Exactly at the budget passes; one cell over refuses."""
+    words = _basin_cells(24, order=6, limit=100)
+    exact = len(words) * 4 ** 2  # d = 2 -> 16 children each
+    ok = mortie.children_of(words, 8, max_cells=exact)
+    np.testing.assert_array_equal(ok, mortie.children_of(words, 8))
+    with pytest.raises(ValueError, match=rf"exceeding max_cells={exact - 1}"):
+        mortie.children_of(words, 8, max_cells=exact - 1)
+    np.testing.assert_array_equal(mortie.children_of(words, 8, max_cells=1 << 40), ok)
+    # A zero budget refuses any non-empty refinement but passes an empty batch,
+    # which is genuinely zero cells.
+    with pytest.raises(ValueError, match="exceeding max_cells=0"):
+        mortie.children_of(words, 8, max_cells=0)
+    assert mortie.children_of(np.asarray([], np.uint64), 8, max_cells=0).shape == (0, 1)
+    with pytest.raises(ValueError, match="max_cells must be non-negative"):
+        mortie.children_of(words, 8, max_cells=-1)
+
+
+def test_children_max_cells_refusal_is_a_plain_value_error():
+    """A bare ``except ValueError`` sees the refusal.
+
+    The PR #160 pattern: the analogous ``moc_to_order`` guard had a
+    ``PanicException`` escaping even ``except Exception``, so the handler shape
+    a consumer actually writes is what gets asserted, not ``pytest.raises``.
+    """
+    words = _basin_cells(24, order=6, limit=100)
+    caught = None
+    try:
+        mortie.children_of(words, 14, max_cells=1 << 20)
+    except ValueError as exc:
+        caught = str(exc)
+    assert caught is not None
+    assert "exceeding max_cells=1048576" in caught
+    assert "would generate" in caught
+    # And the message says what to do about it, in moc_to_order's wording.
+    assert "max_cells=None to proceed" in caught
+
+
+def test_children_max_cells_outranks_the_overflow_guard():
+    """The caller's budget answers before the internal overflow diagnostic.
+
+    64 order-0 parents at order 29 is 2**64 elements — the ``checked_mul``
+    guard's case when no budget is set.  With a budget set the budget answers,
+    because it is compared in 128-bit and an explicit argument condition is more
+    actionable than "the element count does not fit a usize".  Pinned because
+    the ordering is deliberate, not incidental.
+    """
+    words = _pack(np.arange(64) % 12, np.zeros(64, np.uint8))
+    with pytest.raises(ValueError, match="children each overflows"):
+        mortie.children_of(words, 29)
+    with pytest.raises(ValueError, match="exceeding max_cells=1048576"):
+        mortie.children_of(words, 29, max_cells=1 << 20)
+    # Same ordering ahead of the fallible-allocation refusal.
+    twelve = _pack(np.arange(12), np.zeros(12, np.uint8))
+    with pytest.raises(ValueError, match="allocation failed"):
+        mortie.children_of(twelve, 25)
+    with pytest.raises(ValueError, match="exceeding max_cells=1048576"):
+        mortie.children_of(twelve, 25, max_cells=1 << 20)
+
+
+def test_children_max_cells_refuses_the_zagg_d8_shape_catchably():
+    """The case that motivated the ruling: a worker refuses instead of dying.
+
+    1M order-6 parents refined to order 14 is the shipped ``d = 8`` shape at
+    fleet scale — 488 GiB, which ``try_reserve`` cannot refuse because the OS
+    accepts the reservation and kills the process later, mid-write.  With the
+    budget a worker would set it comes back as a ``ValueError`` the worker can
+    catch and retry at a coarser order.
+    """
+    words = _pack(np.arange(1_000_000) % (12 << 12), np.full(1_000_000, 6, np.uint8))
+    budget = 1 << 27  # 2**27 cells = 1 GiB of uint64, a plausible worker ceiling
+    caught = None
+    try:
+        mortie.children_of(words, 14, max_cells=budget)
+    except ValueError as exc:
+        caught = str(exc)
+    assert caught is not None
+    assert f"exceeding max_cells={budget}" in caught
+    assert "would generate 65536000000 cells" in caught
+    # The same shape under the budget still works, so the guard is a ceiling and
+    # not a refusal of the shape itself.
+    ok = mortie.children_of(words[:1000], 14, max_cells=budget)
+    assert ok.shape == (1000, 65536)
+
+
 @pytest.mark.parametrize(
     "offender", [0, 1, 7, CHUNK - 1, CHUNK, CHUNK + 1, 2 * CHUNK + 5, 3 * CHUNK - 1]
 )

--- a/mortie/tests/test_dense_batch.py
+++ b/mortie/tests/test_dense_batch.py
@@ -224,6 +224,27 @@ def test_ancestors_errors_name_the_group_index():
         mortie.common_ancestors([0, 0], [0, 2])
 
 
+def test_ancestors_layout_errors_outrank_domain_errors():
+    """Layout is a whole-batch pre-pass, so it outranks a lower-index domain error.
+
+    The lowest-index rule holds *within* a pass, not across the two: a bad
+    offset at group 7 is reported ahead of a mixed-base-cell group 0.  That is
+    deliberate — a broken ``offsets`` array is what the group indices a domain
+    error would be reported by are derived from — and pinned here so it cannot
+    drift silently.
+    """
+    n = 10
+    values = _pack(np.arange(2 * n) % 4096, np.full(2 * n, 6, np.uint8))
+    values[1] = _pack([(1 << 12) + 1], [6])[0]  # group 0 spans two base cells
+    offsets = np.arange(0, 2 * n + 1, 2, dtype=np.int64)
+    with pytest.raises(ValueError, match=r"group 0: .*multiple base cells"):
+        mortie.common_ancestors(values, offsets)
+    broken = offsets.copy()
+    broken[8] = 99
+    with pytest.raises(ValueError, match=r"group 7: offset 99 exceeds"):
+        mortie.common_ancestors(values, broken)
+
+
 @pytest.mark.parametrize(
     "offender", [0, 1, 7, CHUNK - 1, CHUNK, CHUNK + 1, 2 * CHUNK + 5, 3 * CHUNK - 1]
 )

--- a/mortie/tests/test_dense_batch.py
+++ b/mortie/tests/test_dense_batch.py
@@ -11,6 +11,8 @@ error surface (lowest-index fail-fast, proved across chunk boundaries),
 determinism under rayon, and the GIL-release guarantee.
 """
 
+import subprocess
+import sys
 import threading
 from pathlib import Path
 
@@ -396,6 +398,70 @@ def test_children_refuse_invalid_words_and_orders():
         mortie.children_of(words[:5], 30)
     with pytest.raises(ValueError, match="Order must be between 0 and 29"):
         mortie.children_of(words[:5], -1)
+
+
+def test_children_oversized_result_raises_instead_of_aborting():
+    """An unservable result is a catchable ``ValueError``, not a process abort.
+
+    ``vec![0u64; total]`` in the Rust kernel used Rust's *infallible* allocator,
+    whose failure path is ``handle_alloc_error`` -> ``abort()`` — SIGABRT, no
+    Python traceback, nothing to ``except``.  The scalar loop this op replaces
+    raises a catchable ``MemoryError`` at the same sizes, so the batch has to be
+    catchable too.  12 order-0 parents at order 25 asks for 96 PiB.
+    """
+    words = _pack(np.arange(12), np.zeros(12, np.uint8))
+    with pytest.raises(ValueError, match="allocation failed"):
+        mortie.children_of(words, 25)
+    # A plain ``except ValueError`` must see it — the PR #160 lesson, where a
+    # PanicException escaped even ``except Exception``.
+    caught = None
+    try:
+        mortie.children_of(words[:1], 29)  # 2 EiB
+    except ValueError as exc:
+        caught = str(exc)
+    assert caught is not None and "allocation failed" in caught
+    # The overflow guard above it still answers separately (>= 2**64 elements).
+    with pytest.raises(ValueError, match="children each overflows"):
+        mortie.children_of(_pack(np.arange(64) % 12, np.zeros(64, np.uint8)), 29)
+
+
+def test_children_oversized_result_leaves_the_process_alive():
+    """The refusal happens in-process: a fresh interpreter exits 0.
+
+    ``pytest.raises`` cannot observe an ``abort()`` — the whole run dies with
+    it — so the guarantee that actually matters (the interpreter survives) is
+    asserted from outside, on the exit status of a subprocess.
+    """
+    code = (
+        "import numpy as np, mortie\n"
+        "from mortie import _rustie\n"
+        "w = np.asarray(_rustie.rust_nested2mort(\n"
+        "    np.arange(12, dtype=np.uint64), np.zeros(12, np.uint8)), np.uint64)\n"
+        "try:\n"
+        "    mortie.children_of(w, 25)\n"
+        "except ValueError as exc:\n"
+        "    print('CAUGHT', 'allocation failed' in str(exc))\n"
+        "print('ALIVE')\n"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert out.returncode == 0, f"exit {out.returncode}: {out.stderr}"
+    assert "CAUGHT True" in out.stdout
+    assert out.stdout.strip().endswith("ALIVE")
+
+
+def test_children_large_but_servable_result_still_works():
+    """The guard refuses only what the allocator refuses.
+
+    100k parents refined by 5 orders is 819 MB — the size the docstring quotes
+    as the reason to budget caller-side — and it must still go through, so the
+    fallible allocation is not a de facto budget.
+    """
+    words = _pack(np.arange(100_000) % (12 << 12), np.full(100_000, 6, np.uint8))
+    kids = mortie.children_of(words, 11)
+    assert kids.shape == (100_000, 1024)
+    np.testing.assert_array_equal(
+        kids[7], mortie.generate_morton_children(int(words[7]), 11)
+    )
 
 
 @pytest.mark.parametrize(

--- a/mortie/tests/test_dense_batch.py
+++ b/mortie/tests/test_dense_batch.py
@@ -1,0 +1,489 @@
+"""Tests for the dense-output batches (``common_ancestors`` / ``children_of``).
+
+Issue #156 phase 3.  Both ops are *dense*: their results are fixed-shape arrays
+rather than a ragged (values, offsets) pair, which is why they are one phase.
+
+The contract for both is per-item parity with the scalar twin — result ``i`` is
+byte-identical to :func:`mortie.common_ancestor` on group ``i`` alone, and row
+``i`` to :func:`mortie.generate_morton_children` on ``words[i]`` alone — over
+randomized input and the in-tree Antarctic basin fixtures.  Plus the layout and
+error surface (lowest-index fail-fast, proved across chunk boundaries),
+determinism under rayon, and the GIL-release guarantee.
+"""
+
+import threading
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import mortie
+
+# The Rust batches step through 2048 items at a time, so offenders are placed
+# either side of these seams rather than at arbitrary indices.
+CHUNK = 2048
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_basin(basin_id):
+    """Load Antarctic basin vertices.  Returns (lats, lons) or skips test."""
+    coords_file = Path("mortie/tests/Ant_Grounded_DrainageSystem_Polygons.txt")
+    if not coords_file.exists():
+        pytest.skip("Antarctic polygon data not found")
+    data = np.loadtxt(coords_file)
+    mask = data[:, 2] == basin_id
+    return data[mask, 0], data[mask, 1]
+
+
+def _simplify_vertices(lats, lons, target):
+    """Uniformly subsample vertices to approximately *target* count."""
+    n = len(lats)
+    if n <= target:
+        return lats, lons
+    step = max(1, n // target)
+    idx = np.arange(0, n, step)
+    return lats[idx], lons[idx]
+
+
+def _basin_cells(basin_id, order, limit=None):
+    """A real Antarctic basin's flat cover at ``order`` (uint64, one order)."""
+    lats, lons = _simplify_vertices(*_load_basin(basin_id), 300)
+    cells = np.asarray(mortie.morton_coverage(lats, lons, order=order), np.uint64)
+    return cells[:limit] if limit else cells
+
+
+def _ragged(groups):
+    """Concatenate word groups into (values, offsets) arrow list layout."""
+    values = np.concatenate(
+        [np.asarray(g, dtype=np.uint64) for g in groups] or [np.empty(0, np.uint64)]
+    )
+    offsets = np.zeros(len(groups) + 1, dtype=np.int64)
+    offsets[1:] = np.cumsum([len(g) for g in groups])
+    return values, offsets
+
+
+def _random_groups(rng, n, order, base=None, size=(1, 6)):
+    """*n* groups of same-base-cell words, each 1-5 words at ``order``."""
+    groups = []
+    span = 1 << (2 * order)
+    for _ in range(n):
+        b = rng.integers(0, 12) if base is None else base
+        k = rng.integers(*size)
+        nested = int(b) * span + rng.integers(0, span, k)
+        groups.append(_pack(nested, np.full(k, order, dtype=np.uint8)))
+    return groups
+
+
+def _pack(nested, depths):
+    """Pack HEALPix NESTED ids at given depths into packed morton words."""
+    from mortie import _rustie
+
+    return np.asarray(
+        _rustie.rust_nested2mort(
+            np.ascontiguousarray(np.asarray(nested, dtype=np.uint64)),
+            np.ascontiguousarray(np.asarray(depths, dtype=np.uint8)),
+        ),
+        dtype=np.uint64,
+    )
+
+
+def _assert_ancestor_parity(groups):
+    """Assert the batch result == the scalar reduction per group."""
+    values, offsets = _ragged(groups)
+    got = mortie.common_ancestors(values, offsets)
+    assert got.dtype == np.uint64 and got.shape == (len(groups),)
+    for i, group in enumerate(groups):
+        assert int(got[i]) == int(mortie.common_ancestor(group)), f"group {i}"
+
+
+def _assert_children_parity(words, order):
+    """Assert the batch block == the scalar generator per word."""
+    words = np.asarray(words, dtype=np.uint64)
+    got = mortie.children_of(words, order)
+    assert got.dtype == np.uint64
+    assert got.shape[0] == len(words)
+    for i, w in enumerate(words):
+        expected = mortie.generate_morton_children(int(w), order)
+        np.testing.assert_array_equal(got[i], expected, err_msg=f"word {i}")
+
+
+# ---------------------------------------------------------------------------
+# common_ancestors: parity with the scalar
+# ---------------------------------------------------------------------------
+
+
+def test_ancestors_randomized_parity():
+    """200 random same-base-cell groups match the scalar reduction."""
+    rng = np.random.default_rng(156)
+    _assert_ancestor_parity(_random_groups(rng, 200, order=7))
+
+
+def test_ancestors_mixed_order_groups_parity():
+    """Groups holding mixed-order words reduce like the scalar does."""
+    rng = np.random.default_rng(1563)
+    groups = []
+    for _ in range(60):
+        base = int(rng.integers(0, 12))
+        parts = [
+            _pack(base * (1 << (2 * o)) + rng.integers(0, 1 << (2 * o), 2),
+                  np.full(2, o, dtype=np.uint8))
+            for o in (3, 6, 9)
+        ]
+        groups.append(np.concatenate(parts))
+    _assert_ancestor_parity(groups)
+
+
+def test_ancestors_sibling_groups_reduce_to_their_parent():
+    """The four order-(k+1) children of a cell reduce to that cell."""
+    parents = np.asarray(mortie.norm2mort([11, 7, 3], [0, 3, 9], 4), dtype=np.uint64)
+    groups = [mortie.generate_morton_children(int(p), 5) for p in parents]
+    values, offsets = _ragged(groups)
+    np.testing.assert_array_equal(mortie.common_ancestors(values, offsets), parents)
+
+
+def test_ancestors_antarctic_basin_parity():
+    """Real pole+antimeridian data: basin cover cells grouped by base cell."""
+    groups = []
+    for basin_id in (24, 2):
+        cells = _basin_cells(basin_id, order=6)
+        # Real covers straddle base cells; the scalar refuses those, so use the
+        # partition mortie itself offers as the group-maker.
+        groups.extend(mortie.split_base_cells(cells).values())
+    assert len(groups) > 2, "fixture should span several base cells"
+    _assert_ancestor_parity(groups)
+
+
+def test_ancestors_group_of_one_returns_that_word():
+    """A one-word group comes back verbatim, kind preserved (the scalar rule)."""
+    cells = _basin_cells(24, order=6, limit=500)
+    got = mortie.common_ancestors(cells, np.arange(len(cells) + 1, dtype=np.int64))
+    np.testing.assert_array_equal(got, cells)
+
+
+def test_ancestors_order_zero_and_max_order_edges():
+    """Order-0 base cells and order-29 words both reduce like the scalar."""
+    bases = _pack(np.arange(12), np.zeros(12, dtype=np.uint8))
+    # Each base cell alone is its own ancestor; a pair from one base cell at
+    # order 29 reduces to their enclosing area cell.
+    deep = _pack([3 * (1 << 58), 3 * (1 << 58) + 1], np.full(2, 29, dtype=np.uint8))
+    groups = [bases[i:i + 1] for i in range(12)] + [deep]
+    _assert_ancestor_parity(groups)
+    got = mortie.common_ancestors(*_ragged(groups))
+    np.testing.assert_array_equal(got[:12], bases)
+
+
+def test_ancestors_empty_batch_and_single_group():
+    got = mortie.common_ancestors([], [0])
+    assert got.shape == (0,) and got.dtype == np.uint64
+    cells = _basin_cells(24, order=6, limit=64)
+    one = mortie.split_base_cells(cells)
+    group = next(iter(one.values()))
+    got = mortie.common_ancestors(group, [0, len(group)])
+    assert got.shape == (1,)
+    assert int(got[0]) == int(mortie.common_ancestor(group))
+
+
+# ---------------------------------------------------------------------------
+# common_ancestors: layout and error surface
+# ---------------------------------------------------------------------------
+
+
+def test_ancestors_offsets_must_exactly_cover_the_values():
+    values = np.asarray(mortie.norm2mort([0, 1, 2], [0, 0, 0], 4), dtype=np.uint64)
+    with pytest.raises(ValueError, match="must start at 0"):
+        mortie.common_ancestors(values, [1, 3])
+    with pytest.raises(ValueError, match="must end at the value count"):
+        mortie.common_ancestors(values, [0, 2])
+    with pytest.raises(ValueError, match="at least one element"):
+        mortie.common_ancestors(values, [])
+    # The re-based spelling of that same group is what the core accepts.
+    got = mortie.common_ancestors(values[:2], [0, 2])
+    assert int(got[0]) == int(mortie.common_ancestor(values[:2]))
+
+
+def test_ancestors_errors_name_the_group_index():
+    values = np.asarray(mortie.norm2mort([0, 1, 2], [0, 0, 5], 4), dtype=np.uint64)
+    with pytest.raises(ValueError, match=r"group 1: .*monotonically"):
+        mortie.common_ancestors(values, [0, 3, 1])
+    with pytest.raises(ValueError, match=r"group 1: .*exceeds"):
+        mortie.common_ancestors(values, [0, 1, 99])
+    # An empty group is refused (many->one over nothing has no answer), unlike
+    # the ragged batches where an empty item is a legal empty slot.
+    with pytest.raises(ValueError, match=r"group 1: .*empty"):
+        mortie.common_ancestors(values, [0, 2, 2, 3])
+    # Mixed base cells: the scalar's own refusal, per group.
+    with pytest.raises(ValueError, match=r"group 0: .*multiple base cells"):
+        mortie.common_ancestors(values, [0, 3])
+    # An invalid word is named by its group.
+    with pytest.raises(ValueError, match=r"group 0: "):
+        mortie.common_ancestors([0, 0], [0, 2])
+
+
+@pytest.mark.parametrize(
+    "offender", [0, 1, 7, CHUNK - 1, CHUNK, CHUNK + 1, 2 * CHUNK + 5, 3 * CHUNK - 1]
+)
+def test_ancestors_lowest_index_holds_across_chunk_boundaries(offender):
+    """The named group is the lowest-index offender, wherever it sits.
+
+    One offender at a time, swept over the chunk seams: rayon may finish any
+    group first, but the reported index must be the offending one — the batch
+    materializes a whole chunk and walks it in index order before failing.
+    """
+    n = 3 * CHUNK
+    base0 = _pack(np.arange(2 * n) % 4096, np.full(2 * n, 6, dtype=np.uint8))
+    offsets = np.arange(0, 2 * n + 1, 2, dtype=np.int64)
+    values = base0.copy()
+    # Break one group by pulling its second word from another base cell.
+    values[2 * offender + 1] = _pack([(1 << 12) + 1], [6])[0]
+    for _ in range(5):  # repeated: a nondeterministic answer would show up here
+        with pytest.raises(ValueError, match=rf"group {offender}: "):
+            mortie.common_ancestors(values, offsets)
+
+
+def test_ancestors_lowest_index_wins_over_later_offenders():
+    """With offenders at several indices, the lowest is always the one named."""
+    n = 3 * CHUNK
+    values = _pack(np.arange(2 * n) % 4096, np.full(2 * n, 6, dtype=np.uint8))
+    offsets = np.arange(0, 2 * n + 1, 2, dtype=np.int64)
+    other = _pack([(1 << 12) + 1], [6])[0]
+    offenders = [3, CHUNK - 1, CHUNK, 2 * CHUNK + 5, n - 1]
+    for off in offenders:
+        values[2 * off + 1] = other
+    # Heal them lowest-first; each call names the lowest survivor.
+    for i, expect in enumerate(offenders):
+        for _ in range(3):
+            with pytest.raises(ValueError, match=rf"group {expect}: "):
+                mortie.common_ancestors(values, offsets)
+        values[2 * offenders[i] + 1] = values[2 * offenders[i]]
+    assert len(mortie.common_ancestors(values, offsets)) == n
+
+
+def test_ancestors_deterministic_across_runs():
+    rng = np.random.default_rng(3)
+    values, offsets = _ragged(_random_groups(rng, 5000, order=8))
+    first = mortie.common_ancestors(values, offsets)
+    for _ in range(9):
+        np.testing.assert_array_equal(mortie.common_ancestors(values, offsets), first)
+
+
+# ---------------------------------------------------------------------------
+# children_of: parity with the scalar
+# ---------------------------------------------------------------------------
+
+
+def test_children_randomized_parity():
+    """1000 random order-5 parents refine to order 8 exactly as the scalar."""
+    rng = np.random.default_rng(156)
+    words = _pack(rng.integers(0, 12 << 10, 1000), np.full(1000, 5, np.uint8))
+    _assert_children_parity(words, 8)
+
+
+def test_children_antarctic_basin_parity():
+    """Real cover cells (pole + antimeridian) refine like the scalar."""
+    cells = _basin_cells(24, order=6, limit=400)
+    _assert_children_parity(cells, 9)
+
+
+def test_children_at_shipped_atl03_shard_orders():
+    """Real shard keys at the shipped order-9 shardmap, refined per zagg.
+
+    zagg's HEALPix grid refines each shard key to its sub-chunks and then each
+    sub-chunk to its cells (``grids/healpix.py:199``), which is the two-step
+    ``generate_morton_children`` loop this replaces.  Both steps must be
+    byte-identical to the scalar on real Antarctic shard keys.
+    """
+    shard_keys = _basin_cells(2, order=9, limit=200)
+    sub_chunks = mortie.children_of(shard_keys, 11)
+    assert sub_chunks.shape == (len(shard_keys), 16)
+    _assert_children_parity(shard_keys, 11)
+    # Second step: the sub-chunks themselves refine to their cells.
+    flat = sub_chunks[:8].ravel()
+    _assert_children_parity(flat, 13)
+
+
+def test_children_zero_depth_returns_the_parents_verbatim():
+    """``order`` equal to the parents' order gives back an (n, 1) identity."""
+    cells = _basin_cells(24, order=7, limit=200)
+    got = mortie.children_of(cells, 7)
+    assert got.shape == (len(cells), 1)
+    np.testing.assert_array_equal(got[:, 0], cells)
+    _assert_children_parity(cells, 7)
+
+
+def test_children_zero_depth_preserves_a_point_word():
+    """A point word survives ``d == 0`` — the reason it is returned verbatim.
+
+    Re-packing through the nested round trip would hand back the order-29
+    *area* cell instead, which is a different word and a different kind.
+    """
+    lats = np.array([-71.5, 40.25])
+    lons = np.array([-122.75, 3.5])
+    points = np.asarray(mortie.geo2mort(lats, lons, points=True), np.uint64)
+    assert mortie.is_point(points).all()
+    got = mortie.children_of(points, 29)
+    np.testing.assert_array_equal(got[:, 0], points)
+    assert mortie.is_point(got[:, 0]).all()
+
+
+def test_children_order_zero_parents_and_max_order_target():
+    """Order-0 base cells refine, and order 29 is a legal target."""
+    bases = _pack(np.arange(12), np.zeros(12, dtype=np.uint8))
+    got = mortie.children_of(bases, 3)
+    assert got.shape == (12, 64)
+    _assert_children_parity(bases, 3)
+    # d == 1 into the kernel's max order.
+    deep = _pack([3 * (1 << 56), 7 * (1 << 56) + 11], np.full(2, 28, np.uint8))
+    got = mortie.children_of(deep, 29)
+    assert got.shape == (2, 4)
+    _assert_children_parity(deep, 29)
+
+
+def test_children_empty_and_single():
+    got = mortie.children_of([], 6)
+    assert got.shape == (0, 1) and got.dtype == np.uint64
+    parent = np.atleast_1d(np.asarray(mortie.norm2mort([11], [0], 4), dtype=np.uint64))
+    got = mortie.children_of(parent, 7)
+    assert got.shape == (1, 64)
+    np.testing.assert_array_equal(
+        got[0], mortie.generate_morton_children(int(parent[0]), 7)
+    )
+
+
+def test_children_stacked_scalar_loop_is_reproduced_exactly():
+    """The consumer's own idiom, replaced verbatim.
+
+    moczarr writes ``np.stack([generate_morton_children(int(w), level) for w in
+    words])`` (``dggs.py:310``) with the comment that no vectorized many-parent
+    kernel exists.  This is that expression, and the batch must equal it.
+    """
+    words = _basin_cells(2, order=8, limit=300)
+    expected = np.stack([mortie.generate_morton_children(int(w), 10) for w in words])
+    np.testing.assert_array_equal(mortie.children_of(words, 10), expected)
+
+
+# ---------------------------------------------------------------------------
+# children_of: layout and error surface
+# ---------------------------------------------------------------------------
+
+
+def test_children_refuse_a_word_finer_than_the_target():
+    """A parent finer than ``order`` is refused, naming its index."""
+    words = list(_basin_cells(24, order=6, limit=10))
+    words.append(_pack([12345], [9])[0])
+    with pytest.raises(ValueError, match=r"word 10: is at order 9, finer than"):
+        mortie.children_of(np.asarray(words, np.uint64), 7)
+    # Word 0 itself being too fine names index 0.
+    with pytest.raises(ValueError, match=r"word 0: is at order 9, finer than"):
+        mortie.children_of(np.asarray(words[::-1], np.uint64), 7)
+
+
+def test_children_refuse_mixed_parent_orders():
+    """Rows would be ragged, so a disagreeing order is refused by index."""
+    words = list(_basin_cells(24, order=6, limit=10))
+    words[4] = _pack([123], [5])[0]
+    with pytest.raises(ValueError, match=r"word 4: is at order 5 but word 0"):
+        mortie.children_of(np.asarray(words, np.uint64), 9)
+
+
+def test_children_refuse_invalid_words_and_orders():
+    words = np.asarray(list(_basin_cells(24, order=6, limit=5)) + [0], np.uint64)
+    with pytest.raises(ValueError, match=r"word 5: .*not a decodable morton word"):
+        mortie.children_of(words, 8)
+    with pytest.raises(ValueError, match="Order must be between 0 and 29"):
+        mortie.children_of(words[:5], 30)
+    with pytest.raises(ValueError, match="Order must be between 0 and 29"):
+        mortie.children_of(words[:5], -1)
+
+
+@pytest.mark.parametrize(
+    "offender", [0, 1, 7, CHUNK - 1, CHUNK, CHUNK + 1, 2 * CHUNK + 5, 3 * CHUNK - 1]
+)
+def test_children_lowest_index_holds_across_chunk_boundaries(offender):
+    """The named word is the lowest-index offender, wherever it sits."""
+    n = 3 * CHUNK
+    words = _pack(np.arange(n) % 4096, np.full(n, 6, dtype=np.uint8))
+    words[offender] = _pack([12345], [9])[0]
+    for _ in range(5):
+        with pytest.raises(ValueError, match=rf"word {offender}: "):
+            mortie.children_of(words, 8)
+
+
+def test_children_lowest_index_wins_over_later_offenders():
+    n = 3 * CHUNK
+    words = _pack(np.arange(n) % 4096, np.full(n, 6, dtype=np.uint8))
+    bad = _pack([12345], [9])[0]
+    offenders = [3, CHUNK - 1, CHUNK, 2 * CHUNK + 5, n - 1]
+    healthy = words.copy()
+    for off in offenders:
+        words[off] = bad
+    for i, expect in enumerate(offenders):
+        for _ in range(3):
+            with pytest.raises(ValueError, match=rf"word {expect}: "):
+                mortie.children_of(words, 8)
+        words[offenders[i]] = healthy[offenders[i]]
+    assert mortie.children_of(words, 8).shape == (n, 16)
+
+
+def test_children_deterministic_across_runs():
+    rng = np.random.default_rng(11)
+    words = _pack(rng.integers(0, 12 << 12, 20_000), np.full(20_000, 6, np.uint8))
+    first = mortie.children_of(words, 8)
+    for _ in range(9):
+        np.testing.assert_array_equal(mortie.children_of(words, 8), first)
+
+
+# ---------------------------------------------------------------------------
+# GIL release
+# ---------------------------------------------------------------------------
+
+
+def _gil_probe(call):
+    """Run *call* 20x with a pure-Python counter thread and return its progress."""
+    counter = [0]
+    stop = threading.Event()
+    started = threading.Event()
+
+    def busy():
+        started.set()
+        while not stop.is_set():
+            counter[0] += 1
+
+    b = threading.Thread(target=busy)
+    b.start()
+    started.wait()
+    try:
+        pre = counter[0]
+        for _ in range(20):
+            call()
+        return counter[0] - pre
+    finally:
+        stop.set()
+        b.join()
+
+
+def test_gil_released_during_common_ancestors():
+    """A pure-Python counter thread keeps running during a large batch call.
+
+    Same instrument as ``test_threading.test_gil_released_during_rust_compute``:
+    with the GIL held for the whole call the counter cannot advance.
+    """
+    rng = np.random.default_rng(5)
+    values, offsets = _ragged(_random_groups(rng, 40_000, order=9, size=(2, 6)))
+    progressed = _gil_probe(lambda: mortie.common_ancestors(values, offsets))
+    assert progressed > 1000, (
+        f"Python thread made ~no progress during common_ancestors ({progressed}); "
+        "the GIL was likely held (allow_threads not in effect)"
+    )
+
+
+def test_gil_released_during_children_of():
+    rng = np.random.default_rng(6)
+    words = _pack(rng.integers(0, 12 << 12, 20_000), np.full(20_000, 6, np.uint8))
+    progressed = _gil_probe(lambda: mortie.children_of(words, 10))
+    assert progressed > 1000, (
+        f"Python thread made ~no progress during children_of ({progressed}); "
+        "the GIL was likely held (allow_threads not in effect)"
+    )

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -1270,7 +1270,14 @@ def children_of(words, order, max_cells=None):
         holds ``words[i]``'s children at ``order``, ascending.  An empty
         ``words`` gives ``(0, 1)`` — with no parent to read an order from there
         is no ``d`` to derive, and 1 is the only width that is not a claim
-        about a block with no rows.
+        about a block with no rows.  Deriving it instead would mean a
+        ``parent_order=`` argument making callers repeat, in the empty case
+        alone, what the data itself carries in every other case; consumers that
+        need a typed empty already special-case it, the way moczarr's
+        ``dggs.py`` builds ``(0, 4**(level - order))`` on its own empty branch
+        because it knows its source order at that point.  So ``(0, 1)`` is the
+        honest shape for "no rows, width unknown", and the width belongs in the
+        consumer-side special case (issue #156, ruled).
 
     Raises
     ------

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -1222,10 +1222,17 @@ def children_of(words, order):
     transient and no ragged assembly copy — peak is **input copy + result**
     plus a fixed 64 KiB chunk of per-word outcomes.  Measured over 1M order-6
     parents refined to order 9: 7.6 MiB of input, a 488.3 MiB result, a 497.1
-    MiB peak — 1.00x that model.  There is deliberately no cell budget here
-    (unlike :func:`moc_to_order`, issue #80), because the scalar has none and
-    adding one would refuse calls the Python loop it replaces completes; the
-    size is exactly predictable from ``n`` and ``d``, so budget it caller-side.
+    MiB peak — 1.00x that model.
+
+    The result block is allocated **fallibly**, so a size the allocator refuses
+    is a catchable ``ValueError`` naming the byte count rather than a process
+    abort — matching the ``MemoryError`` the ``np.stack`` loop this replaces
+    raises at those sizes.  It is not a budget: an allocation an overcommitting
+    OS accepts and then cannot back still ends in a kill, exactly as it does for
+    the scalar loop (numpy accepts the same over-RAM request).  There is
+    deliberately no cell budget here (unlike :func:`moc_to_order`, issue #80),
+    because the scalar has none; the size is exactly predictable from ``n`` and
+    ``d``, so budget it caller-side.
 
     Parameters
     ----------
@@ -1253,7 +1260,9 @@ def children_of(words, order):
         Fail-fast, naming the **lowest-index** offending word (e.g.
         ``word 4217: is at order 9, finer than the requested order 7``): an
         empty/invalid word, one finer than ``order``, or one at a different
-        order from ``words[0]``.  Also if ``order`` is outside 0-29.
+        order from ``words[0]``.  Also if ``order`` is outside 0-29, or if the
+        ``(n, 4**d)`` result is a size the allocator refuses (``... needs N
+        bytes; allocation failed``).
 
     See Also
     --------

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -1194,7 +1194,7 @@ def generate_morton_children(parent_morton, target_order):
     return _rust_nested2mort(np.ascontiguousarray(child_nested), depths)
 
 
-def children_of(words, order):
+def children_of(words, order, max_cells=None):
     """Refine many parent words to their children at ``order``, in one call.
 
     The batch sibling of :func:`generate_morton_children` (issue #156), whose
@@ -1227,12 +1227,22 @@ def children_of(words, order):
     The result block is allocated **fallibly**, so a size the allocator refuses
     is a catchable ``ValueError`` naming the byte count rather than a process
     abort — matching the ``MemoryError`` the ``np.stack`` loop this replaces
-    raises at those sizes.  It is not a budget: an allocation an overcommitting
-    OS accepts and then cannot back still ends in a kill, exactly as it does for
-    the scalar loop (numpy accepts the same over-RAM request).  There is
-    deliberately no cell budget here (unlike :func:`moc_to_order`, issue #80),
-    because the scalar has none; the size is exactly predictable from ``n`` and
-    ``d``, so budget it caller-side.
+    raises at those sizes.  That is not a budget, though: an allocation an
+    overcommitting OS accepts and then cannot back still ends in a kill, exactly
+    as it does for the scalar loop (numpy accepts the same over-RAM request).
+    Only a policy ceiling refuses those, which is what ``max_cells`` is for.
+
+    ``max_cells`` is **opt-in** — ``None`` by default, the opposite of
+    :func:`moc_to_order`'s always-on budget.  The difference is deliberate and
+    is about predictability, not about one op being safer.  ``moc_to_order``
+    defaults its budget on because a densify explodes from a tiny input
+    (``Σ 4**(order - depth)``, issue #80) and the caller cannot cheaply predict
+    the output.  Here the output is exactly ``n * 4**d`` cells, computable from
+    the arguments before the call, so a default guard would refuse calls the
+    caller already knows are fine.  Same parameter name, opposite default, for a
+    stated reason.  The ``None`` polarity inverts with it: for
+    :func:`moc_to_order` ``None`` *disables* a default budget, here it means
+    there is no budget to begin with.
 
     Parameters
     ----------
@@ -1244,6 +1254,14 @@ def children_of(words, order):
         ``order`` equal to the parents' own order is legal and gives back a
         ``(n, 1)`` block of the parents **verbatim** — the same identity the
         scalar returns, which is what preserves a point word's kind.
+    max_cells : int or None, optional
+        Opt-in budget on the result's cell count, ``len(words) * 4**d``.  When
+        set, a result over it raises :class:`ValueError` **before** anything is
+        allocated, so a worker sized for a known memory ceiling fails catchably
+        instead of being killed by the OS mid-write.  Default ``None`` — no
+        budget, behaviour exactly as if the parameter did not exist.  Checked
+        ahead of the internal element-count overflow guard, so an explicit
+        budget is what answers even for a request too large to represent.
 
     Returns
     -------
@@ -1260,9 +1278,10 @@ def children_of(words, order):
         Fail-fast, naming the **lowest-index** offending word (e.g.
         ``word 4217: is at order 9, finer than the requested order 7``): an
         empty/invalid word, one finer than ``order``, or one at a different
-        order from ``words[0]``.  Also if ``order`` is outside 0-29, or if the
-        ``(n, 4**d)`` result is a size the allocator refuses (``... needs N
-        bytes; allocation failed``).
+        order from ``words[0]``.  Also if ``order`` is outside 0-29, if
+        ``max_cells`` is set and the ``n * 4**d`` result exceeds it, or if the
+        result is a size the allocator refuses (``... needs N bytes; allocation
+        failed``).
 
     See Also
     --------
@@ -1278,13 +1297,29 @@ def children_of(words, order):
     (2, 16)
     >>> np.array_equal(kids[0], mortie.generate_morton_children(int(parents[0]), 6))
     True
+
+    An opt-in budget refuses an oversized refinement before it is allocated:
+
+    >>> mortie.children_of(parents, 14, max_cells=1 << 20)
+    ... # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: children_of would generate 2097152 cells ... max_cells=1048576...
     """
     words = np.ascontiguousarray(np.asarray(words, dtype=np.uint64).ravel())
     # Range-checked here so an out-of-range order is a catchable ValueError
     # rather than the binding's u8 OverflowError (the issue #108 posture).
     if not 0 <= order <= 29:
         raise ValueError(f"Order must be between 0 and 29, got {order}")
-    return np.asarray(_rustie.rust_children_of(words, int(order)))
+    if max_cells is not None:
+        max_cells = int(max_cells)
+        if max_cells < 0:
+            raise ValueError(f"max_cells must be non-negative, got {max_cells}")
+        # The kernel compares in u128, so a budget past u64::MAX can never be
+        # exceeded -- clamping keeps that answer instead of raising
+        # OverflowError out of the binding (the mocs_to_orders spelling).
+        max_cells = min(max_cells, (1 << 64) - 1)
+    return np.asarray(_rustie.rust_children_of(words, int(order), max_cells))
 
 
 def morton_buffer(morton_indices, k=1):

--- a/mortie/tools.py
+++ b/mortie/tools.py
@@ -1156,6 +1156,10 @@ def generate_morton_children(parent_morton, target_order):
     ValueError
         If ``target_order`` is coarser than the parent word's own order.
 
+    See Also
+    --------
+    children_of : the batch form (many parents at one order, in one call).
+
     Notes
     -----
     Children are generated in HEALPix NESTED space — descending ``level_diff``
@@ -1188,6 +1192,90 @@ def generate_morton_children(parent_morton, target_order):
     )
     depths = np.full(span, target_order, dtype=np.uint8)
     return _rust_nested2mort(np.ascontiguousarray(child_nested), depths)
+
+
+def children_of(words, order):
+    """Refine many parent words to their children at ``order``, in one call.
+
+    The batch sibling of :func:`generate_morton_children` (issue #156), whose
+    wrapper coerces its input to a *single* parent: the whole parent array
+    crosses the Python/Rust boundary **once**, the GIL is released for the
+    batch, and Rust parallelizes across parents.  Row ``i`` is bit-identical to
+    :func:`generate_morton_children` on ``words[i]`` alone.
+
+    Every parent must sit at one shared order ``p <= order``, so each yields
+    exactly ``4**d`` children for ``d = order - p`` and the **result is dense**
+    — an ``(n, 4**d)`` matrix, not a ragged pair.  That is not a new
+    restriction: consumers already assume it, because the loop this replaces
+    ends in ``np.stack``, which raises on rows of unequal width (moczarr
+    ``dggs.py:310``, whose comment at ``dggs.py:302-305`` records the gap this
+    closes — *"there is still no vectorized many-parent children kernel"*).
+    zagg calls the scalar the same way per sub-chunk on every worker
+    (``grids/healpix.py:199``) and per shard in the shardmap reprojection
+    (``catalog/shardmap.py:708``).
+
+    Memory: the result is the whole of it, and it is ``n * 4**d * 8`` bytes —
+    refining 100k parents by 5 orders is 100k x 1024 x 8 B = 819 MB.  The
+    binding copies ``words`` before releasing the GIL (a borrowed numpy slice
+    cannot cross ``allow_threads``), which adds ``n * 8`` bytes, and the block
+    is allocated once at its exact final size, so there is no growth-realloc
+    transient and no ragged assembly copy — peak is **input copy + result**
+    plus a fixed 64 KiB chunk of per-word outcomes.  Measured over 1M order-6
+    parents refined to order 9: 7.6 MiB of input, a 488.3 MiB result, a 497.1
+    MiB peak — 1.00x that model.  There is deliberately no cell budget here
+    (unlike :func:`moc_to_order`, issue #80), because the scalar has none and
+    adding one would refuse calls the Python loop it replaces completes; the
+    size is exactly predictable from ``n`` and ``d``, so budget it caller-side.
+
+    Parameters
+    ----------
+    words : array_like
+        Parent packed morton words (``uint64``), all at one HEALPix order no
+        finer than ``order``.
+    order : int
+        Target HEALPix order (0-29) for the children, shared by every parent.
+        ``order`` equal to the parents' own order is legal and gives back a
+        ``(n, 1)`` block of the parents **verbatim** — the same identity the
+        scalar returns, which is what preserves a point word's kind.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``uint64`` array of shape ``(len(words), 4**d)``, row-major: row ``i``
+        holds ``words[i]``'s children at ``order``, ascending.  An empty
+        ``words`` gives ``(0, 1)`` — with no parent to read an order from there
+        is no ``d`` to derive, and 1 is the only width that is not a claim
+        about a block with no rows.
+
+    Raises
+    ------
+    ValueError
+        Fail-fast, naming the **lowest-index** offending word (e.g.
+        ``word 4217: is at order 9, finer than the requested order 7``): an
+        empty/invalid word, one finer than ``order``, or one at a different
+        order from ``words[0]``.  Also if ``order`` is outside 0-29.
+
+    See Also
+    --------
+    generate_morton_children : the scalar (one parent) form.
+    clip2order : the coarsening direction (elementwise, already vectorized).
+
+    Examples
+    --------
+    >>> import mortie, numpy as np
+    >>> parents = np.asarray(mortie.norm2mort([11, 7], [0, 3], 4), dtype=np.uint64)
+    >>> kids = mortie.children_of(parents, 6)
+    >>> kids.shape
+    (2, 16)
+    >>> np.array_equal(kids[0], mortie.generate_morton_children(int(parents[0]), 6))
+    True
+    """
+    words = np.ascontiguousarray(np.asarray(words, dtype=np.uint64).ravel())
+    # Range-checked here so an out-of-range order is a catchable ValueError
+    # rather than the binding's u8 OverflowError (the issue #108 posture).
+    if not 0 <= order <= 29:
+        raise ValueError(f"Order must be between 0 and 29, got {order}")
+    return np.asarray(_rustie.rust_children_of(words, int(order)))
 
 
 def morton_buffer(morton_indices, k=1):

--- a/src_rust/src/decimal_morton.rs
+++ b/src_rust/src/decimal_morton.rs
@@ -51,6 +51,9 @@
 //! below an element's order, so two encodings of the same cell are bit-equal
 //! (canonical) -- integer equality, hashing, dedup and the raw sort all work.
 
+/// Dense-output batches over the packed-word hierarchy (issue #156).
+pub mod batch;
+
 /// Highest HEALPix order this datatype encodes.
 pub const MAX_ORDER: u8 = 29;
 /// Number of two-bit tuples held in the body (orders 1..=27).

--- a/src_rust/src/decimal_morton/batch.rs
+++ b/src_rust/src/decimal_morton/batch.rs
@@ -100,11 +100,35 @@
 //!   panic.
 //! * [`common_ancestors`] validates only the *layout* up front and leaves the
 //!   per-group failures (an empty group, an undecodable word, words spanning
-//!   more than one base cell) to the parallel pass.  Hoisting them into the
-//!   pre-pass would break the lowest-index rule, not preserve it: the cheap
-//!   check (emptiness) would then out-rank the expensive one (mixed base
-//!   cells) regardless of index, so an empty group 7 would be reported ahead of
-//!   a mixed-base-cell group 2.
+//!   more than one base cell) to the parallel pass.  The reason is **cost**,
+//!   not ordering: the mixed-base-cell check *is* the reduction — it decodes
+//!   every word in every group — so a pre-pass that ran it would run the whole
+//!   kernel twice.  Hoisting per se would not break the lowest-index rule: a
+//!   single index-order pre-pass doing *all* the checks preserves it, which is
+//!   exactly what [`validate_words`] and [`crate::moc::batch`]'s validator do.
+//!   Only a *partial* hoist would invert — emptiness alone, as its own earlier
+//!   pass, would report an empty group 7 ahead of a mixed-base-cell group 2.
+//!   Lowest-index across the domain classes holds either way, because the
+//!   parallel pass materializes each chunk's outcomes and walks them in index
+//!   order.
+//!
+//! One asymmetry to state plainly rather than leave implicit: for
+//! [`common_ancestors`] the lowest-index rule holds **within** each pass, not
+//! across the two.  Layout errors are found in the serial pre-pass, so a bad
+//! offset at group 7 is reported ahead of a mixed-base-cell group 0:
+//!
+//! ```text
+//! ValueError: group 7: offset 99 exceeds value array length 20
+//! ```
+//!
+//! That ordering is intended.  A layout failure says the `offsets` array itself
+//! is wrong, and the group indices a domain error would be reported *by* are
+//! derived from that same array — so answering "your offsets are broken" before
+//! "group 0's words span two base cells" reports the failure the caller has to
+//! fix first.  [`crate::moc::batch`] has no such split only because its domain
+//! check (a per-MOC cell budget, computable from the words without reducing
+//! them) is cheap enough to interleave into the index-order layout loop; this
+//! op's is not.
 
 use rayon::prelude::*;
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -203,9 +227,13 @@ where
 /// that word verbatim, kind preserved).
 ///
 /// # Errors
-/// The lowest-index offending group, named in the message: a layout problem
-/// (see [`validate_ragged`]) or a group the scalar reduction refuses — empty,
-/// holding an undecodable word, or spanning more than one base cell.
+/// A layout problem (see [`validate_ragged`]) or a group the scalar reduction
+/// refuses — empty, holding an undecodable word, or spanning more than one base
+/// cell — naming the offending group.  The index named is the lowest-index
+/// offender **within its pass**: layout is checked first for the whole batch,
+/// so a layout failure at a high index outranks a domain failure at a low one
+/// (see the module's error posture for why).  Among the domain failures, the
+/// lowest index always wins.
 pub fn common_ancestors(values: &[u64], offsets: &[i64]) -> Result<Vec<u64>, String> {
     let n_groups = validate_ragged(values.len(), offsets)?;
     let mut out = Vec::with_capacity(n_groups);
@@ -430,8 +458,9 @@ mod tests {
         // An empty group has no ancestor, and is named.
         let err = common_ancestors(&values, &[0, 1, 1, 3]).unwrap_err();
         assert!(err.starts_with("group 1:"), "{err}");
-        // Mixed base cells: group 0 offends first even though group 1 is empty,
-        // which is the whole reason emptiness is not hoisted into the pre-pass.
+        // Mixed base cells: group 0 offends first even though group 1 is empty.
+        // Both are domain failures found in the same pass, so the lower index
+        // wins regardless of which check is cheaper.
         let err = common_ancestors(&values, &[0, 2, 2, 3]).unwrap_err();
         assert!(err.starts_with("group 0:"), "{err}");
         assert!(err.contains("multiple base cells"), "{err}");
@@ -440,6 +469,22 @@ mod tests {
         assert!(err.starts_with("group 1:"), "{err}");
         let err = common_ancestors(&values, &[0, 1, 99]).unwrap_err();
         assert!(err.starts_with("group 1:"), "{err}");
+    }
+
+    #[test]
+    fn ancestors_layout_errors_outrank_domain_errors() {
+        // Pinned because it is deliberate, not incidental: layout is a whole-
+        // batch pre-pass, so a bad offset at a *higher* index is reported ahead
+        // of a domain failure at a lower one (see the module's error posture).
+        let values = vec![word(0, 4, 1), word(5, 4, 1), word(0, 4, 2), word(0, 4, 3)];
+        // Group 0 spans two base cells: on its own that is what surfaces.
+        let err = common_ancestors(&values, &[0, 2, 3, 4]).unwrap_err();
+        assert!(err.starts_with("group 0:"), "{err}");
+        assert!(err.contains("multiple base cells"), "{err}");
+        // Add a layout problem at group 2 and it outranks the group-0 domain one.
+        let err = common_ancestors(&values, &[0, 2, 3, 99]).unwrap_err();
+        assert!(err.starts_with("group 2:"), "{err}");
+        assert!(err.contains("exceeds value array length"), "{err}");
     }
 
     #[test]

--- a/src_rust/src/decimal_morton/batch.rs
+++ b/src_rust/src/decimal_morton/batch.rs
@@ -47,6 +47,28 @@
 //! measured peak silently under-counts it (the same 5M-group case reads as
 //! 77.3 MiB that way).  Size a worker off `input + result`, not the result.
 //!
+//! # Allocation posture
+//!
+//! [`children_of`]'s result grows as `4**d`, so an over-ambitious `order` asks
+//! for an allocation no machine can serve.  It is therefore allocated
+//! **fallibly** — `try_reserve_exact`, not `vec![0u64; total]` — because the
+//! latter goes through Rust's infallible allocator, whose failure path is
+//! `handle_alloc_error` -> `abort()`: the process dies with no Python
+//! traceback and nothing a caller can `except`.  The scalar loop this op
+//! replaces raises a catchable `MemoryError` from `np.arange` at exactly those
+//! sizes, so the fallible path is what keeps the batch's observable behaviour
+//! matching the scalar's (the same reasoning issue #108 used to keep
+//! `moc_to_order`'s ceiling a catchable `ValueError`).
+//!
+//! What this does **not** fence is an allocation the OS accepts and then cannot
+//! back: on an overcommitting kernel a request far larger than RAM succeeds at
+//! `try_reserve` time and the process is killed later, while it is being
+//! written.  Refusing those needs a *policy* ceiling (a `max_cells`-style
+//! budget), which is a separate question from making the allocator fallible.
+//! The `checked_mul` above is not that fence either: it only trips when the
+//! element count overflows `usize`, which is far past any allocation a machine
+//! would attempt.
+//!
 //! # Error posture
 //!
 //! Fail-fast naming the **lowest-index** offending item, as in
@@ -266,16 +288,31 @@ fn validate_words(words: &[u64], order: u8) -> Result<usize, String> {
 /// # Errors
 /// The lowest-index offending word, named in the message: undecodable, finer
 /// than `order`, or at a different order from word 0.  Also an `order` past
-/// [`MAX_ORDER`], or a result whose element count overflows `usize`.
+/// [`MAX_ORDER`], a result whose element count overflows `usize`, or a result
+/// the allocator refuses (see the module's allocation posture).
 pub fn children_of(words: &[u64], order: u8) -> Result<Children, String> {
     let width = validate_words(words, order)?;
     let total = words
         .len()
         .checked_mul(width)
         .ok_or_else(|| format!("{} parents x {width} children each overflows", words.len()))?;
-    // Allocated once at the exact final size: no growth realloc, so no
-    // old-plus-new transient in the peak (see the module's memory posture).
-    let mut out = vec![0u64; total];
+    // Allocated once at the exact final size (no growth realloc, so no
+    // old-plus-new transient in the peak) and **fallibly**: `vec![0u64; total]`
+    // goes through Rust's infallible allocator, whose failure path is
+    // `handle_alloc_error` -> `abort()`, which kills the interpreter with no
+    // catchable Python exception.  `try_reserve_exact` hands the failure back as
+    // an `Err(String)` the binding turns into `ValueError`, matching the
+    // catchable `MemoryError` the scalar loop this replaces raises.
+    let mut out: Vec<u64> = Vec::new();
+    out.try_reserve_exact(total).map_err(|_| {
+        format!(
+            "{} parents x {width} children each needs {} bytes; allocation failed \
+             (refine fewer parents, or to a coarser order)",
+            words.len(),
+            total.saturating_mul(std::mem::size_of::<u64>()),
+        )
+    })?;
+    out.resize(total, 0);
 
     for base in (0..words.len()).step_by(CHUNK) {
         let end = (base + CHUNK).min(words.len());
@@ -556,6 +593,21 @@ mod tests {
         // Word 0 itself finer than the target is named as index 0.
         let err = children_of(&[word(0, 9, 1), word(0, 5, 1)], 6).unwrap_err();
         assert!(err.starts_with("word 0:"), "{err}");
+    }
+
+    #[test]
+    fn children_oversized_result_errors_instead_of_aborting() {
+        // 12 order-0 parents at order 25 is 96 PiB.  `vec![0u64; total]` sent
+        // this through Rust's infallible allocator, which aborts the process;
+        // the fallible path names the byte count and returns.
+        let bases: Vec<u64> = (0..12).map(|b| from_nested(b, 0)).collect();
+        let err = children_of(&bases, 25).unwrap_err();
+        assert!(err.contains("allocation failed"), "{err}");
+        assert!(err.contains("108086391056891904 bytes"), "{err}");
+        // The `checked_mul` guard still owns the >= 2**64 *element* case, which
+        // is a different message and sits far above any real allocation.
+        let err = children_of(&[from_nested(0, 0); 64], MAX_ORDER).unwrap_err();
+        assert!(err.contains("children each overflows"), "{err}");
     }
 
     #[test]

--- a/src_rust/src/decimal_morton/batch.rs
+++ b/src_rust/src/decimal_morton/batch.rs
@@ -1,0 +1,593 @@
+//! Dense-output batches over the packed-word hierarchy (issue #156, phase 3).
+//!
+//! The two ops here are the **dense** half of the batch sweep: their results
+//! are fixed-shape arrays, not ragged ones, so neither needs an arrow offsets
+//! pair on the way out.
+//!
+//! * [`common_ancestors`] — ragged in (groups of words), one word out per
+//!   group: a segmented reduce of [`super::common_ancestor`].
+//! * [`children_of`] — flat in, a fixed-width block out: every parent at the
+//!   same order yields exactly `4**d` children at the target order, so the
+//!   result is an `(n, 4**d)` matrix.
+//!
+//! Both scalar kernels are this module's parent ([`super::common_ancestor`],
+//! and the [`super::to_nested`] / [`super::from_nested`] pair the child
+//! generator is built from), which is why the batches live here rather than
+//! beside [`crate::moc::batch`] — the batch submodule sits with the scalar
+//! kernel it wraps, the same axis the Python side splits on (issue #156's
+//! domain ruling).
+//!
+//! # Memory posture
+//!
+//! Dense output makes this simpler than the ragged batches, and the honest
+//! statement is short.  The pyfunction must `to_vec()` its numpy inputs — a
+//! borrowed `&[u64]` cannot cross `py.allow_threads` — so an input copy is
+//! **mandatory**, the term issue #162 records as missing from the merged
+//! ragged batches' docs:
+//!
+//! * [`common_ancestors`]: peak is **input copy + result + one chunk of
+//!   `Result`s**.  The result is one word per group, so with `g` groups over
+//!   `n` words it is `g / n` of the input copy — for the t-digest consumer
+//!   (groups of 2-3 centroids) about a third of it — and the chunk term is
+//!   2048 x 32 B = 64 KiB regardless of batch size.  The input copy is
+//!   therefore the peak, always.  Measured over 5M groups of 3 order-9 words:
+//!   152.6 MiB of input, a 38.1 MiB result, and a 191.9 MiB peak — 1.01x the
+//!   `input + result` model, and **5.0x the result alone**.
+//! * [`children_of`]: peak is **input copy + result + one chunk of
+//!   `Result`s**, and here the result dominates by construction — it is
+//!   `4**d` times the input.  The output is allocated once at its exact final
+//!   size (no growth reallocation, so no 1.5x transient) and written in place;
+//!   the only transient is the same 64 KiB chunk of per-word `Result`s.
+//!   Measured over 1M order-6 parents refined to order 9: 7.6 MiB of input, a
+//!   488.3 MiB result, and a 497.1 MiB peak — 1.00x the model.
+//!
+//! Both numbers come from sampled RSS in a process that loads its input rather
+//! than building it, which matters: when the input is *constructed* in-process
+//! the `to_vec()` copy is served out of already-resident freed heap and the
+//! measured peak silently under-counts it (the same 5M-group case reads as
+//! 77.3 MiB that way).  Size a worker off `input + result`, not the result.
+//!
+//! # Error posture
+//!
+//! Fail-fast naming the **lowest-index** offending item, as in
+//! [`crate::coverage::batch`] and [`crate::moc::batch`]: a serial pre-pass
+//! scans in index order, and the parallel pass materializes a whole chunk's
+//! outcomes (chunks themselves in index order) and walks them in index order
+//! before any is allowed to fail the call.  The error is therefore
+//! deterministic under any rayon schedule — `try_reduce`-style short-circuiting
+//! was rejected in PR #154 for exactly this reason.
+//!
+//! The two ops differ in *which* pass owns their domain errors, and the split
+//! is deliberate:
+//!
+//! * [`children_of`] validates every word up front (decodability, the target
+//!   order, the shared parent order), because it must know the row width
+//!   before it can allocate at all.  Its parallel pass cannot fail except by
+//!   panic.
+//! * [`common_ancestors`] validates only the *layout* up front and leaves the
+//!   per-group failures (an empty group, an undecodable word, words spanning
+//!   more than one base cell) to the parallel pass.  Hoisting them into the
+//!   pre-pass would break the lowest-index rule, not preserve it: the cheap
+//!   check (emptiness) would then out-rank the expensive one (mixed base
+//!   cells) regardless of index, so an empty group 7 would be reported ahead of
+//!   a mixed-base-cell group 2.
+
+use rayon::prelude::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use super::{common_ancestor, from_nested, to_nested, MAX_ORDER};
+
+/// Items processed per parallel chunk.
+///
+/// Same value and same reason as [`crate::moc::batch`]'s: the batch runs chunk
+/// by chunk so only one chunk's per-item outcomes are ever resident, and 2048
+/// is large enough that the per-chunk fork-join is noise against the work.
+const CHUNK: usize = 2048;
+
+/// Validate a ragged arrow list layout over `n_values` values.
+///
+/// Checks, in order: a non-empty `offsets` starting at 0, then per group
+/// (lowest index first) offset monotonicity and bounds, and finally the
+/// endpoint requirement `offsets[n_groups] == n_values`.  The offsets must
+/// **exactly cover** the value array — both endpoints are checked and each
+/// names which one failed — so stale or misaligned offsets that happen to stay
+/// in bounds cannot silently reduce a valid-looking wrong set.  Per-group
+/// errors name the offending group and are raised ahead of the endpoint check,
+/// so the lowest-index group is still what a caller sees first.
+///
+/// This is the offsets-only spelling of the same contract
+/// [`crate::coverage::batch`] and [`crate::moc::batch`] enforce.  They are not
+/// folded into one helper because each of those interleaves a *domain* check
+/// (the 3-vertex ring minimum; the per-MOC `max_cells` budget) inside the
+/// index-order loop, which is what makes their errors lowest-index across both
+/// kinds of failure — a shared helper would have to take that as a callback.
+/// This op has no such per-group pre-check (see the module's error posture), so
+/// it is the degenerate case, not a duplicate of a callback-shaped abstraction
+/// nothing else would use.
+fn validate_ragged(n_values: usize, offsets: &[i64]) -> Result<usize, String> {
+    if offsets.is_empty() {
+        return Err("offsets must have at least one element".to_string());
+    }
+    if offsets[0] != 0 {
+        return Err(format!("offsets must start at 0, got {}", offsets[0]));
+    }
+    let n_groups = offsets.len() - 1;
+    for i in 0..n_groups {
+        let (s, e) = (offsets[i], offsets[i + 1]);
+        if e < s {
+            return Err(format!(
+                "group {i}: offsets must be monotonically non-decreasing ({e} < {s})"
+            ));
+        }
+        if e as usize > n_values {
+            return Err(format!(
+                "group {i}: offset {e} exceeds value array length {n_values}"
+            ));
+        }
+    }
+    // Exact coverage: the last offset must land on the end of the value array.
+    // Checked after the per-group pass so an out-of-bounds group is still
+    // reported by index (the lowest-index rule).
+    if offsets[n_groups] as usize != n_values {
+        return Err(format!(
+            "offsets must end at the value count: offsets[{n_groups}] is {} but \
+             values has {n_values} entries",
+            offsets[n_groups]
+        ));
+    }
+    Ok(n_groups)
+}
+
+/// Run one item's kernel, turning a panic into an item-named error.
+///
+/// `label` is the noun the message leads with (`group` / `word`), so the
+/// message reads in the caller's own vocabulary.
+fn run_item<T, F>(label: &str, i: usize, kernel: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String>,
+{
+    match catch_unwind(AssertUnwindSafe(kernel)) {
+        Ok(r) => r.map_err(|e| format!("{label} {i}: {e}")),
+        Err(e) => Err(format!(
+            "{label} {i}: {}",
+            crate::panic_msg(e, "batch kernel panicked")
+        )),
+    }
+}
+
+/// Reduce many independent groups of words to their deepest common ancestors.
+///
+/// Plural *ancestors*: one ancestor word per input group (many→many), the
+/// segmented-reduce batch sibling of [`super::common_ancestor`].  Group `i` is
+/// `values[offsets[i]..offsets[i + 1]]` (arrow list layout, the same one
+/// [`crate::coverage::batch`] emits), and the result is dense — one `u64` per
+/// group, `offsets.len() - 1` of them — because the reduction is many→one per
+/// group, so no output offsets are needed.
+///
+/// Each output word is bit-identical to [`super::common_ancestor`] on that
+/// group alone, including its single-element case (a group of one word returns
+/// that word verbatim, kind preserved).
+///
+/// # Errors
+/// The lowest-index offending group, named in the message: a layout problem
+/// (see [`validate_ragged`]) or a group the scalar reduction refuses — empty,
+/// holding an undecodable word, or spanning more than one base cell.
+pub fn common_ancestors(values: &[u64], offsets: &[i64]) -> Result<Vec<u64>, String> {
+    let n_groups = validate_ragged(values.len(), offsets)?;
+    let mut out = Vec::with_capacity(n_groups);
+    // Chunk the parallel pass so only one chunk's outcomes are resident, and
+    // drain each chunk (in index order) before the next one is built.
+    for base in (0..n_groups).step_by(CHUNK) {
+        let end = (base + CHUNK).min(n_groups);
+        let words: Vec<Result<u64, String>> = (base..end)
+            .into_par_iter()
+            .map(|i| {
+                let (s, e) = (offsets[i] as usize, offsets[i + 1] as usize);
+                run_item("group", i, || {
+                    common_ancestor(&values[s..e]).map_err(|e| e.to_string())
+                })
+            })
+            .collect();
+        for word in words {
+            out.push(word?);
+        }
+    }
+    Ok(out)
+}
+
+/// A batch of children: a dense `(n_parents, width)` block, row-major.
+#[derive(Debug)]
+pub struct Children {
+    /// The children of every parent, row-major: parent `i`'s children are
+    /// `values[i * width..(i + 1) * width]`.
+    pub values: Vec<u64>,
+    /// `4**(order - parent_order)`, the children each parent yields.
+    pub width: usize,
+}
+
+/// Validate the parent words against the target `order`, returning the row width.
+///
+/// One index-order pass doing all three checks per word — decodability, then
+/// "not finer than the target", then agreement with word 0's order — so the
+/// error names the genuinely lowest-index offender across all three, rather
+/// than whichever check happens to run as its own earlier pass.
+///
+/// The shared-order requirement is what makes the result dense: rows of
+/// different widths would be a ragged layout, which is the shape this op exists
+/// to avoid.  It is also what every consumer already assumes — moczarr's
+/// `np.stack([generate_morton_children(int(w), level) for w in words])`
+/// (`dggs.py:310`) raises on rows of unequal width.
+fn validate_words(words: &[u64], order: u8) -> Result<usize, String> {
+    if order > MAX_ORDER {
+        return Err(format!(
+            "Order must be between 0 and {MAX_ORDER}, got {order}"
+        ));
+    }
+    let mut parent_order: Option<u8> = None;
+    for (i, &w) in words.iter().enumerate() {
+        let (o, _) = to_nested(w).ok_or_else(|| {
+            format!("word {i}: {w} is not a decodable morton word (empty sentinel or bad prefix)")
+        })?;
+        if o > order {
+            return Err(format!(
+                "word {i}: is at order {o}, finer than the requested order {order}; \
+                 children_of only refines (use clip2order to coarsen)"
+            ));
+        }
+        match parent_order {
+            None => parent_order = Some(o),
+            Some(p) if p != o => {
+                return Err(format!(
+                    "word {i}: is at order {o} but word 0 is at order {p}; children_of \
+                     returns a dense (n, 4**d) block, so every parent must sit at one order"
+                ))
+            }
+            Some(_) => {}
+        }
+    }
+    // An empty batch has no parent order to derive the width from; 1 (== 4**0)
+    // is the only width that is not a lie about a block with no rows.
+    let depth = parent_order.map_or(0, |p| order - p);
+    Ok(1usize << (2 * depth as u32))
+}
+
+/// Generate every parent's children at `order`, as a dense `(n, 4**d)` block.
+///
+/// The batch sibling of the Python-level `generate_morton_children`, whose
+/// wrapper coerces its input to a *single* parent.  All parents must sit at one
+/// order `p <= order`; `d = order - p`, so each yields exactly `4**d` children
+/// and the result is a fixed-width matrix rather than a ragged list.
+///
+/// Row `i` is bit-identical to the scalar generator on `words[i]` alone,
+/// including the `d == 0` case, where the parent comes back **verbatim** — that
+/// is what preserves a [`super::Kind::Point`] word, which round-tripping
+/// through [`super::from_nested`] would re-pack as an area cell.
+///
+/// # Errors
+/// The lowest-index offending word, named in the message: undecodable, finer
+/// than `order`, or at a different order from word 0.  Also an `order` past
+/// [`MAX_ORDER`], or a result whose element count overflows `usize`.
+pub fn children_of(words: &[u64], order: u8) -> Result<Children, String> {
+    let width = validate_words(words, order)?;
+    let total = words
+        .len()
+        .checked_mul(width)
+        .ok_or_else(|| format!("{} parents x {width} children each overflows", words.len()))?;
+    // Allocated once at the exact final size: no growth realloc, so no
+    // old-plus-new transient in the peak (see the module's memory posture).
+    let mut out = vec![0u64; total];
+
+    for base in (0..words.len()).step_by(CHUNK) {
+        let end = (base + CHUNK).min(words.len());
+        let block = &mut out[base * width..end * width];
+        let outcomes: Vec<Result<(), String>> = block
+            .par_chunks_mut(width)
+            .enumerate()
+            .map(|(k, row)| {
+                run_item("word", base + k, || {
+                    children_row(words[base + k], order, row);
+                    Ok(())
+                })
+            })
+            .collect();
+        for outcome in outcomes {
+            outcome?;
+        }
+    }
+    Ok(Children { values: out, width })
+}
+
+/// Write one parent's children at `order` into `row` (length `4**d`).
+///
+/// In NESTED space a cell's descendants at `order` are the contiguous block
+/// `nested * 4**d + [0, 4**d)`, so the row is a single ascending run packed
+/// back through [`super::from_nested`].
+fn children_row(word: u64, order: u8, row: &mut [u64]) {
+    let (o, nested) = to_nested(word).expect("validate_words accepted this word");
+    let depth = order - o;
+    if depth == 0 {
+        // Parity with the scalar generator, which returns the parent verbatim
+        // at `target_order == parent_order`.  Re-packing through `from_nested`
+        // would answer with the order-29 *area* cell for a `Kind::Point` word.
+        row[0] = word;
+        return;
+    }
+    let first = nested << (2 * depth as u32);
+    for (k, slot) in row.iter_mut().enumerate() {
+        *slot = from_nested(first + k as u64, order);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decimal_morton::{encode, encode_point, kind_of, Kind};
+
+    /// One area word in base `base` at `order`, tuples all `t`.
+    fn word(base: u8, order: u8, t: u8) -> u64 {
+        encode(base, &vec![t; order as usize], order)
+    }
+
+    // -- common_ancestors ---------------------------------------------------
+
+    #[test]
+    fn ancestors_match_the_scalar_per_group() {
+        // Group 0: the four order-5 children of an order-4 cell.  Group 1: a
+        // lone word.  Group 2: two cells sharing only their base cell.
+        let parent = word(3, 4, 1);
+        let (o4, n4) = to_nested(parent).unwrap();
+        let kids: Vec<u64> = (0..4).map(|k| from_nested((n4 << 2) + k, o4 + 1)).collect();
+        let mut values = kids.clone();
+        values.push(word(7, 6, 2));
+        values.push(word(9, 3, 0));
+        values.push(word(9, 3, 3));
+        let offsets = vec![0, 4, 5, 7];
+
+        let out = common_ancestors(&values, &offsets).unwrap();
+        assert_eq!(out.len(), 3);
+        for i in 0..3 {
+            let (s, e) = (offsets[i] as usize, offsets[i + 1] as usize);
+            assert_eq!(out[i], common_ancestor(&values[s..e]).unwrap(), "group {i}");
+        }
+        assert_eq!(out[0], parent);
+        // A group of one word comes back verbatim.
+        assert_eq!(out[1], values[4]);
+    }
+
+    #[test]
+    fn ancestors_span_more_than_one_chunk() {
+        // 2x CHUNK + 1 groups, so the chunk seam and the trailing partial chunk
+        // are both exercised.
+        let n = 2 * CHUNK + 1;
+        let values: Vec<u64> = (0..n as u64)
+            .map(|k| from_nested(k % (12 << 12), 6))
+            .collect();
+        let offsets: Vec<i64> = (0..=n as i64).collect();
+        let out = common_ancestors(&values, &offsets).unwrap();
+        assert_eq!(out.len(), n);
+        for i in 0..n {
+            assert_eq!(out[i], values[i], "singleton group {i} returns itself");
+        }
+    }
+
+    #[test]
+    fn ancestors_empty_batch() {
+        assert!(common_ancestors(&[], &[0]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn ancestors_errors_name_lowest_index_group() {
+        let values = vec![word(0, 4, 1), word(5, 4, 1), word(0, 4, 2)];
+        // An empty group has no ancestor, and is named.
+        let err = common_ancestors(&values, &[0, 1, 1, 3]).unwrap_err();
+        assert!(err.starts_with("group 1:"), "{err}");
+        // Mixed base cells: group 0 offends first even though group 1 is empty,
+        // which is the whole reason emptiness is not hoisted into the pre-pass.
+        let err = common_ancestors(&values, &[0, 2, 2, 3]).unwrap_err();
+        assert!(err.starts_with("group 0:"), "{err}");
+        assert!(err.contains("multiple base cells"), "{err}");
+        // Layout problems name the group too.
+        let err = common_ancestors(&values, &[0, 3, 1]).unwrap_err();
+        assert!(err.starts_with("group 1:"), "{err}");
+        let err = common_ancestors(&values, &[0, 1, 99]).unwrap_err();
+        assert!(err.starts_with("group 1:"), "{err}");
+    }
+
+    #[test]
+    fn ancestors_offsets_must_exactly_cover_the_values() {
+        let values = vec![word(0, 4, 1), word(0, 4, 2)];
+        let err = common_ancestors(&values, &[1, 2]).unwrap_err();
+        assert!(err.contains("must start at 0"), "{err}");
+        let err = common_ancestors(&values, &[0, 1]).unwrap_err();
+        assert!(err.contains("must end at the value count"), "{err}");
+        assert!(common_ancestors(&[], &[]).is_err());
+    }
+
+    #[test]
+    fn ancestors_lowest_index_holds_across_chunks() {
+        // Offenders at the start, in the middle, at a chunk seam, and at the
+        // end: each call must name the lowest-index one, not whichever rayon
+        // finished first.
+        let n = 3 * CHUNK;
+        // Every group is a pair of base-cell-0 words; an offender's second word
+        // comes from base cell 1, which has no common ancestor with the first.
+        let offenders = [0usize, 7, CHUNK - 1, CHUNK, 2 * CHUNK + 5, n - 1];
+        let other_base = from_nested((1 << 12) + 1, 6);
+        let offsets: Vec<i64> = (0..=n as i64).map(|i| 2 * i).collect();
+        let base_values: Vec<u64> = (0..2 * n as u64)
+            .map(|k| from_nested(k % (1 << 12), 6))
+            .collect();
+
+        // Heal the offenders one at a time, lowest first: each call must name
+        // the lowest *surviving* offender, across chunk seams and the tail.
+        for healed in 0..offenders.len() {
+            let mut values = base_values.clone();
+            for (rank, &off) in offenders.iter().enumerate() {
+                if rank >= healed {
+                    values[2 * off + 1] = other_base;
+                }
+            }
+            let err = common_ancestors(&values, &offsets).unwrap_err();
+            let expect = offenders[healed];
+            assert!(err.starts_with(&format!("group {expect}:")), "{err}");
+            assert!(err.contains("multiple base cells"), "{err}");
+        }
+        // With every offender healed the batch goes through.
+        assert_eq!(common_ancestors(&base_values, &offsets).unwrap().len(), n);
+    }
+
+    #[test]
+    fn ancestors_kernel_panic_is_caught_and_named() {
+        // No validated input reaches a panic in the reduction, so the capture
+        // half of the lowest-index guarantee is driven directly.
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let err = run_item::<u64, _>("group", 9, || panic!("kernel exploded")).unwrap_err();
+        std::panic::set_hook(hook);
+        assert!(err.starts_with("group 9:"), "{err}");
+        assert!(err.contains("kernel exploded"), "{err}");
+    }
+
+    // -- children_of --------------------------------------------------------
+
+    /// The scalar reference: one parent's children at `order`.
+    fn scalar_children(parent: u64, order: u8) -> Vec<u64> {
+        let (o, nested) = to_nested(parent).unwrap();
+        if o == order {
+            return vec![parent];
+        }
+        let d = order - o;
+        (0..(1u64 << (2 * d)))
+            .map(|k| from_nested((nested << (2 * d)) + k, order))
+            .collect()
+    }
+
+    #[test]
+    fn children_match_the_scalar_per_word() {
+        let words: Vec<u64> = (0..12).map(|b| word(b, 5, b % 4)).collect();
+        let out = children_of(&words, 8).unwrap();
+        assert_eq!(out.width, 64);
+        assert_eq!(out.values.len(), 12 * 64);
+        for (i, &w) in words.iter().enumerate() {
+            let row = &out.values[i * out.width..(i + 1) * out.width];
+            assert_eq!(row, &scalar_children(w, 8)[..], "word {i}");
+        }
+    }
+
+    #[test]
+    fn children_at_zero_depth_return_the_parent_verbatim() {
+        // Area words round-trip either way; a point word only survives the
+        // verbatim path, which is what the scalar promises.
+        let area = word(4, 9, 2);
+        let point = encode_point(4, &[2u8; MAX_ORDER as usize]);
+        assert!(matches!(kind_of(point), Kind::Point));
+        let out = children_of(&[area], 9).unwrap();
+        assert_eq!((out.width, out.values.as_slice()), (1, &[area][..]));
+        let out = children_of(&[point], MAX_ORDER).unwrap();
+        assert_eq!((out.width, out.values.as_slice()), (1, &[point][..]));
+    }
+
+    #[test]
+    fn children_order_zero_parents_and_max_order_target() {
+        // Order-0 parents (whole base cells) refine like any other order.
+        let bases: Vec<u64> = (0..12).map(|b| from_nested(b, 0)).collect();
+        let out = children_of(&bases, 2).unwrap();
+        assert_eq!(out.width, 16);
+        for (i, &b) in bases.iter().enumerate() {
+            assert_eq!(
+                &out.values[i * 16..(i + 1) * 16],
+                &scalar_children(b, 2)[..]
+            );
+        }
+        // The max-order target at d == 1, so the block stays small.
+        let parents = [word(0, MAX_ORDER - 1, 1), word(6, MAX_ORDER - 1, 3)];
+        let out = children_of(&parents, MAX_ORDER).unwrap();
+        assert_eq!(out.width, 4);
+        for (i, &p) in parents.iter().enumerate() {
+            assert_eq!(
+                &out.values[i * 4..(i + 1) * 4],
+                &scalar_children(p, MAX_ORDER)[..]
+            );
+        }
+    }
+
+    #[test]
+    fn children_empty_and_single() {
+        let out = children_of(&[], 6).unwrap();
+        assert!(out.values.is_empty());
+        assert_eq!(out.width, 1, "no parent order to derive a width from");
+        let w = word(2, 3, 1);
+        let out = children_of(&[w], 5).unwrap();
+        assert_eq!(out.values, scalar_children(w, 5));
+    }
+
+    #[test]
+    fn children_span_more_than_one_chunk() {
+        let n = 2 * CHUNK + 1;
+        let words: Vec<u64> = (0..n as u64)
+            .map(|k| from_nested(k % (12 << 12), 6))
+            .collect();
+        let out = children_of(&words, 8).unwrap();
+        assert_eq!(out.width, 16);
+        for i in [0, 1, CHUNK - 1, CHUNK, CHUNK + 1, n - 1] {
+            let row = &out.values[i * 16..(i + 1) * 16];
+            assert_eq!(row, &scalar_children(words[i], 8)[..], "word {i}");
+        }
+    }
+
+    #[test]
+    fn children_errors_name_lowest_index_word() {
+        let mut words: Vec<u64> = (0..4).map(|b| word(b, 5, 1)).collect();
+        // Finer than the target.
+        words.push(word(4, 9, 1));
+        let err = children_of(&words, 7).unwrap_err();
+        assert!(err.starts_with("word 4:"), "{err}");
+        assert!(err.contains("finer than the requested order 7"), "{err}");
+        // Coarser but disagreeing with word 0's order -> ragged rows, refused.
+        words[4] = word(4, 6, 1);
+        let err = children_of(&words, 8).unwrap_err();
+        assert!(err.starts_with("word 4:"), "{err}");
+        assert!(err.contains("word 0 is at order 5"), "{err}");
+        // The empty sentinel is undecodable and named.
+        words[2] = 0;
+        let err = children_of(&words, 8).unwrap_err();
+        assert!(err.starts_with("word 2:"), "{err}");
+        assert!(err.contains("not a decodable morton word"), "{err}");
+        // Word 0 itself finer than the target is named as index 0.
+        let err = children_of(&[word(0, 9, 1), word(0, 5, 1)], 6).unwrap_err();
+        assert!(err.starts_with("word 0:"), "{err}");
+    }
+
+    #[test]
+    fn children_bad_order_rejected() {
+        let err = children_of(&[word(0, 3, 1)], MAX_ORDER + 1).unwrap_err();
+        assert!(err.contains("Order must be between 0 and 29"), "{err}");
+    }
+
+    #[test]
+    fn children_lowest_index_holds_across_chunks() {
+        // An offender at a chunk seam and one late in the batch: the pre-pass
+        // scans in index order, so the earlier is always what surfaces.
+        let n = 3 * CHUNK;
+        let mut words: Vec<u64> = (0..n).map(|_| word(0, 4, 1)).collect();
+        words[2 * CHUNK + 3] = word(0, 9, 1);
+        words[CHUNK] = word(0, 9, 1);
+        let err = children_of(&words, 6).unwrap_err();
+        assert!(err.starts_with(&format!("word {CHUNK}:")), "{err}");
+        words[CHUNK] = word(0, 4, 1);
+        let err = children_of(&words, 6).unwrap_err();
+        assert!(
+            err.starts_with(&format!("word {}:", 2 * CHUNK + 3)),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn children_deterministic_across_runs() {
+        let words: Vec<u64> = (0..1000u64).map(|k| from_nested(k, 5)).collect();
+        let a = children_of(&words, 8).unwrap();
+        let b = children_of(&words, 8).unwrap();
+        assert_eq!(a.values, b.values);
+        assert_eq!(a.width, b.width);
+    }
+}

--- a/src_rust/src/decimal_morton/batch.rs
+++ b/src_rust/src/decimal_morton/batch.rs
@@ -72,14 +72,24 @@
 //! matching the scalar's (the same reasoning issue #108 used to keep
 //! `moc_to_order`'s ceiling a catchable `ValueError`).
 //!
-//! What this does **not** fence is an allocation the OS accepts and then cannot
-//! back: on an overcommitting kernel a request far larger than RAM succeeds at
-//! `try_reserve` time and the process is killed later, while it is being
-//! written.  Refusing those needs a *policy* ceiling (a `max_cells`-style
-//! budget), which is a separate question from making the allocator fallible.
-//! The `checked_mul` above is not that fence either: it only trips when the
-//! element count overflows `usize`, which is far past any allocation a machine
+//! What a fallible allocator does **not** fence is an allocation the OS accepts
+//! and then cannot back: on an overcommitting kernel a request far larger than
+//! RAM succeeds at `try_reserve` time and the process is killed later, while it
+//! is being written.  Refusing those needs a *policy* ceiling, which is what
+//! `max_cells` is.  The `checked_mul` is not that fence either: it only trips
+//! when the element count overflows `usize`, far past any allocation a machine
 //! would attempt.
+//!
+//! `max_cells` is therefore **opt-in, defaulting to `None`** — the opposite
+//! default from [`crate::moc::batch`]'s per-MOC budget, and deliberately so.
+//! `moc_to_order` defaults its budget *on* because a densify can explode from a
+//! tiny input (`Σ 4**(order - depth)`, issue #80) and the caller cannot cheaply
+//! predict the output.  `children_of`'s output is exactly `n * 4**d` cells,
+//! computable from the arguments before the call, so a default guard would
+//! refuse calls the caller already knows are fine.  Same parameter name,
+//! opposite default, because the two ops differ in exactly the property the
+//! default is about: predictability of the output size.  Note the `None`
+//! polarity inverts too — here `None` is "no budget", not "disable a default".
 //!
 //! # Error posture
 //!
@@ -325,13 +335,37 @@ fn validate_words(words: &[u64], order: u8) -> Result<usize, String> {
 /// is what preserves a [`super::Kind::Point`] word, which round-tripping
 /// through [`super::from_nested`] would re-pack as an area cell.
 ///
+/// `max_cells` is an **opt-in** budget on the result's cell count, `None` by
+/// default — the opposite default from [`crate::moc::batch`]'s, for the reason
+/// given in the module's allocation posture.  When set, a result larger than the
+/// budget is refused *before* anything is allocated.
+///
 /// # Errors
 /// The lowest-index offending word, named in the message: undecodable, finer
 /// than `order`, or at a different order from word 0.  Also an `order` past
-/// [`MAX_ORDER`], a result whose element count overflows `usize`, or a result
-/// the allocator refuses (see the module's allocation posture).
-pub fn children_of(words: &[u64], order: u8) -> Result<Children, String> {
+/// [`MAX_ORDER`], a result over `max_cells` when one is set, a result whose
+/// element count overflows `usize`, or a result the allocator refuses (see the
+/// module's allocation posture).
+pub fn children_of(words: &[u64], order: u8, max_cells: Option<u64>) -> Result<Children, String> {
     let width = validate_words(words, order)?;
+    // The caller's budget is checked first, and in `u128`, so it stays reachable
+    // at sizes where the element count would overflow `usize`.  That ordering is
+    // deliberate: `max_cells` is a caller-controlled argument condition (issue
+    // #108's framing) and answering it beats answering with an internal
+    // representability diagnostic the caller cannot act on.  The overflow guard
+    // below is therefore only reachable when no budget is set.
+    if let Some(budget) = max_cells {
+        let cells = words.len() as u128 * width as u128;
+        if cells > budget as u128 {
+            return Err(format!(
+                "children_of would generate {cells} cells ({} parents x {width} children \
+                 each) at order {order}, exceeding max_cells={budget}. Pass a larger \
+                 max_cells, or max_cells=None to proceed (risking OOM), or refine to a \
+                 coarser order.",
+                words.len()
+            ));
+        }
+    }
     let total = words
         .len()
         .checked_mul(width)
@@ -559,7 +593,7 @@ mod tests {
     #[test]
     fn children_match_the_scalar_per_word() {
         let words: Vec<u64> = (0..12).map(|b| word(b, 5, b % 4)).collect();
-        let out = children_of(&words, 8).unwrap();
+        let out = children_of(&words, 8, None).unwrap();
         assert_eq!(out.width, 64);
         assert_eq!(out.values.len(), 12 * 64);
         for (i, &w) in words.iter().enumerate() {
@@ -575,9 +609,9 @@ mod tests {
         let area = word(4, 9, 2);
         let point = encode_point(4, &[2u8; MAX_ORDER as usize]);
         assert!(matches!(kind_of(point), Kind::Point));
-        let out = children_of(&[area], 9).unwrap();
+        let out = children_of(&[area], 9, None).unwrap();
         assert_eq!((out.width, out.values.as_slice()), (1, &[area][..]));
-        let out = children_of(&[point], MAX_ORDER).unwrap();
+        let out = children_of(&[point], MAX_ORDER, None).unwrap();
         assert_eq!((out.width, out.values.as_slice()), (1, &[point][..]));
     }
 
@@ -585,7 +619,7 @@ mod tests {
     fn children_order_zero_parents_and_max_order_target() {
         // Order-0 parents (whole base cells) refine like any other order.
         let bases: Vec<u64> = (0..12).map(|b| from_nested(b, 0)).collect();
-        let out = children_of(&bases, 2).unwrap();
+        let out = children_of(&bases, 2, None).unwrap();
         assert_eq!(out.width, 16);
         for (i, &b) in bases.iter().enumerate() {
             assert_eq!(
@@ -595,7 +629,7 @@ mod tests {
         }
         // The max-order target at d == 1, so the block stays small.
         let parents = [word(0, MAX_ORDER - 1, 1), word(6, MAX_ORDER - 1, 3)];
-        let out = children_of(&parents, MAX_ORDER).unwrap();
+        let out = children_of(&parents, MAX_ORDER, None).unwrap();
         assert_eq!(out.width, 4);
         for (i, &p) in parents.iter().enumerate() {
             assert_eq!(
@@ -607,11 +641,11 @@ mod tests {
 
     #[test]
     fn children_empty_and_single() {
-        let out = children_of(&[], 6).unwrap();
+        let out = children_of(&[], 6, None).unwrap();
         assert!(out.values.is_empty());
         assert_eq!(out.width, 1, "no parent order to derive a width from");
         let w = word(2, 3, 1);
-        let out = children_of(&[w], 5).unwrap();
+        let out = children_of(&[w], 5, None).unwrap();
         assert_eq!(out.values, scalar_children(w, 5));
     }
 
@@ -621,7 +655,7 @@ mod tests {
         let words: Vec<u64> = (0..n as u64)
             .map(|k| from_nested(k % (12 << 12), 6))
             .collect();
-        let out = children_of(&words, 8).unwrap();
+        let out = children_of(&words, 8, None).unwrap();
         assert_eq!(out.width, 16);
         for i in [0, 1, CHUNK - 1, CHUNK, CHUNK + 1, n - 1] {
             let row = &out.values[i * 16..(i + 1) * 16];
@@ -634,21 +668,21 @@ mod tests {
         let mut words: Vec<u64> = (0..4).map(|b| word(b, 5, 1)).collect();
         // Finer than the target.
         words.push(word(4, 9, 1));
-        let err = children_of(&words, 7).unwrap_err();
+        let err = children_of(&words, 7, None).unwrap_err();
         assert!(err.starts_with("word 4:"), "{err}");
         assert!(err.contains("finer than the requested order 7"), "{err}");
         // Coarser but disagreeing with word 0's order -> ragged rows, refused.
         words[4] = word(4, 6, 1);
-        let err = children_of(&words, 8).unwrap_err();
+        let err = children_of(&words, 8, None).unwrap_err();
         assert!(err.starts_with("word 4:"), "{err}");
         assert!(err.contains("word 0 is at order 5"), "{err}");
         // The empty sentinel is undecodable and named.
         words[2] = 0;
-        let err = children_of(&words, 8).unwrap_err();
+        let err = children_of(&words, 8, None).unwrap_err();
         assert!(err.starts_with("word 2:"), "{err}");
         assert!(err.contains("not a decodable morton word"), "{err}");
         // Word 0 itself finer than the target is named as index 0.
-        let err = children_of(&[word(0, 9, 1), word(0, 5, 1)], 6).unwrap_err();
+        let err = children_of(&[word(0, 9, 1), word(0, 5, 1)], 6, None).unwrap_err();
         assert!(err.starts_with("word 0:"), "{err}");
     }
 
@@ -658,18 +692,58 @@ mod tests {
         // this through Rust's infallible allocator, which aborts the process;
         // the fallible path names the byte count and returns.
         let bases: Vec<u64> = (0..12).map(|b| from_nested(b, 0)).collect();
-        let err = children_of(&bases, 25).unwrap_err();
+        let err = children_of(&bases, 25, None).unwrap_err();
         assert!(err.contains("allocation failed"), "{err}");
         assert!(err.contains("108086391056891904 bytes"), "{err}");
         // The `checked_mul` guard still owns the >= 2**64 *element* case, which
         // is a different message and sits far above any real allocation.
-        let err = children_of(&[from_nested(0, 0); 64], MAX_ORDER).unwrap_err();
+        let err = children_of(&[from_nested(0, 0); 64], MAX_ORDER, None).unwrap_err();
         assert!(err.contains("children each overflows"), "{err}");
     }
 
     #[test]
+    fn children_max_cells_refuses_before_allocating() {
+        // 12 order-4 parents to order 8 is 12 x 256 = 3072 cells.
+        let parents: Vec<u64> = (0..12).map(|b| word(b, 4, 1)).collect();
+        let unset = children_of(&parents, 8, None).unwrap();
+        // Exactly at the budget passes, and byte-for-byte matches the unset run.
+        let at = children_of(&parents, 8, Some(3072)).unwrap();
+        assert_eq!((at.width, &at.values), (unset.width, &unset.values));
+        // One under refuses, naming the size and the budget.
+        let err = children_of(&parents, 8, Some(3071)).unwrap_err();
+        assert!(err.contains("would generate 3072 cells"), "{err}");
+        assert!(err.contains("exceeding max_cells=3071"), "{err}");
+        // A budget of 0 refuses anything with rows, but an empty batch is 0
+        // cells and still goes through.
+        assert!(children_of(&parents, 8, Some(0)).is_err());
+        assert!(children_of(&[], 8, Some(0)).unwrap().values.is_empty());
+    }
+
+    #[test]
+    fn children_max_cells_outranks_the_overflow_guard() {
+        // 64 order-0 parents at order 29 is 2**64 elements, which the
+        // `checked_mul` guard owns when no budget is set.  With a budget the
+        // caller's own condition answers instead: it is compared in u128, so it
+        // is reachable at sizes the element count cannot represent.  Deliberate
+        // -- an explicit argument condition beats an internal representability
+        // diagnostic the caller cannot act on (issue #108's framing).
+        let bases = [from_nested(0, 0); 64];
+        let err = children_of(&bases, MAX_ORDER, None).unwrap_err();
+        assert!(err.contains("children each overflows"), "{err}");
+        let err = children_of(&bases, MAX_ORDER, Some(1 << 20)).unwrap_err();
+        assert!(err.contains("exceeding max_cells=1048576"), "{err}");
+        assert!(err.contains("18446744073709551616 cells"), "{err}");
+        // Same ordering against the allocation failure: 12 order-0 parents to
+        // order 25 aborted before the previous fold and is `allocation failed`
+        // with no budget, but a budget answers first.
+        let bases: Vec<u64> = (0..12).map(|b| from_nested(b, 0)).collect();
+        let err = children_of(&bases, 25, Some(1 << 20)).unwrap_err();
+        assert!(err.contains("exceeding max_cells=1048576"), "{err}");
+    }
+
+    #[test]
     fn children_bad_order_rejected() {
-        let err = children_of(&[word(0, 3, 1)], MAX_ORDER + 1).unwrap_err();
+        let err = children_of(&[word(0, 3, 1)], MAX_ORDER + 1, None).unwrap_err();
         assert!(err.contains("Order must be between 0 and 29"), "{err}");
     }
 
@@ -681,10 +755,10 @@ mod tests {
         let mut words: Vec<u64> = (0..n).map(|_| word(0, 4, 1)).collect();
         words[2 * CHUNK + 3] = word(0, 9, 1);
         words[CHUNK] = word(0, 9, 1);
-        let err = children_of(&words, 6).unwrap_err();
+        let err = children_of(&words, 6, None).unwrap_err();
         assert!(err.starts_with(&format!("word {CHUNK}:")), "{err}");
         words[CHUNK] = word(0, 4, 1);
-        let err = children_of(&words, 6).unwrap_err();
+        let err = children_of(&words, 6, None).unwrap_err();
         assert!(
             err.starts_with(&format!("word {}:", 2 * CHUNK + 3)),
             "{err}"
@@ -694,8 +768,8 @@ mod tests {
     #[test]
     fn children_deterministic_across_runs() {
         let words: Vec<u64> = (0..1000u64).map(|k| from_nested(k, 5)).collect();
-        let a = children_of(&words, 8).unwrap();
-        let b = children_of(&words, 8).unwrap();
+        let a = children_of(&words, 8, None).unwrap();
+        let b = children_of(&words, 8, None).unwrap();
         assert_eq!(a.values, b.values);
         assert_eq!(a.width, b.width);
     }

--- a/src_rust/src/decimal_morton/batch.rs
+++ b/src_rust/src/decimal_morton/batch.rs
@@ -318,7 +318,12 @@ fn validate_words(words: &[u64], order: u8) -> Result<usize, String> {
         }
     }
     // An empty batch has no parent order to derive the width from; 1 (== 4**0)
-    // is the only width that is not a lie about a block with no rows.
+    // is the only width that is not a lie about a block with no rows.  Deriving
+    // it would mean taking a `parent_order` argument, making callers repeat --
+    // in the empty case alone -- what the data carries in every other case.
+    // Consumers needing a typed empty already special-case it (moczarr's
+    // `dggs.py` builds `(0, 4**(level - order))` on its own empty branch,
+    // because it knows its source order there).  Ruled on issue #156.
     let depth = parent_order.map_or(0, |p| order - p);
     Ok(1usize << (2 * depth as u32))
 }

--- a/src_rust/src/decimal_morton/batch.rs
+++ b/src_rust/src/decimal_morton/batch.rs
@@ -26,13 +26,25 @@
 //! ragged batches' docs:
 //!
 //! * [`common_ancestors`]: peak is **input copy + result + one chunk of
-//!   `Result`s**.  The result is one word per group, so with `g` groups over
-//!   `n` words it is `g / n` of the input copy — for the t-digest consumer
-//!   (groups of 2-3 centroids) about a third of it — and the chunk term is
-//!   2048 x 32 B = 64 KiB regardless of batch size.  The input copy is
-//!   therefore the peak, always.  Measured over 5M groups of 3 order-9 words:
-//!   152.6 MiB of input, a 38.1 MiB result, and a 191.9 MiB peak — 1.01x the
-//!   `input + result` model, and **5.0x the result alone**.
+//!   `Result`s + the reduction's own scratch**.  The result is one word per
+//!   group, so with `g` groups over `n` words it is `g / n` of the input copy —
+//!   for the t-digest consumer (groups of 2-3 centroids) about a third of it —
+//!   and the chunk term is 2048 x 32 B = 64 KiB regardless of batch size.  The
+//!   scratch is [`super::common_ancestor`]'s own `others` buffer, 16 B per
+//!   non-first word in the group it is reducing, held for that whole reduction:
+//!   one per group in flight, so the term is
+//!   `min(threads, groups) * 16 B * max_group_size`.  It scales with the
+//!   **largest single group**, not with `n` — which is why it is invisible in
+//!   the consumer shape and dominant in a skewed one.  Measured over 5M groups
+//!   of 3 order-9 words: 152.6 MiB of input, a 38.1 MiB result, and a 191.9 MiB
+//!   peak — 1.01x the `input + result` model, **5.0x the result alone**, and a
+//!   scratch term under a kilobyte.  Two skewed shapes, same order and
+//!   instrument: 40 groups of 1M words peaks at 458.6 MiB against a 305.2 MiB
+//!   `input + result` model (**1.50x**, excess 153.4 MiB against the 152.6 MiB
+//!   the formula predicts), and a single 20M-word group at 460.0 MiB against
+//!   152.7 MiB (**3.01x**, excess 307.3 against a predicted 305.2).  So the
+//!   input copy is the peak for small groups only; size a worker off the
+//!   largest group when groups are large.
 //! * [`children_of`]: peak is **input copy + result + one chunk of
 //!   `Result`s**, and here the result dominates by construction — it is
 //!   `4**d` times the input.  The output is allocated once at its exact final

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -1119,6 +1119,56 @@ fn rust_moc_min(py: Python<'_>, morton: PyReadonlyArray1<u64>) -> PyResult<u64> 
         .map_err(|e| PyValueError::new_err(format!("moc_min: {}", e)))
 }
 
+/// Deepest common ancestor of each of many groups of words, in one call
+/// (issue #156).
+///
+/// Ragged input in arrow list layout — group `i` is
+/// `values[offsets[i]..offsets[i+1]]`, the same pair `rust_polygons_coverage_mocs`
+/// returns.  The output is **dense**: one `u64` per group, `offsets.len() - 1` of
+/// them, each identical to the scalar `rust_moc_min` on that group alone.  Raises
+/// `ValueError` naming the lowest-index offending group (a layout problem, or a
+/// group that is empty / undecodable / spanning more than one base cell).  The
+/// GIL is released for the whole batch; rayon parallelizes across groups.
+#[pyfunction]
+fn rust_common_ancestors(
+    py: Python<'_>,
+    values: PyReadonlyArray1<u64>,
+    offsets: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let vals = values.to_vec()?;
+    let off = offsets.to_vec()?;
+
+    match py.allow_threads(|| decimal_morton::batch::common_ancestors(&vals, &off)) {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(msg) => Err(PyValueError::new_err(msg)),
+    }
+}
+
+/// Children of many parent words at a target order, in one call (issue #156).
+///
+/// The parents must all sit at one order `p <= order`, so every one yields the
+/// same `4**(order - p)` children and the result is a **dense** `(n, 4**d)`
+/// row-major array — no ragged offsets.  Row `i` is identical to the scalar
+/// `generate_morton_children` on `words[i]` alone, the `d == 0` case included
+/// (the parent comes back verbatim, preserving a point word's kind).  Raises
+/// `ValueError` naming the lowest-index offending word (undecodable, finer than
+/// `order`, or at a different order from word 0).  The GIL is released for the
+/// whole batch; rayon parallelizes across parents.
+#[pyfunction]
+fn rust_children_of(py: Python<'_>, words: PyReadonlyArray1<u64>, order: u8) -> PyResult<PyObject> {
+    let data = words.to_vec()?;
+    let n = data.len();
+
+    let children = py
+        .allow_threads(|| decimal_morton::batch::children_of(&data, order))
+        .map_err(PyValueError::new_err)?;
+    let arr = numpy::ndarray::Array2::from_shape_vec((n, children.width), children.values)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok(PyArray2::from_owned_array_bound(py, arr)
+        .into_any()
+        .unbind())
+}
+
 /// Compute morton indices tracing a linestring (open polyline).
 ///
 /// # Arguments
@@ -1544,6 +1594,8 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_moc_minus, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_xor, m)?)?;
     m.add_function(wrap_pyfunction!(rust_moc_min, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_common_ancestors, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_children_of, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
     #[cfg(feature = "descent-stats")]
     m.add_function(wrap_pyfunction!(rust_descent_stats_take, m)?)?;

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -1152,8 +1152,10 @@ fn rust_common_ancestors(
 /// `generate_morton_children` on `words[i]` alone, the `d == 0` case included
 /// (the parent comes back verbatim, preserving a point word's kind).  Raises
 /// `ValueError` naming the lowest-index offending word (undecodable, finer than
-/// `order`, or at a different order from word 0).  The GIL is released for the
-/// whole batch; rayon parallelizes across parents.
+/// `order`, or at a different order from word 0), or naming the byte count when
+/// the `4**d` result is a size the allocator refuses — the block is allocated
+/// fallibly so an unservable `order` is catchable rather than an `abort()`.  The
+/// GIL is released for the whole batch; rayon parallelizes across parents.
 #[pyfunction]
 fn rust_children_of(py: Python<'_>, words: PyReadonlyArray1<u64>, order: u8) -> PyResult<PyObject> {
     let data = words.to_vec()?;

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -1156,13 +1156,25 @@ fn rust_common_ancestors(
 /// the `4**d` result is a size the allocator refuses — the block is allocated
 /// fallibly so an unservable `order` is catchable rather than an `abort()`.  The
 /// GIL is released for the whole batch; rayon parallelizes across parents.
+///
+/// `max_cells` is an **opt-in** budget on the result's cell count, `None` by
+/// default — the opposite default from `rust_mocs_to_orders`' per-MOC budget,
+/// because this op's output size is exactly `n * 4**d` and therefore predictable
+/// by the caller (see the batch module's allocation posture).  When set, an
+/// over-budget result is refused before anything is allocated.
 #[pyfunction]
-fn rust_children_of(py: Python<'_>, words: PyReadonlyArray1<u64>, order: u8) -> PyResult<PyObject> {
+#[pyo3(signature = (words, order, max_cells=None))]
+fn rust_children_of(
+    py: Python<'_>,
+    words: PyReadonlyArray1<u64>,
+    order: u8,
+    max_cells: Option<u64>,
+) -> PyResult<PyObject> {
     let data = words.to_vec()?;
     let n = data.len();
 
     let children = py
-        .allow_threads(|| decimal_morton::batch::children_of(&data, order))
+        .allow_threads(|| decimal_morton::batch::children_of(&data, order, max_cells))
         .map_err(PyValueError::new_err)?;
     let arr = numpy::ndarray::Array2::from_shape_vec((n, children.width), children.values)
         .map_err(|e| PyValueError::new_err(e.to_string()))?;


### PR DESCRIPTION
Refs #156 — **phase 3 of many** (not `Closes`). Phase 1 (`mocs_to_orders` + the `mortie/moc.py` domain split) merged as `42db670`; this is the dense-output pair.

## What this does

Adds the two **dense-output** batches from the [issue #156 audit table](https://github.com/espg/mortie/issues/156#issuecomment-5223411794). They are one phase because they share a property: their results are fixed-shape arrays, so neither needs an arrow offsets pair on the way out, and both are the cheapest high-value entries in the sweep.

### `common_ancestors(values, offsets) -> uint64[N]`

Segmented reduce of `common_ancestor` / `moc_min`. Ragged in (the arrow list layout `polygons_to_morton_mocs` and `mocs_to_orders` already use), **dense out** — one word per group, because the reduction is many→one per group.

The consumer is a per-worker inner loop, not a one-off: zagg's t-digest merge runs `for j in np.flatnonzero(~single):` at [`src/zagg/stats/tdigest.py:198`](https://github.com/englacial/zagg/blob/main/src/zagg/stats/tdigest.py#L198) — once per multi-member centroid (δ=512), per cell, per build **and** per fold, on every Lambda worker, at 65,536 cells/shard in the shipped ATL03 config. That module's own docstring at `tdigest.py:177-179` already names it "the same O(n) Python-loop shape issue #279 removed".

One contract decision worth flagging: an **empty group is an error**, not an empty slot. `mocs_to_orders` lets an empty item densify to an empty slice, but a many→one reduction over no words has no answer — the scalar refuses empty input, so the batch refuses that group by index.

### `children_of(words, order, max_cells=None) -> uint64[N, 4**d]`

Batch of `generate_morton_children`, whose wrapper coerces to a scalar parent (`tools.py:1167`). Every parent must sit at one order `p <= order`, so each yields exactly `4**d` children for `d = order - p` and the result is a dense `(n, 4**d)` block.

That shared-order requirement is not new — it is what the consumers already assume, because the loop this replaces ends in `np.stack`, which raises on rows of unequal width. moczarr wrote the gap down in its own source: `src/moczarr/dggs.py:310` is `np.stack([generate_morton_children(int(w), level) for w in words])`, with the comment at `dggs.py:302-305` saying *"there is still no vectorized many-parent children kernel"*. zagg calls the scalar the same way per sub-chunk on every worker (`src/zagg/grids/healpix.py:199`) and per shard in the shardmap reprojection (`src/zagg/catalog/shardmap.py:708`).

`d == 0` returns the parents **verbatim**, matching the scalar exactly — that is what preserves a `Kind::Point` word, which a `to_nested`/`from_nested` round trip would re-pack as the order-29 *area* cell. Pinned by a test.

The result block is allocated **fallibly** (`try_reserve_exact`, not `vec![0u64; total]`), so an `order` whose `(n, 4**d)` block the allocator refuses is a catchable `ValueError` naming the byte count rather than a `handle_alloc_error` → `abort()` that kills the interpreter. An **opt-in** `max_cells=None` budget (espg's ruling on question (2)) refuses an over-budget `n * 4**d` result before anything is allocated, which is the only thing that fences an allocation an overcommitting OS accepts and then cannot back. See "Allocation posture" below.

## House pattern

Per #153/#154/#160, and unchanged here:

- **Plural naming** marks many→many; `children_of` keeps espg's named form from the audit.
- **Strict ragged contract** on the one ragged input: `offsets[0] == 0`, `offsets[-1] == len(values)`, exact coverage, both endpoints checked and each naming which one failed.
- **Shared scalar params** (`order`), not per-item arrays.
- **Lowest-index fail-fast**: serial validation pre-pass + per-item capture + index-order scan. No `try_reduce` short-circuiting (rejected in #154 for nondeterminism).
- **rayon under `py.allow_threads`**, chunked at `CHUNK = 2048`.

**Rust module placement is the house pattern too, not a deviation.** `src_rust/src/decimal_morton/batch.rs` sits exactly where the tree already puts batch submodules — `coverage/batch.rs`, `moc/batch.rs`, and PR #158's `wkb/batch.rs` are all `<domain>/batch.rs`. That is the axis espg ruled in the [plan revision](https://github.com/espg/mortie/issues/156#issuecomment-5223710911) item 1 ("Rust side follows the same axis"), and *both* scalar kernels this phase wraps (`common_ancestor`, and the `to_nested`/`from_nested` pair the child generator is built from) live in `decimal_morton.rs`. An earlier revision of this description called it a deviation; it is not.

One place this phase genuinely does differ from its siblings:

- **`children_of` validates entirely up front; `common_ancestors` does not.** `children_of` must know the row width before it can allocate, so decodability / target order / shared-order all run in the pre-pass. `common_ancestors` validates only the *layout* up front and leaves per-group failures to the parallel pass. The reason is **cost**, not error ordering: the mixed-base-cell check *is* the reduction (it decodes every word in every group), so a pre-pass that ran it would run the whole kernel twice. Hoisting per se would not break the lowest-index rule — a single index-order pre-pass doing *all* the checks preserves it, which is exactly what `validate_words` and `moc::batch`'s validator do. Only a *partial* hoist would invert (emptiness alone, as its own earlier pass, would report an empty group 7 ahead of a mixed-base-cell group 2). An earlier revision of this description gave the partial-hoist inversion as the reason for the whole design; that was wrong, and the module header now says cost.

### The one place the lowest-index promise is qualified

For `common_ancestors` the rule holds **within** each pass, not across the two. Layout is a whole-batch serial pre-pass, so a bad offset at a high index outranks a domain failure at a low one:

```python
v, o = ...            # group 0 spans two base cells (domain error at index 0)
o[8] = 99             # group 7's offset is out of bounds (layout error at index 7)
mortie.common_ancestors(v, o)
# ValueError: group 7: offset 99 exceeds value array length 20
```

That ordering is deliberate and now documented and pinned by a test (`test_ancestors_layout_errors_outrank_domain_errors`, plus a Rust twin): a layout failure says the `offsets` array itself is wrong, and the group indices a domain error would be *reported by* are read out of that same array, so "your offsets are broken" is the failure a caller has to fix first. `moc::batch` has no such split only because its domain check (a per-MOC cell budget, computable without reducing) is cheap enough to interleave into the index-order layout loop; this op's is not. Among the domain classes themselves the lowest index always wins — verified with offenders straddling the `CHUNK` seam in both directions, 200 repeats per configuration, one distinct answer every time.

On reuse: there were no `pub(crate)` helpers in `coverage::batch` on `main` to reuse (all its helpers are private, and PR #158 is unmerged). `validate_ragged` here is the offsets-only spelling of the same contract. It is deliberately **not** folded into a shared helper with `coverage::batch` / `moc::batch`, because each of those interleaves a *domain* check (the 3-vertex ring minimum; the per-MOC `max_cells` budget) inside the index-order loop, which is exactly what makes their errors lowest-index across both kinds of failure — a shared helper would have to take that as a callback, and this op has no such per-item pre-check. Raised as a question below.

## Allocation posture — `children_of` must not abort the process

`vec![0u64; total]` goes through Rust's **infallible** allocator, whose failure path is `handle_alloc_error` → `abort()`. Measured on the pre-fix branch (macOS/arm64, 64 GiB, 10 cores), each row a fresh subprocess:

| call | scalar `np.stack([generate_morton_children(...)])` | batch, before | batch, after |
|---|---|---|---|
| 1 order-0 parent → order 29 (2.00 EiB) | `MemoryError`, exit 0 | `memory allocation of 2305843009213693952 bytes failed`, **SIGABRT exit 134** | `ValueError: 1 parents x 288230376151711744 children each needs 2305843009213693952 bytes; allocation failed`, exit 0 |
| 12 order-0 parents → order 25 (96 PiB) | `MemoryError`, exit 0 | **SIGABRT exit 134** | `ValueError: ... needs 108086391056891904 bytes; allocation failed`, exit 0 |
| 64 order-0 parents → order 29 (≥2⁶⁴ elements) | — | `ValueError: 64 parents x 288230376151711744 children each overflows` | unchanged |
| 100k order-6 parents → order 11 (819 MB) | works | works | works |

The existing `checked_mul` guard only trips at ≥2⁶⁴ *elements* — ≥64 parents at `d=29` — so every reachable blowup sat below it and aborted. The fix is `try_reserve_exact` on the result block; no new constant, no policy.

**What it does not fence.** An allocation an overcommitting OS accepts and then cannot back still ends in a kill: 1M order-6 parents → order 14 (`d=8`, 488 GiB) is `try_reserve`-clean and dies at exit 137 (SIGKILL) while the block is being written. That is not a batch-specific gap — numpy accepts the same request (`np.empty((1_000_000, 65_536), np.uint64)` allocates 488 GiB on this box without raising, while `(12, 1125899906842624)` raises `MemoryError`), so the scalar loop dies at the same shape. After the fix the two agree everywhere measured: both raise catchably where the allocator refuses, both are killed where the OS overcommits. Refusing the second class needs a *policy* ceiling — that is what the opt-in `max_cells` added in `73b0681` is, per espg's ruling on question (2) below.

**Cost of the fix.** `try_reserve_exact` + `resize` loses `vec![0; n]`'s `alloc_zeroed`, so the block is memset once before the parallel pass overwrites it. Median of 5 runs, same box, before → after: `d=4` 14.4x → 12.9x, `d=8` 8.6x → 7.4x (≈10–15% off the largest results; no measurable change at `d ≤ 2`, where the result is small). The zero-fill is recoverable by writing into `spare_capacity_mut()` as `MaybeUninit` and a single `set_len` — one `unsafe` line in a module that has none today, which is why it is not in this diff. Flagged as question (6).

## Memory posture — measured, not asserted

#162 exists because merged batches claimed "result + one chunk" while omitting the mandatory input copy (`to_vec()` is required for a numpy-borrowed slice to cross `allow_threads`). Both docstrings here state the real model, with numbers.

| op | input | result | measured peak | vs `input + result` | vs result alone |
|---|---|---|---|---|---|
| `common_ancestors`, 5M groups × 3 order-9 words | 152.6 MiB | 38.1 MiB | **191.9 MiB** | 1.01x | **5.0x** |
| `children_of`, 1M order-6 parents → order 9 | 7.6 MiB | 488.3 MiB | **497.1 MiB** | 1.00x | 1.02x |

Dense output makes the model short: **input copy + result + one chunk of `Result`s**, where the chunk term is a flat 2048 × 32 B = 64 KiB regardless of batch size. `children_of` additionally allocates its block once at the exact final size, so there is no growth-realloc transient and no ragged assembly copy.

### `common_ancestors` has a fourth term, and it scales with the largest group

An earlier revision of this description said "for `common_ancestors` the input copy is the peak, **always**". That is false for skewed groups. The scalar kernel builds its own scratch — `let mut others: Vec<(u8, u64)> = Vec::with_capacity(rest.len())` (`decimal_morton.rs:429`), 16 B per non-first word — and holds it for the whole reduction, one per group in flight. So the term is `min(threads, n_groups) * 16 B * max_group_size`: it grows with the **largest single group**, which is the one dimension the quoted case (groups of 3) holds constant.

Measured on this branch, every input loaded from disk, same instrument and order across rows:

| shape | input | documented model | measured Δpeak | ratio | excess | scratch the formula predicts |
|---|---|---|---|---|---|---|
| 5M groups × 3 words, order 9 | 152.6 MiB | 190.8 MiB | 191.9 MiB | **1.01x** | ~0 | < 1 KiB |
| 40 groups × 1M words, order 9 | 305.2 MiB | 305.2 MiB | 458.6 MiB | **1.50x** | 153.4 MiB | 152.6 MiB |
| 1 group × 20M words, order 9 | 152.6 MiB | 152.7 MiB | 460.0 MiB | **3.01x** | 307.3 MiB | 305.2 MiB |

The excess is the missing term to within 2 MiB in both skewed rows. The docstrings in `decimal_morton/batch.rs` and `mortie/moc.py` now state the four-term model and both regimes: size a worker off `input + result` for many small groups, and off the largest group when groups are large. For the t-digest consumer (groups of 2–3) the term is noise, which is why the original measurement was accurate and the generalisation was not.

A measurement caveat worth recording, because it bit this PR: sampled RSS **under-counts the input copy** when the input is *constructed* in-process, since `to_vec` is then served out of already-resident freed heap. The same 5M-group case reads as 77.3 MiB that way versus 191.9 MiB when the input is loaded from disk (independently reproduced to 0.1 MiB). The numbers above are the load-from-disk ones.

## Benchmarks — honest read

`benchmarks/measure_common_ancestors.py` and `benchmarks/measure_children_of.py`, 10 cores, macOS/arm64, ≥100k items except where noted. The `children_of` scalar side is timed as the consumer actually writes it, `np.stack` included, since a caller cannot get a dense block out of the scalar without it.

**These are medians of 5 runs, with the observed range.** An earlier revision of this description published single-run figures (87.8x / 61.7x / 15.4x / 14.6x / 18.7x); re-measuring showed the batch side is a few hundredths of a second at small `d`, so one shot lands anywhere in a ±20% band and those numbers sat at the top of it. The medians below are lower and reproducible; the ranges are printed so a re-run that disagrees by 10% is not a surprise. Both scripts now carry the table in their module docstring.

| case | result | median speedup | range over 5 runs |
|---|---|---|---|
| `common_ancestors`, 100k groups of 3, order 9 | — | **17.3x** | 15.0–18.3 |
| `common_ancestors`, 500k groups of 2, order 9 | — | **19.6x** | 18.1–19.9 |
| `children_of`, 100k parents, 6 → 7 (d=1) | 3.1 MiB | **74.2x** | 68.5–84.8 |
| `children_of`, 100k parents, 6 → 8 (d=2) | 12.2 MiB | **50.3x** | 48.1–55.9 |
| `children_of`, 100k parents, 6 → 9 (d=3) | 48.8 MiB | **28.2x** | 26.3–28.8 |
| `children_of`, 100k parents, 6 → 10 (d=4) | 195.3 MiB | **12.9x** | 12.3–13.1 |
| `children_of`, 2k parents, 6 → 14 (**d=8, the shipped zagg shape**) | 1000.0 MiB | **7.4x** | 7.1–7.5 |

These land high, unlike phase 1's `mocs_to_orders` (2.96–5.80x), and the reason is the same reason phase 1 landed low: what dominates. Phase 1 was bandwidth-bound on writing a flat result far larger than its input, so removing the boundary cost bought little. Here the per-item work is tiny (a shared-prefix walk over 2-3 words; a contiguous nested run) and the result is small or written once at exact size, so the Python boundary *is* the wall — which is what a batch removes.

**The `children_of` decay does not flatten inside the published range, and `d=8` is below its low end.** 74x at d=1 falls to 12.9x at d=4 as the result turns it back into a bandwidth measurement, and keeps falling to **7.4x at d=8** — the 65,536 cells/shard shape zagg ships, and the only row a zagg or moczarr reader will actually look for. An earlier revision predicted d=8 would "sit nearer the low end" of a d≤4 table; it sits below it. The row is now measured, not predicted, and the benchmark docstring says so. (Independently measured at 8.71x pre-fix on real order-6 shard keys from the in-tree Antarctic drainage-basin fixture coarsened with `clip2order(6, ...)`, 644 distinct keys — the random-parent corpus and the real-key corpus agree.)

## Testing

- `mortie/tests/test_dense_batch.py` — **51 tests**, all passing (42 in phase 3a/3b, 4 folding review, 5 folding the `max_cells` ruling).
- 21 Rust unit tests in `decimal_morton::batch`; `cargo test --lib` is 297 passed / 0 failed / 1 ignored.
- Full suite: **1119 passed, 12 skipped**.

Coverage of the acceptance list:

- **Per-item byte parity with the scalar twin**, over randomized inputs *and* the in-tree Antarctic basin fixtures (`Ant_Grounded_DrainageSystem_Polygons.txt`) — for `common_ancestors` grouped by `split_base_cells`, for `children_of` at real order-9 shard keys refined the way zagg's two-step does it. Plus `test_children_stacked_scalar_loop_is_reproduced_exactly`, which is moczarr's `np.stack([...])` expression verbatim.
- **Edges**: order-0 parents and base-cell groups; order-29 / max-order targets; single item; empty batch (`(0,)` and `(0, 1)`); a group of one word (returns that word); `children_of` with `d = 0` (identity, and the point-word case); a word finer than `order` (refused, index named); mixed parent orders (refused, index named); undecodable words (refused, index named).
- **Allocation**: an unservable result is a `ValueError` a plain `except ValueError` catches (the PR #160 lesson, where a `PanicException` escaped even `except Exception`) — and, because `pytest.raises` cannot observe an `abort()`, a subprocess test asserts the interpreter *survives* it (exit 0). Plus a 819 MB result that must still go through, so the fallible allocation is not a de facto budget.
- **Error ordering**: the layout-before-domain asymmetry is pinned in both Python and Rust, so it cannot drift silently.
- **Determinism**: `test_ancestors_lowest_index_holds_across_chunk_boundaries` and its `children_of` twin are parametrized over offenders at indices `0, 1, 7, CHUNK-1, CHUNK, CHUNK+1, 2*CHUNK+5, 3*CHUNK-1` and repeat each 5x; the `..._wins_over_later_offenders` pair plants five simultaneous offenders and heals them lowest-first, asserting the named index each time (3x per step). Plus 10-run byte-equality checks on both ops.
- **GIL genuinely released**: a pure-Python counter thread ticks during a large call, same instrument as `test_threading.test_gil_released_during_rust_compute`.

## Gates

`cargo fmt --check` clean · `cargo clippy --lib --benches` — **no new warnings** (the remaining 7 are the pre-existing `coverage/tests.rs`, `geo2mort.rs`, `prefix_trie.rs` set) · `cargo test --lib` 297 passed / 1 ignored · `pytest` 1119 passed / 12 skipped · `flake8 mortie --select=E9,F63,F7,F82` clean · `flake8 --max-line-length=88` clean on every touched file (the three `tools.py` hits are pre-existing, at lines 958/975/986 — the `on_antimeridian` one is #151 item 4) · `numpydoc lint` clean on `moc.py`, `tools.py`, `__init__.py` · doctests pass on both touched modules.

## Phases

- [x] **Phase 3a** — `common_ancestors`: Rust kernel + binding + `mortie/moc.py` wrapper, beside its scalar twin.
- [x] **Phase 3b** — `children_of`: Rust kernel + binding + `mortie/tools.py` wrapper, beside its scalar twin.
- [x] Tests, benchmarks, `USAGE.md`, `docs/api/moc.md`, `docs/api/tools.md`, `__init__` exports.
- [x] Adversarial self-review folded (4 findings: fallible allocation, the scratch term, the hoisting justification, the bench table).
- [x] espg's rulings on questions (2) and (3) folded: opt-in `max_cells`, and `(0, 1)` kept with the reasoning recorded.

Landed as one commit because the two share a Rust module and a test file; splitting them would have been file-splitting, not phasing.

## Questions for review

1. **`tools.py` is now 1,451 lines, against this repo's ~1,000-line aim** (CLAUDE.md §4). It was already over at 1,354 before this PR. The instruction for this phase was explicit: put `children_of` beside its scalar twin and note that #159 will move the hierarchy/order functions to `orders.py` later, and do **not** start the #159 split here (it is `blocked`). I followed that, but the rule says stop and raise when a file would cross, so raising it.

   **The remedy has a deadline that is earlier than "after the sweep."** `children_of` genuinely belongs beside `generate_morton_children`, so 1,451 is the right place to land *this* phase — but every remaining phase lands in the same file too: phase 4's `words_to_decimals` / `hive_paths`, phase 5's `mort2polygons` / `mort2bboxes`. That puts `tools.py` near ~1,700 by the end of the sweep. So the ask is to unblock **#159 before phase 4**, not after phase 5, so the split absorbs the batch additions instead of chasing them. `mortie/moc.py` is fine at 644; `src_rust/src/decimal_morton/batch.rs` is 702.

   Second, smaller point: mortie's CLAUDE.md has **no 1,200-line raise** — that is zagg's standing ruling (its issues #351/#358), not this repo's, and it should not be inherited silently. If you want the same allowance here it belongs in mortie's own CLAUDE.md as its own decision.

2. **~~Should `children_of` carry a `max_cells` budget?~~ RULED — option (b), implemented in `73b0681`.** espg ruled the opt-in form: *"it costs adopters nothing and gives a Lambda worker a way to fail catchably instead of being killed."*

   `children_of(words, order, max_cells=None)`. Unset — the default — behaviour is **byte-identical** to before: same SHA-256 over `children_of` output across six shapes (d=0, 3, 5, 8 spans, order-0 and order-29 edges, plus the empty batch) on the pre- and post-change builds, and the `try_reserve` path and its documented overcommit residual are untouched. Set, the result's `n * 4**d` cell count is checked **before anything is allocated** and refused with a `ValueError` in `moc_to_order`'s wording, so the two read alike:

   ```
   ValueError: children_of would generate 65536000000 cells (1000000 parents x 65536
   children each) at order 14, exceeding max_cells=134217728. Pass a larger max_cells,
   or max_cells=None to proceed (risking OOM), or refine to a coarser order.
   ```

   That is the case that motivated the ruling and it is the acceptance test: zagg's shipped `d=8` shape at fleet scale (1M order-6 parents → order 14, 488 GiB) is the one `try_reserve` **cannot** refuse, because the OS accepts the reservation and kills the process mid-write. With a worker's own ceiling set it comes back catchable.

   **Why the default is the opposite of `moc_to_order`'s, stated in the docstring** so the API does not read as inconsistent: `moc_to_order` defaults its budget *on* because a densify explodes from a tiny input (`Σ 4**(order - depth)`, #80) and the caller cannot cheaply predict the output; `children_of`'s output is exactly `n * 4**d`, computable from the arguments before the call, so a default guard would refuse calls the caller already knows are fine. Same parameter name, opposite default, for a stated reason. The `None` polarity inverts with it — here `None` means *no budget*, not *disable a default* — and that is written down too.

   Follows #108's ruled semantics where they apply: `ValueError` (a caller-controlled argument condition, not a failed allocation), caller-settable, negative rejected, and clamped at `u64::MAX` the way `mocs_to_orders` clamps.

   **One ordering decision, made deliberately and pinned:** the budget is compared in `u128` and checked **ahead of** the `checked_mul` element-count guard, so an explicit budget answers even for a request too large to represent as a `usize`. 64 order-0 parents at order 29 gives `... children each overflows` with no budget and `... exceeding max_cells=1048576` with one; likewise the budget outranks the `allocation failed` refusal. Rationale: an explicit argument condition is more actionable than an internal representability diagnostic the caller cannot act on (#108's framing). Pinned in `children_max_cells_outranks_the_overflow_guard` (Rust) and `test_children_max_cells_outranks_the_overflow_guard` (Python).

   **The residual stands and is why (b) beat (a):** an unset budget still cannot close the overcommit class, and the scalar loop has the identical gap (`np.empty((1_000_000, 65_536), np.uint64)` allocates 488 GiB on this box without raising). A caller-set ceiling is the only thing that closes it, which is exactly what (b) provides without changing anyone's behaviour by default.

3. **~~`children_of` on an empty batch returns shape `(0, 1)`.~~ RULED — keep `(0, 1)`; no `parent_order=` parameter.** No behaviour change; the reasoning is now recorded in the docstring (`722ec03`) so it is not re-opened. With no words there is no source order to derive `4**(order - parent_order)` from, so a derived width would require callers to pass `parent_order` — repeating, in the empty case alone, what the data carries in every other case. Consumers that need a typed empty already special-case it: moczarr's `dggs.py` builds `(0, 4**(level - order))` on its own empty branch precisely because it knows its source order at that point. So `(0, 1)` is the honest shape for "no rows, width unknown", and the width belongs in the consumer-side special case.

4. **The three ragged validators are now structurally parallel and not shared** (`coverage::batch`, `moc::batch`, `decimal_morton::batch`). I deliberately did not refactor: the other two interleave a domain check inside the index-order loop, so unifying them needs a callback, and touching `coverage/batch.rs` right now would collide with PR #158. Worth a follow-up issue after #158 merges, or leave the three as they are?

5. **Should `common_ancestors` grow a `split_base_cells`-style escape?** Today a group spanning more than one base cell refuses the whole call by index, matching the scalar. That is the right default, but the real Antarctic fixtures *do* straddle base cells — the parity test has to run `split_base_cells` first to build groups the reduction accepts. If a consumer wants "reduce each group, and partition the ones that straddle", that is a different op and I would rather it be filed than smuggled in here.

6. **Should `children_of` recover the zero-fill the fallible allocation costs?** `try_reserve_exact` + `resize` memsets the block before the parallel pass overwrites every word of it — measured at ~10–15% on the large-`d` shapes (`d=4` 14.4x → 12.9x, `d=8` 8.6x → 7.4x; no measurable change at `d ≤ 2`). Writing into `spare_capacity_mut()` as `[MaybeUninit<u64>]` and calling `set_len` after the last chunk succeeds removes it entirely and is provably fully-initialised (`words.len()` rows × `width` = `total`, and an early return drops the vec at len 0). It costs one `unsafe` line in a module that has none today — `unsafe` in this crate is currently confined to `arrow_ffi.rs` and the C ABI export. I left it out rather than expand the scope of a correctness fold; say the word and it is a two-line follow-up.

