### PR TITLE
toc word: temporal order coverage (issue #175)

### DIFF
--- a/docs/api/toc.md
+++ b/docs/api/toc.md
@@ -1,0 +1,28 @@
+# mortie.toc
+
+The toc word — temporal order coverage (issue #175): one `uint64` packing
+either an exact nanosecond timestamp or a conservative time range, sortable
+as a plain unsigned integer and closed under a semilattice merge. Times are
+ns since 1850-01-01 on a continuous, leap-free, GPS-aligned scale; the
+`datetime64` / GPS converters are the only place leap seconds exist. Not an
+IVOA T-MOC. These flat-array elementwise ops are the type's scalar surface
+(the same relationship [mortie.moc](moc.md) has to its ops over one cover);
+the ragged many-cover plurals land in [mortie.batch](batch.md) when the
+interval-set algebra (issue #177) activates. The names stay flat on the
+package (`mortie.time2toc`, ...).
+
+::: mortie.toc
+    options:
+      members:
+        - time2toc
+        - span2toc
+        - toc2time
+        - toc_merge
+        - toc_reduce
+        - toc_is_range
+        - toc_overlaps
+        - toc_contains
+        - from_datetime64
+        - to_datetime64
+        - from_gps_ns
+        - to_gps_ns

--- a/docs/api/toc.md
+++ b/docs/api/toc.md
@@ -26,3 +26,7 @@ package (`mortie.time2toc`, ...).
         - to_datetime64
         - from_gps_ns
         - to_gps_ns
+        - Q_START_NS
+        - Q_END_NS
+        - TOC_MAX_NS
+        - GPS_EPOCH_NS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - buffer: api/buffer.md
       - coverage: api/coverage.md
       - moc: api/moc.md
+      - toc: api/toc.md
       - prefix_trie: api/prefix_trie.md
       - geometry: api/geometry.md
       - batch: api/batch.md

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -106,8 +106,12 @@ from .rank_xy import (
 
 # toc word -- temporal order coverage (issue #175)
 from .toc import (
+    from_datetime64,
+    from_gps_ns,
     span2toc,
     time2toc,
+    to_datetime64,
+    to_gps_ns,
     toc2time,
     toc_contains,
     toc_is_range,
@@ -183,6 +187,10 @@ __all__ = [
     'toc_is_range',
     'toc_overlaps',
     'toc_contains',
+    'from_datetime64',
+    'to_datetime64',
+    'from_gps_ns',
+    'to_gps_ns',
 ]
 
 # morton_index datatype (phase 5) + Arrow interop (phase 4) for issue #35. The

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -104,6 +104,18 @@ from .rank_xy import (
     xy_to_rank,
 )
 
+# toc word -- temporal order coverage (issue #175)
+from .toc import (
+    span2toc,
+    time2toc,
+    toc2time,
+    toc_contains,
+    toc_is_range,
+    toc_merge,
+    toc_overlaps,
+    toc_reduce,
+)
+
 __all__ = [
     'geo2mort',
     'mort2geo',
@@ -163,6 +175,14 @@ __all__ = [
     'morton_polygon_from_array',
     'rank_to_xy',
     'xy_to_rank',
+    'time2toc',
+    'span2toc',
+    'toc2time',
+    'toc_merge',
+    'toc_reduce',
+    'toc_is_range',
+    'toc_overlaps',
+    'toc_contains',
 ]
 
 # morton_index datatype (phase 5) + Arrow interop (phase 4) for issue #35. The

--- a/mortie/tests/test_toc.py
+++ b/mortie/tests/test_toc.py
@@ -12,11 +12,16 @@ import numpy as np
 import pytest
 
 from mortie.toc import (
+    GPS_EPOCH_NS,
     Q_END_NS,
     Q_START_NS,
     TOC_MAX_NS,
+    from_datetime64,
+    from_gps_ns,
     span2toc,
     time2toc,
+    to_datetime64,
+    to_gps_ns,
     toc2time,
     toc_contains,
     toc_is_range,
@@ -295,3 +300,83 @@ def test_dtype_and_domain_validation():
     # The last valid instant is fine for both encoders.
     assert time2toc(TOC_MAX_NS - 1) > 0
     assert span2toc(0, TOC_MAX_NS - 1) > 0
+
+
+# ── timescale boundary (phase 3) ────────────────────────────────────────
+
+
+def test_gps_epoch_constant_against_date_arithmetic():
+    # The 1850 -> GPS-epoch constant is a plain proleptic-Gregorian day
+    # count (the internal scale is leap-free and ticks with GPS).
+    from datetime import date
+    days = (date(1980, 1, 6) - date(1850, 1, 1)).days
+    assert days == 47_486
+    assert GPS_EPOCH_NS == days * 86_400 * 10**9
+
+
+def test_gps_epoch_zero_offset_identity():
+    # At the GPS epoch TAI - UTC = 19, so GPS - UTC = 0: the UTC and GPS
+    # entry points agree exactly there.
+    assert from_datetime64("1980-01-06") == GPS_EPOCH_NS
+    assert from_gps_ns(0) == GPS_EPOCH_NS
+    assert to_gps_ns(GPS_EPOCH_NS) == 0
+    assert to_datetime64(GPS_EPOCH_NS) == np.datetime64("1980-01-06", "ns")
+
+
+def test_epoch_identity_and_pre1972_convention():
+    # Zero offset before 1972 pins the epoch identity exactly.
+    assert from_datetime64("1850-01-01") == 0
+    assert to_datetime64(0) == np.datetime64("1850-01-01", "ns")
+    with pytest.raises(ValueError, match="before the 1850"):
+        from_datetime64("1849-12-31T23:59:59")
+
+
+def test_gps_conversion_exact_roundtrip():
+    rng = np.random.default_rng(53)
+    gps = rng.integers(0, TOC_MAX_NS - GPS_EPOCH_NS, size=500,
+                       dtype=np.uint64)
+    np.testing.assert_array_equal(to_gps_ns(from_gps_ns(gps)), gps)
+    with pytest.raises(ValueError, match="before the GPS epoch"):
+        to_gps_ns(GPS_EPOCH_NS - 1)
+
+
+def test_2018_utc_conversion_matches_golden():
+    # The same instant the golden timestamp fixture pins: 61,362 days of
+    # 86,400 s past 1850, +18 s GPS-UTC.
+    t = from_datetime64("2018-01-01")
+    assert t == 5_301_590_418_000_000_000
+    assert to_gps_ns(t) == 1_198_800_018 * 10**9  # published GPS seconds
+
+
+def test_leap_second_boundary_pinned():
+    # A leap second was inserted at the end of 2016-12-31: one UTC second
+    # across the boundary spans two internal seconds.
+    before = from_datetime64("2016-12-31T23:59:59")
+    after = from_datetime64("2017-01-01T00:00:00")
+    assert after - before == 2 * 10**9
+    # An instant inside the inserted leap second renders into the
+    # following UTC second (datetime64 cannot express 23:59:60).
+    inside = before + int(1.5e9)
+    assert to_datetime64(inside) == np.datetime64(
+        "2017-01-01T00:00:00.500000000")
+
+
+def test_datetime64_roundtrip_exact_modern_era():
+    rng = np.random.default_rng(59)
+    lo = np.datetime64("1972-01-01", "ns").astype(np.int64)
+    hi = np.datetime64("2100-01-01", "ns").astype(np.int64)
+    naive = rng.integers(lo, hi, size=2000, dtype=np.int64)
+    dt = naive.astype("datetime64[ns]")
+    np.testing.assert_array_equal(to_datetime64(from_datetime64(dt)), dt)
+    # ... and through a toc timestamp word.
+    t = from_datetime64(dt)
+    starts, _ = toc2time(time2toc(t))
+    np.testing.assert_array_equal(to_datetime64(starts), dt)
+
+
+def test_datetime64_scalar_forms():
+    t = from_datetime64(np.datetime64("2020-05-17T12:34:56.789"))
+    assert isinstance(t, int)
+    assert isinstance(to_datetime64(t), np.datetime64)
+    with pytest.raises(ValueError, match="ceiling"):
+        from_datetime64("2150-01-01")

--- a/mortie/tests/test_toc.py
+++ b/mortie/tests/test_toc.py
@@ -67,7 +67,7 @@ def test_golden_epoch_timestamp():
 
 
 def test_golden_2018_timestamp():
-    # 2018-01-01T00:00:00 UTC = 61,362 proleptic-Gregorian days of 86,400 s
+    # 2018-01-01T00:00:00 UTC = 61,361 proleptic-Gregorian days of 86,400 s
     # past 1850-01-01, plus GPS-UTC = 18 s: 5,301,590,418e9 ns internal.
     t = 5_301_590_418_000_000_000
     assert time2toc(t) == 10_603_180_836_377_408_512
@@ -254,6 +254,16 @@ def test_inverted_window_raises():
         toc_overlaps(time2toc(0), 10, 5)
 
 
+def test_empty_window_matches_nothing():
+    # An empty window intersects and contains nothing -- for both
+    # variants, even when it sits strictly inside a range's envelope.
+    q = 5 * Q_END_NS
+    words = np.array([time2toc(q), span2toc(q - Q_END_NS, q + Q_END_NS)],
+                     dtype=np.uint64)
+    assert not toc_overlaps(words, q, q).any()
+    assert not toc_contains(words, q, q).any()
+
+
 # ── validation, shapes, and edges ───────────────────────────────────────
 
 
@@ -341,7 +351,7 @@ def test_gps_conversion_exact_roundtrip():
 
 
 def test_2018_utc_conversion_matches_golden():
-    # The same instant the golden timestamp fixture pins: 61,362 days of
+    # The same instant the golden timestamp fixture pins: 61,361 days of
     # 86,400 s past 1850, +18 s GPS-UTC.
     t = from_datetime64("2018-01-01")
     assert t == 5_301_590_418_000_000_000
@@ -380,3 +390,44 @@ def test_datetime64_scalar_forms():
     assert isinstance(to_datetime64(t), np.datetime64)
     with pytest.raises(ValueError, match="ceiling"):
         from_datetime64("2150-01-01")
+    # A 0-d ndarray classifies as array, matching the word ops.
+    out = from_datetime64(np.array("2020-05-17", dtype="datetime64[ns]"))
+    assert isinstance(out, np.ndarray) and out.shape == (1,)
+
+
+def test_pre1972_zero_offset_and_1972_step():
+    from datetime import date
+
+    # Zero offset before 1972: exactly the proleptic day count.
+    days = (date(1960, 1, 1) - date(1850, 1, 1)).days
+    assert from_datetime64("1960-01-01") == days * 86_400 * 10**9
+    # The 9 s backward step across 1972-01-01: the last 9 SI seconds of
+    # 1971 alias early 1972 ...
+    assert (from_datetime64("1971-12-31T23:59:55")
+            == from_datetime64("1972-01-01T00:00:04"))
+    assert (from_datetime64("1972-01-01")
+            == from_datetime64("1971-12-31T23:59:51"))
+    # ... and aliased instants render on the 1972 side of the step.
+    assert to_datetime64(from_datetime64("1971-12-31T23:59:55")) == \
+        np.datetime64("1972-01-01T00:00:04", "ns")
+    # From 1972 on the mapping is invertible (the roundtrip test sweeps
+    # the modern era; this pins the very first invertible instant).
+    assert to_datetime64(from_datetime64("1972-01-01")) == \
+        np.datetime64("1972-01-01", "ns")
+
+
+def test_timescale_empty_arrays():
+    assert from_datetime64(np.array([], dtype="datetime64[ns]")).shape == (0,)
+    empty = np.empty(0, dtype=np.uint64)
+    assert to_datetime64(empty).shape == (0,)
+    assert from_gps_ns(empty).shape == (0,)
+    assert to_gps_ns(empty).shape == (0,)
+
+
+def test_timescale_domain_errors():
+    with pytest.raises(ValueError, match="2\\*\\*63"):
+        to_datetime64(1 << 63)
+    with pytest.raises(ValueError, match="ceiling"):
+        from_gps_ns(TOC_MAX_NS)
+    with pytest.raises(ValueError, match="q_start_ns"):
+        toc_overlaps(time2toc(0), -1, 5)

--- a/mortie/tests/test_toc.py
+++ b/mortie/tests/test_toc.py
@@ -1,0 +1,297 @@
+"""Tests for the toc word (temporal order coverage, issue #175).
+
+The golden u64 fixtures here are normative: words persist on disk, so the
+bit layout, constants, merge results, and sort order they pin must never
+change.  The property tests mirror the cargo suite in src_rust/src/toc.rs
+at array level.
+"""
+
+from functools import reduce
+
+import numpy as np
+import pytest
+
+from mortie.toc import (
+    Q_END_NS,
+    Q_START_NS,
+    TOC_MAX_NS,
+    span2toc,
+    time2toc,
+    toc2time,
+    toc_contains,
+    toc_is_range,
+    toc_merge,
+    toc_overlaps,
+    toc_reduce,
+)
+
+FLAG = 1 << 31
+LOW_MASK = FLAG - 1
+
+
+def py_timestamp(t):
+    """Reference splice: t_ns with a 1 flag bit inserted at position 31."""
+    return ((t >> 31) << 32) | FLAG | (t & LOW_MASK)
+
+
+def py_range(a, b):
+    """Reference range encode: floored start, strictly-greater end ceiling."""
+    return ((a >> 31) << 32) | ((b >> 32) + 1)
+
+
+def rand_times(rng, n):
+    """Random valid internal times as uint64."""
+    return rng.integers(0, TOC_MAX_NS, size=n, dtype=np.uint64)
+
+
+def rand_words(rng, n):
+    """A mixed batch of valid timestamp and range words."""
+    t = time2toc(rand_times(rng, n))
+    x, y = rand_times(rng, n), rand_times(rng, n)
+    r = span2toc(np.minimum(x, y), np.maximum(x, y))
+    pick = rng.integers(0, 2, size=n).astype(bool)
+    return np.where(pick, t, r)
+
+
+# ── golden fixtures (normative) ─────────────────────────────────────────
+
+
+def test_golden_epoch_timestamp():
+    # 1850-01-01T00:00:00 (t = 0): only the flag bit set.
+    assert time2toc(0) == 0x8000_0000
+
+
+def test_golden_2018_timestamp():
+    # 2018-01-01T00:00:00 UTC = 61,362 proleptic-Gregorian days of 86,400 s
+    # past 1850-01-01, plus GPS-UTC = 18 s: 5,301,590,418e9 ns internal.
+    t = 5_301_590_418_000_000_000
+    assert time2toc(t) == 10_603_180_836_377_408_512
+    assert toc2time(10_603_180_836_377_408_512) == (t, t)
+
+
+def test_golden_range_fixtures():
+    # Straddling the 2^32 grid line at 3*2^32: s = 5, e = 4.
+    assert span2toc(3 * 2**32 - 500_000_000,
+                    3 * 2**32 + 500_000_000) == 21_474_836_484
+    # End exactly on the grid at 7*2^32: e = 8, strictly greater.
+    w = span2toc(7 * 2**32 - 10**9, 7 * 2**32)
+    assert w == (13 << 32) | 8
+    _, end = toc2time(w)
+    assert end == 8 * 2**32 > 7 * 2**32
+
+
+# ── parity with the Rust scalars ────────────────────────────────────────
+
+
+def test_encode_parity_with_reference_splice():
+    rng = np.random.default_rng(175)
+    times = rand_times(rng, 500)
+    words = time2toc(times)
+    assert words.dtype == np.uint64
+    for t, w in zip(times.tolist(), words.tolist()):
+        assert w == py_timestamp(t)
+    x, y = rand_times(rng, 500), rand_times(rng, 500)
+    a, b = np.minimum(x, y), np.maximum(x, y)
+    words = span2toc(a, b)
+    for aa, bb, w in zip(a.tolist(), b.tolist(), words.tolist()):
+        assert w == py_range(aa, bb)
+
+
+def test_timestamp_roundtrip_exact():
+    rng = np.random.default_rng(17)
+    times = rand_times(rng, 1000)
+    starts, ends = toc2time(time2toc(times))
+    np.testing.assert_array_equal(starts, times)
+    np.testing.assert_array_equal(ends, times)
+    assert not toc_is_range(time2toc(times)).any()
+
+
+def test_envelope_conservatism_and_width():
+    rng = np.random.default_rng(23)
+    x, y = rand_times(rng, 1000), rand_times(rng, 1000)
+    a, b = np.minimum(x, y), np.maximum(x, y)
+    # Force some ends exactly onto the 2^32 grid (the strictly-greater
+    # ceiling edge); keep the pairs ordered.
+    b[::8] = (b[::8] >> np.uint64(32)) << np.uint64(32)
+    a = np.minimum(a, b)
+    starts, ends = toc2time(span2toc(a, b))
+    assert (starts <= a).all(), "start floors"
+    assert (b < ends).all(), "end strictly greater, half-open envelope"
+    assert (ends - starts <= (b - a) + np.uint64(Q_START_NS + Q_END_NS)).all()
+    assert toc_is_range(span2toc(a, b)).all()
+
+
+# ── merge laws (mirroring the cargo property suite) ─────────────────────
+
+
+def test_merge_idempotent_including_timestamps():
+    rng = np.random.default_rng(29)
+    w = rand_words(rng, 1000)
+    np.testing.assert_array_equal(toc_merge(w, w), w)
+    # The load-bearing case: equal timestamps must stay timestamps.
+    t = time2toc(123_456_789_012)
+    assert toc_merge(t, t) == t
+    assert not toc_is_range(t)
+
+
+def test_merge_commutative_associative():
+    rng = np.random.default_rng(31)
+    a, b, c = (rand_words(rng, 1000) for _ in range(3))
+    np.testing.assert_array_equal(toc_merge(a, b), toc_merge(b, a))
+    np.testing.assert_array_equal(toc_merge(toc_merge(a, b), c),
+                                  toc_merge(a, toc_merge(b, c)))
+    # Mixed case: an equal-timestamp pair inside a triple.
+    np.testing.assert_array_equal(toc_merge(toc_merge(a, a), c),
+                                  toc_merge(a, toc_merge(a, c)))
+
+
+def test_reduce_matches_pairwise_fold_and_permutations():
+    rng = np.random.default_rng(37)
+    for n in (1, 2, 3, 7, 100):
+        words = rand_words(rng, n)
+        # Plant a duplicated timestamp inside the larger reductions.
+        if n >= 3:
+            words[1] = words[0] = time2toc(int(rand_times(rng, 1)[0]))
+        expected = reduce(toc_merge, (int(w) for w in words))
+        assert toc_reduce(words) == expected
+        assert toc_reduce(words[::-1].copy()) == expected
+        assert toc_reduce(rng.permutation(words)) == expected
+
+
+def test_reduce_singleton_and_all_equal():
+    t = time2toc(42)
+    assert toc_reduce([int(t)]) == t
+    assert toc_reduce(np.full(17, t, dtype=np.uint64)) == t
+
+
+def test_reduce_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        toc_reduce(np.empty(0, dtype=np.uint64))
+
+
+def test_merged_envelope_contains_inputs():
+    rng = np.random.default_rng(41)
+    words = rand_words(rng, 200)
+    fs, fe = toc2time(toc_reduce(words))
+    starts, ends = toc2time(words)
+    is_rng = toc_is_range(words)
+    assert (fs <= starts).all()
+    assert (ends[is_rng] <= fe).all()
+    assert (starts[~is_rng] < fe).all()
+
+
+# ── sort property ───────────────────────────────────────────────────────
+
+
+def test_sort_order_is_conservative_start_order():
+    rng = np.random.default_rng(43)
+    words = np.sort(rand_words(rng, 2000))
+    starts, _ = toc2time(words)
+    quantized = (starts >> np.uint64(31)) << np.uint64(31)
+    assert (np.diff(quantized.astype(np.int64)) >= 0).all()
+
+
+def test_tied_quantum_tiebreaks():
+    base = 1_000_000 * Q_START_NS
+    ts_lo = time2toc(base + 7)
+    ts_hi = time2toc(base + Q_START_NS - 1)
+    rng_short = span2toc(base + 100, base + 200)
+    rng_long = span2toc(base + 100, base + 10 * Q_END_NS)
+    assert rng_short < rng_long < ts_lo < ts_hi
+
+
+# ── window predicates ───────────────────────────────────────────────────
+
+
+def test_timestamp_window_semantics_exact():
+    t = 10**15
+    w = time2toc(t)
+    # Half-open window: inclusive start, exclusive end.
+    assert toc_overlaps(w, t, t + 1)
+    assert toc_contains(w, t, t + 1)
+    assert not toc_overlaps(w, t + 1, t + 2)
+    assert not toc_overlaps(w, t - 2, t)  # exclusive end excludes t
+    assert not toc_contains(w, t - 2, t)
+
+
+def test_range_window_uses_conservative_bounds():
+    a, b = 10 * Q_END_NS + 100, 10 * Q_END_NS + 200
+    w = span2toc(a, b)
+    start, end = toc2time(w)
+    # Envelope grazing: a window touching only the envelope slop still
+    # reports an overlap (documented over-report, never an under-report).
+    assert toc_overlaps(w, int(start), int(start) + 1)
+    assert not toc_overlaps(w, 0, int(start))
+    assert not toc_overlaps(w, int(end), int(end) + 1)
+    # Containment is envelope containment: the real [a, b] fits a snug
+    # window but the envelope does not (documented under-report) ...
+    assert not toc_contains(w, a, b + 1)
+    # ... and the envelope itself does.
+    assert toc_contains(w, int(start), int(end))
+
+
+def test_overlaps_never_under_reports_contains_never_over_reports():
+    rng = np.random.default_rng(47)
+    x, y = rand_times(rng, 2000), rand_times(rng, 2000)
+    a, b = np.minimum(x, y), np.maximum(x, y)
+    words = span2toc(a, b)
+    q0, q1 = TOC_MAX_NS // 4, TOC_MAX_NS // 2
+    hits = toc_overlaps(words, q0, q1)
+    true_overlap = (a < q1) & (b >= q0)
+    assert (hits | ~true_overlap).all(), "a real overlap must be reported"
+    inside = toc_contains(words, q0, q1)
+    truly_inside = (a >= q0) & (b < q1)
+    assert (~inside | truly_inside).all(), "contains must not over-report"
+
+
+def test_inverted_window_raises():
+    with pytest.raises(ValueError, match="window"):
+        toc_overlaps(time2toc(0), 10, 5)
+
+
+# ── validation, shapes, and edges ───────────────────────────────────────
+
+
+def test_empty_arrays():
+    empty = np.empty(0, dtype=np.uint64)
+    assert time2toc(empty).shape == (0,)
+    assert span2toc(empty, empty).shape == (0,)
+    starts, ends = toc2time(empty)
+    assert starts.shape == ends.shape == (0,)
+    assert toc_merge(empty, empty).shape == (0,)
+    assert toc_is_range(empty).shape == (0,)
+    assert toc_overlaps(empty, 0, 1).shape == (0,)
+    assert toc_contains(empty, 0, 1).shape == (0,)
+
+
+def test_scalar_in_scalar_out():
+    assert isinstance(time2toc(0), int)
+    assert isinstance(span2toc(0, 5), int)
+    assert isinstance(toc2time(time2toc(0))[0], int)
+    assert isinstance(toc_merge(time2toc(0), time2toc(1)), int)
+    assert isinstance(toc_is_range(time2toc(0)), bool)
+    assert isinstance(toc_overlaps(time2toc(0), 0, 1), bool)
+
+
+def test_broadcasting():
+    times = np.arange(4, dtype=np.uint64) * np.uint64(10**12)
+    words = span2toc(0, times)  # scalar start broadcast over array ends
+    assert words.shape == (4,)
+    merged = toc_merge(int(words[0]), words)
+    assert merged.shape == (4,)
+
+
+def test_dtype_and_domain_validation():
+    with pytest.raises(ValueError, match="integer"):
+        time2toc(np.array([1.5]))
+    with pytest.raises(ValueError, match="non-negative"):
+        time2toc(np.array([-1]))
+    with pytest.raises(ValueError, match="ceiling"):
+        time2toc(TOC_MAX_NS)
+    with pytest.raises(ValueError, match="ceiling"):
+        span2toc(0, TOC_MAX_NS)
+    with pytest.raises(ValueError, match="after its end"):
+        span2toc(5, 3)
+    # The last valid instant is fine for both encoders.
+    assert time2toc(TOC_MAX_NS - 1) > 0
+    assert span2toc(0, TOC_MAX_NS - 1) > 0

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -1,0 +1,391 @@
+"""toc word -- temporal order coverage (issue #175).
+
+One ``uint64``, a tagged union of an exact nanosecond **timestamp** and a
+quantized, conservative **time range**, templated on what the morton word
+does for space: self-describing, sortable as a plain unsigned integer, and
+closed under a semilattice merge.  All internal times are u64 nanoseconds
+since **1850-01-01T00:00:00** on a continuous, leap-free, GPS-aligned
+timescale; leap seconds exist only at the UTC boundary
+(:func:`from_datetime64` / :func:`to_datetime64`).
+
+Layout (bit 0 = LSB)::
+
+    [start: 32 bits, 2^31 ns units][flag: 1 bit][low: 31 bits]
+
+- **timestamp** (flag = 1): the word is ``t_ns`` with the flag bit spliced
+  in at position 31 -- monotone in ``t_ns``.
+- **range** (flag = 0): ``low`` is the end code, 31 bits at 2^32 ns; the
+  encoded envelope is half-open ``[start * 2^31, end * 2^32)``, rounded
+  outward with a strictly-greater end ceiling so it always properly
+  contains the real interval.
+
+Unsigned word order is order by conservative encoded start; within a tied
+start quantum, ranges sort before timestamps, then timestamps by exact ns
+and ranges shorter-first.  The layout, epoch, merge results, and sort
+order are normative (words persist on disk) and pinned by golden fixtures;
+see the decision ledger on `issue #175
+<https://github.com/espg/mortie/issues/175>`_ and the design record on
+`zagg#410 <https://github.com/englacial/zagg/issues/410>`_.
+
+Naming note: "toc" pleasantly echoes tick/tock and T-MOC, but this is
+**not** an IVOA T-MOC and does not conform to the IVOA MOC 2.0
+recommendation (different epoch, timescale, and cell model -- see the
+T-MOC research on zagg#410 for why the hierarchical cell was rejected).
+
+These flat-array elementwise ops are the type's scalar surface, mirroring
+the relationship :mod:`mortie.moc` has to its ops over one cover; the
+ragged many-cover plurals land in :mod:`mortie.batch` when the interval-set
+algebra (issue #177) activates.
+"""
+
+import operator
+
+import numpy as np
+
+from . import _rustie
+
+#: Start quantum: 2^31 ns (~2.15 s); a range's start code floors to this.
+Q_START_NS = 1 << 31
+#: End quantum: 2^32 ns (~4.29 s); a range's end code ceils to this.
+Q_END_NS = 1 << 32
+#: Exclusive ceiling on internal times: 2^63 - 2^32 ns past the epoch
+#: (~4 s short of year 2142); the end code must fit its 31-bit field.
+TOC_MAX_NS = (1 << 63) - (1 << 32)
+
+
+def _as_u64(values, name):
+    """Validate non-negative integer input and return it as uint64."""
+    arr = np.atleast_1d(np.asarray(values))
+    if arr.dtype.kind not in "iu":
+        raise ValueError(
+            f"{name} must be integer-typed, got dtype {arr.dtype}")
+    if arr.dtype.kind == "i" and arr.size and np.any(arr < 0):
+        raise ValueError(f"{name} must be non-negative")
+    return arr.astype(np.uint64)
+
+
+def _as_scalar_ns(value, name):
+    """Validate a scalar ns argument and return it as a plain int."""
+    value = operator.index(value)
+    if not 0 <= value < 1 << 64:
+        raise ValueError(f"{name} must lie in [0, 2**64)")
+    return value
+
+
+def time2toc(t_ns):
+    """Encode exact instants (internal ns) as timestamp words.
+
+    The word is ``t_ns`` with a 1 flag bit spliced in at position 31, so
+    unsigned word order over timestamps is exactly the ns order.
+
+    Parameters
+    ----------
+    t_ns : int or array-like
+        Instant(s) in nanoseconds since 1850-01-01T00:00:00 on the
+        continuous GPS-aligned scale, each in ``[0, TOC_MAX_NS)``.
+
+    Returns
+    -------
+    int or ndarray
+        Timestamp word(s), ``uint64`` for array input (scalar in ->
+        ``int`` out).
+
+    Raises
+    ------
+    ValueError
+        If any instant is negative, non-integer-typed, or at or beyond
+        ``TOC_MAX_NS``.
+
+    See Also
+    --------
+    span2toc : encode a real interval as a range word.
+    toc2time : decode words back to conservative bounds.
+    """
+    is_scalar = np.isscalar(t_ns)
+    t = _as_u64(t_ns, "t_ns")
+    words = _rustie.rust_time2toc(np.ascontiguousarray(t.ravel()))
+    words = words.reshape(t.shape)
+    if is_scalar:
+        return int(words[0])
+    return words
+
+
+def span2toc(start_ns, end_ns):
+    """Encode real closed intervals ``[start, end]`` as range words.
+
+    Outward rounding with a strictly-greater end ceiling: the start code
+    floors to the 2^31 ns grid and the end code is ``(end >> 32) + 1`` --
+    uniformly, including when ``end`` sits exactly on the 2^32 ns grid --
+    so the encoded envelope always properly contains the interval.
+    ``start_ns`` and ``end_ns`` broadcast against each other.
+
+    Parameters
+    ----------
+    start_ns : int or array-like
+        Interval start(s) in internal ns.
+    end_ns : int or array-like
+        Interval end(s) in internal ns (inclusive real endpoint), each
+        ``>= start_ns`` and ``< TOC_MAX_NS``.
+
+    Returns
+    -------
+    int or ndarray
+        Range word(s), ``uint64`` for array input (scalar in -> ``int``
+        out).
+
+    Raises
+    ------
+    ValueError
+        If any start is after its end, or any end is at or beyond
+        ``TOC_MAX_NS`` (the 31-bit end code would overflow -- ~4 s short
+        of the year-2142 span ceiling; rejected rather than wrapped).
+
+    See Also
+    --------
+    time2toc : encode an exact instant.
+    toc2time : decode words back to conservative bounds.
+    """
+    is_scalar = np.isscalar(start_ns) and np.isscalar(end_ns)
+    starts, ends = np.broadcast_arrays(_as_u64(start_ns, "start_ns"),
+                                       _as_u64(end_ns, "end_ns"))
+    words = _rustie.rust_span2toc(np.ascontiguousarray(starts.ravel()),
+                                  np.ascontiguousarray(ends.ravel()))
+    words = words.reshape(starts.shape)
+    if is_scalar:
+        return int(words[0])
+    return words
+
+
+def toc2time(words):
+    """Decode toc words to conservative ``(start_ns, end_ns)`` bounds.
+
+    A timestamp yields its exact instant twice, ``(t, t)``.  A range
+    yields its half-open envelope bounds: ``end_ns`` is **exclusive**,
+    strictly greater than every instant the range covers (the encoder's
+    strictly-greater ceiling guarantees this even for interval ends that
+    sat exactly on the 2^32 ns grid).
+
+    Parameters
+    ----------
+    words : int or array-like
+        Toc word(s) (``uint64``).
+
+    Returns
+    -------
+    start_ns : int or ndarray
+        Conservative start(s) in internal ns, ``uint64`` for array input
+        (scalar in -> ``int`` out).
+    end_ns : int or ndarray
+        Exact instant (timestamps) or exclusive envelope end (ranges),
+        same convention as ``start_ns``.
+
+    Raises
+    ------
+    ValueError
+        If ``words`` is negative or non-integer-typed.
+
+    See Also
+    --------
+    toc_is_range : which variant each word is.
+    """
+    is_scalar = np.isscalar(words)
+    w = _as_u64(words, "words")
+    starts, ends = _rustie.rust_toc2time(np.ascontiguousarray(w.ravel()))
+    starts, ends = starts.reshape(w.shape), ends.reshape(w.shape)
+    if is_scalar:
+        return int(starts[0]), int(ends[0])
+    return starts, ends
+
+
+def toc_merge(a, b):
+    """Merge two toc words elementwise (the semilattice join).
+
+    Bitwise-equal inputs return that word unchanged -- merging two equal
+    timestamps must not produce their range envelope.  Any other pair
+    merges conservative envelopes (min of start codes, max of end codes)
+    into a range word.  Exactly associative, commutative, and idempotent,
+    so any fold tree over the same words produces the identical ``uint64``.
+    ``a`` and ``b`` broadcast against each other.
+
+    Parameters
+    ----------
+    a : int or array-like
+        Toc word(s) (``uint64``).
+    b : int or array-like
+        Toc word(s) (``uint64``).
+
+    Returns
+    -------
+    int or ndarray
+        Merged word(s), ``uint64`` for array input (scalar in -> ``int``
+        out).
+
+    Raises
+    ------
+    ValueError
+        If either input is negative or non-integer-typed.
+
+    See Also
+    --------
+    toc_reduce : merge a whole array to one word.
+    """
+    is_scalar = np.isscalar(a) and np.isscalar(b)
+    wa, wb = np.broadcast_arrays(_as_u64(a, "a"), _as_u64(b, "b"))
+    merged = _rustie.rust_toc_merge(np.ascontiguousarray(wa.ravel()),
+                                    np.ascontiguousarray(wb.ravel()))
+    merged = merged.reshape(wa.shape)
+    if is_scalar:
+        return int(merged[0])
+    return merged
+
+
+def toc_reduce(words):
+    """Merge an array of toc words down to one word.
+
+    The fold tree is unspecified (parallel under the hood) -- safe because
+    the merge is exactly associative, commutative, and idempotent, so
+    every fold tree produces the identical ``uint64``.
+
+    Parameters
+    ----------
+    words : array-like
+        Toc words (``uint64``), at least one.
+
+    Returns
+    -------
+    int
+        The merged word.
+
+    Raises
+    ------
+    ValueError
+        If ``words`` is empty (the merge has no identity element), or is
+        negative or non-integer-typed.
+
+    See Also
+    --------
+    toc_merge : the elementwise pairwise form.
+    """
+    w = _as_u64(words, "words")
+    return int(_rustie.rust_toc_reduce(np.ascontiguousarray(w.ravel())))
+
+
+def toc_is_range(words):
+    """Test which variant each toc word is.
+
+    Parameters
+    ----------
+    words : int or array-like
+        Toc word(s) (``uint64``).
+
+    Returns
+    -------
+    bool or ndarray
+        True where the word is a range (flag bit 31 = 0), False for a
+        timestamp; ``bool`` ndarray for array input (scalar in ->
+        ``bool`` out).
+
+    Raises
+    ------
+    ValueError
+        If ``words`` is negative or non-integer-typed.
+    """
+    is_scalar = np.isscalar(words)
+    w = _as_u64(words, "words")
+    flags = _rustie.rust_toc_is_range(np.ascontiguousarray(w.ravel()))
+    flags = flags.reshape(w.shape)
+    if is_scalar:
+        return bool(flags[0])
+    return flags
+
+
+def toc_overlaps(words, q_start_ns, q_end_ns):
+    """Test which words intersect a half-open query window.
+
+    The test runs on each word's **conservative encoded bounds** (a
+    timestamp is its exact instant; a range is its outward-rounded
+    envelope), against the half-open window ``[q_start_ns, q_end_ns)``.
+    Consequently it may **over-report** near window edges by up to one
+    quantum (a range whose envelope grazes the window without its real
+    interval doing so), and it **never under-reports**: every word whose
+    real time content intersects the window tests True.
+
+    Parameters
+    ----------
+    words : int or array-like
+        Toc word(s) (``uint64``).
+    q_start_ns : int
+        Window start in internal ns (inclusive).
+    q_end_ns : int
+        Window end in internal ns (exclusive), ``>= q_start_ns``.
+
+    Returns
+    -------
+    bool or ndarray
+        True where the word's conservative bounds intersect the window;
+        ``bool`` ndarray for array input (scalar in -> ``bool`` out).
+
+    Raises
+    ------
+    ValueError
+        If the window is inverted, or ``words`` is negative or
+        non-integer-typed.
+
+    See Also
+    --------
+    toc_contains : containment in the window instead of intersection.
+    """
+    return _window(words, q_start_ns, q_end_ns, 0)
+
+
+def toc_contains(words, q_start_ns, q_end_ns):
+    """Test which words are contained in a half-open query window.
+
+    The test runs on each word's **conservative encoded bounds** against
+    the half-open window ``[q_start_ns, q_end_ns)``.  Consequently it
+    **never over-reports** (the real interval is inside the envelope, so
+    envelope-in-window implies interval-in-window), and it may
+    **under-report** near window edges by up to one quantum -- a range
+    whose real interval fits the window but whose outward-rounded
+    envelope spills past an edge tests False.
+
+    Parameters
+    ----------
+    words : int or array-like
+        Toc word(s) (``uint64``).
+    q_start_ns : int
+        Window start in internal ns (inclusive).
+    q_end_ns : int
+        Window end in internal ns (exclusive), ``>= q_start_ns``.
+
+    Returns
+    -------
+    bool or ndarray
+        True where the word's conservative bounds fit inside the window;
+        ``bool`` ndarray for array input (scalar in -> ``bool`` out).
+
+    Raises
+    ------
+    ValueError
+        If the window is inverted, or ``words`` is negative or
+        non-integer-typed.
+
+    See Also
+    --------
+    toc_overlaps : intersection with the window instead of containment.
+    """
+    return _window(words, q_start_ns, q_end_ns, 1)
+
+
+def _window(words, q_start_ns, q_end_ns, mode):
+    """Run one window predicate (0 = overlaps, 1 = contains)."""
+    is_scalar = np.isscalar(words)
+    w = _as_u64(words, "words")
+    hits = _rustie.rust_toc_window(np.ascontiguousarray(w.ravel()),
+                                   _as_scalar_ns(q_start_ns, "q_start_ns"),
+                                   _as_scalar_ns(q_end_ns, "q_end_ns"),
+                                   mode)
+    hits = hits.reshape(w.shape)
+    if is_scalar:
+        return bool(hits[0])
+    return hits

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -44,13 +44,15 @@ import numpy as np
 
 from . import _rustie
 
-#: Start quantum: 2^31 ns (~2.15 s); a range's start code floors to this.
 Q_START_NS = 1 << 31
-#: End quantum: 2^32 ns (~4.29 s); a range's end code ceils to this.
+"""Start quantum: 2^31 ns (~2.15 s); a range's start code floors to this."""
+
 Q_END_NS = 1 << 32
-#: Exclusive ceiling on internal times: 2^63 - 2^32 ns past the epoch
-#: (~4 s short of year 2142); the end code must fit its 31-bit field.
+"""End quantum: 2^32 ns (~4.29 s); a range's end code ceils to this."""
+
 TOC_MAX_NS = (1 << 63) - (1 << 32)
+"""Exclusive ceiling on internal times: 2^63 - 2^32 ns past the epoch
+(~4 s short of year 2142); the end code must fit its 31-bit field."""
 
 
 def _as_u64(values, name):
@@ -308,7 +310,8 @@ def toc_overlaps(words, q_start_ns, q_end_ns):
     Consequently it may **over-report** near window edges by up to one
     quantum (a range whose envelope grazes the window without its real
     interval doing so), and it **never under-reports**: every word whose
-    real time content intersects the window tests True.
+    real time content intersects the window tests True.  An empty window
+    (``q_start_ns == q_end_ns``) matches nothing.
 
     Parameters
     ----------
@@ -347,7 +350,8 @@ def toc_contains(words, q_start_ns, q_end_ns):
     envelope-in-window implies interval-in-window), and it may
     **under-report** near window edges by up to one quantum -- a range
     whose real interval fits the window but whose outward-rounded
-    envelope spills past an edge tests False.
+    envelope spills past an edge tests False.  An empty window
+    (``q_start_ns == q_end_ns``) contains nothing.
 
     Parameters
     ----------
@@ -397,11 +401,11 @@ def _window(words, q_start_ns, q_end_ns, mode):
 # to or from UTC. GPS interop is a pure constant offset.
 # ---------------------------------------------------------------------------
 
-#: Internal ns of the GPS epoch 1980-01-06T00:00:00: 47,486
-#: proleptic-Gregorian days of 86,400 s past 1850-01-01 (the leap-free
-#: scale ticks exactly with GPS, so the constant is a plain day count --
-#: validated against ``datetime.date`` arithmetic in the test suite).
 GPS_EPOCH_NS = 47_486 * 86_400 * 10**9
+"""Internal ns of the GPS epoch 1980-01-06T00:00:00: 47,486
+proleptic-Gregorian days of 86,400 s past 1850-01-01 (the leap-free
+scale ticks exactly with GPS, so the constant is a plain day count --
+validated against ``datetime.date`` arithmetic in the test suite)."""
 
 # Internal/naive ns between 1850-01-01 and the numpy datetime64 epoch
 # 1970-01-01: 43,829 proleptic-Gregorian days of 86,400 s.
@@ -498,10 +502,18 @@ def from_datetime64(when):
     to_datetime64 : the inverse conversion.
     from_gps_ns : the leap-free GPS entry point.
     """
-    is_scalar = np.ndim(when) == 0
+    # A 0-d ndarray classifies as array (matching np.isscalar in the word
+    # ops); np.isscalar itself is unusable here -- it is False for a
+    # np.datetime64 scalar.
+    is_scalar = np.ndim(when) == 0 and not isinstance(when, np.ndarray)
     naive = np.atleast_1d(
         np.asarray(when, dtype="datetime64[ns]")).astype(np.int64)
-    if naive.size and int(naive.max()) >= TOC_MAX_NS - _EPOCH_1850_1970_NS:
+    # Ceiling guard on the *internal* result, evaluated before the offset
+    # addition so the int64 arithmetic below cannot overflow: the offset in
+    # force anywhere near the ceiling is the table's last entry, so every
+    # naive value at or past this limit maps to internal >= TOC_MAX_NS.
+    limit = TOC_MAX_NS - _EPOCH_1850_1970_NS - int(_OFFSETS_NS[-1])
+    if naive.size and int(naive.max()) >= limit:
         raise ValueError(
             "datetime64 input is at or beyond the toc span ceiling "
             "(~year 2142)")

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -389,3 +389,251 @@ def _window(words, q_start_ns, q_end_ns, mode):
     if is_scalar:
         return bool(hits[0])
     return hits
+
+
+# ---------------------------------------------------------------------------
+# Timescale boundary (issue #175 phase 3). The internal scale is continuous
+# and leap-free; leap seconds are handled exactly once, here, when crossing
+# to or from UTC. GPS interop is a pure constant offset.
+# ---------------------------------------------------------------------------
+
+#: Internal ns of the GPS epoch 1980-01-06T00:00:00: 47,486
+#: proleptic-Gregorian days of 86,400 s past 1850-01-01 (the leap-free
+#: scale ticks exactly with GPS, so the constant is a plain day count --
+#: validated against ``datetime.date`` arithmetic in the test suite).
+GPS_EPOCH_NS = 47_486 * 86_400 * 10**9
+
+# Internal/naive ns between 1850-01-01 and the numpy datetime64 epoch
+# 1970-01-01: 43,829 proleptic-Gregorian days of 86,400 s.
+_EPOCH_1850_1970_NS = 43_829 * 86_400 * 10**9
+
+# Static leap-second table: (UTC step date, TAI-UTC after the step).
+# Data, not a dependency; complete as of the 2017-01-01 step (+18 s
+# GPS-UTC), and no further leap second is currently scheduled.  Update by
+# appending when the IERS announces one.
+_LEAP_TABLE = (
+    ("1972-01-01", 10),
+    ("1972-07-01", 11),
+    ("1973-01-01", 12),
+    ("1974-01-01", 13),
+    ("1975-01-01", 14),
+    ("1976-01-01", 15),
+    ("1977-01-01", 16),
+    ("1978-01-01", 17),
+    ("1979-01-01", 18),
+    ("1980-01-01", 19),
+    ("1981-07-01", 20),
+    ("1982-07-01", 21),
+    ("1983-07-01", 22),
+    ("1985-07-01", 23),
+    ("1988-01-01", 24),
+    ("1990-01-01", 25),
+    ("1991-01-01", 26),
+    ("1992-07-01", 27),
+    ("1993-07-01", 28),
+    ("1994-07-01", 29),
+    ("1996-01-01", 30),
+    ("1997-07-01", 31),
+    ("1999-01-01", 32),
+    ("2006-01-01", 33),
+    ("2009-01-01", 34),
+    ("2012-07-01", 35),
+    ("2015-07-01", 36),
+    ("2017-01-01", 37),
+)
+
+# UTC step instants as naive ns since 1970 (datetime64 arithmetic), and the
+# internal-ns offset in force from each step on: GPS - UTC = TAI - UTC - 19.
+# _OFFSETS_NS[0] is the pre-1972 proleptic convention: zero (see
+# from_datetime64); at the GPS epoch itself TAI - UTC = 19, so the offset
+# is exactly zero there -- the identity the GPS alignment pins.
+_UTC_STEPS_1970_NS = np.array(
+    [np.datetime64(d, "ns").astype(np.int64) for d, _ in _LEAP_TABLE],
+    dtype=np.int64)
+_OFFSETS_NS = np.array(
+    [0] + [(tai - 19) * 10**9 for _, tai in _LEAP_TABLE], dtype=np.int64)
+# The same step instants on the internal scale (naive + the offset the step
+# switches to), for the inverse lookup.
+_INTERNAL_STEPS_NS = (
+    _UTC_STEPS_1970_NS + _EPOCH_1850_1970_NS + _OFFSETS_NS[1:]
+).astype(np.uint64)
+
+
+def from_datetime64(when):
+    """Convert UTC ``datetime64`` times to internal ns.
+
+    The internal scale is continuous and GPS-aligned: from 1972 the offset
+    to naive UTC day-count time is ``GPS - UTC = TAI - UTC - 19`` from the
+    static in-module leap-second table (zero at the GPS epoch 1980-01-06,
+    +18 s since 2017-01-01).  **Before 1972** the proleptic convention is
+    **zero offset** (naive day-count seconds, no leap adjustment): it pins
+    the epoch identity (1850-01-01T00:00:00 -> 0 ns exactly), whereas
+    freezing the 1972 offset of -9 s would push the epoch itself to a
+    negative, unrepresentable internal time.  Pre-1972 "UTC" was not
+    SI-second aligned anyway, and such data carries hours-level precision.
+    Cost: the mapping steps back 9 s across the 1972-01-01 boundary, so
+    the last 9 SI seconds of 1971 are not invertible (they alias early
+    1972); conversion is exact and invertible from 1972 on.
+
+    Parameters
+    ----------
+    when : datetime64, str, or array-like
+        UTC instant(s); anything ``np.asarray(when, 'datetime64[ns]')``
+        accepts.
+
+    Returns
+    -------
+    int or ndarray
+        Internal ns (``uint64``) since 1850-01-01T00:00:00 on the
+        continuous GPS-aligned scale; scalar in -> ``int`` out.
+
+    Raises
+    ------
+    ValueError
+        If any instant is before the 1850 epoch or at or beyond
+        ``TOC_MAX_NS`` (the toc span ceiling, ~year 2142).
+
+    See Also
+    --------
+    to_datetime64 : the inverse conversion.
+    from_gps_ns : the leap-free GPS entry point.
+    """
+    is_scalar = np.ndim(when) == 0
+    naive = np.atleast_1d(
+        np.asarray(when, dtype="datetime64[ns]")).astype(np.int64)
+    if naive.size and int(naive.max()) >= TOC_MAX_NS - _EPOCH_1850_1970_NS:
+        raise ValueError(
+            "datetime64 input is at or beyond the toc span ceiling "
+            "(~year 2142)")
+    idx = np.searchsorted(_UTC_STEPS_1970_NS, naive, side="right")
+    internal = naive + _EPOCH_1850_1970_NS + _OFFSETS_NS[idx]
+    if internal.size and int(internal.min()) < 0:
+        raise ValueError("datetime64 input is before the 1850-01-01 epoch")
+    internal = internal.astype(np.uint64)
+    if is_scalar:
+        return int(internal[0])
+    return internal
+
+
+def to_datetime64(t_ns):
+    """Convert internal ns to UTC ``datetime64[ns]`` times.
+
+    The inverse of :func:`from_datetime64` (same leap table, same pre-1972
+    zero-offset convention).  Internal instants that fall *inside* an
+    inserted leap second render into the following UTC second --
+    ``datetime64`` cannot express 23:59:60 -- so, e.g., the middle of the
+    2016-12-31 leap second renders as 2017-01-01T00:00:00.5.  Roundtrip
+    ``to_datetime64(from_datetime64(t))`` is exact for every ``datetime64``
+    from 1972 on (no ``datetime64`` names a leap-second instant).
+
+    Parameters
+    ----------
+    t_ns : int or array-like
+        Internal ns (``uint64``), each below ``2**63``.
+
+    Returns
+    -------
+    datetime64 or ndarray
+        UTC instant(s) as ``datetime64[ns]``; scalar in -> ``np.datetime64``
+        out.
+
+    Raises
+    ------
+    ValueError
+        If any value is negative, non-integer-typed, or at or beyond
+        ``2**63`` (past every representable envelope bound).
+
+    See Also
+    --------
+    from_datetime64 : the inverse conversion.
+    to_gps_ns : the leap-free GPS exit point.
+    """
+    is_scalar = np.isscalar(t_ns)
+    t = _as_u64(t_ns, "t_ns")
+    if t.size and int(t.max()) >= 1 << 63:
+        raise ValueError("t_ns must lie below 2**63")
+    idx = np.searchsorted(_INTERNAL_STEPS_NS, t, side="right")
+    naive = t.astype(np.int64) - _OFFSETS_NS[idx] - _EPOCH_1850_1970_NS
+    out = naive.astype("datetime64[ns]")
+    if is_scalar:
+        return out[0]
+    return out
+
+
+def from_gps_ns(gps_ns):
+    """Convert GPS time (ns since 1980-01-06T00:00:00) to internal ns.
+
+    A pure constant offset: both scales are continuous and leap-free and
+    tick together, so the conversion is ``gps_ns + GPS_EPOCH_NS``.  The
+    ICESat-2 ingest path (``delta_time`` + ``atlas_sdp_gps_epoch`` -> GPS
+    ns) composes with this directly.
+
+    Parameters
+    ----------
+    gps_ns : int or array-like
+        GPS time(s) in ns since the GPS epoch, each below
+        ``TOC_MAX_NS - GPS_EPOCH_NS``.
+
+    Returns
+    -------
+    int or ndarray
+        Internal ns (``uint64``); scalar in -> ``int`` out.
+
+    Raises
+    ------
+    ValueError
+        If any value is negative, non-integer-typed, or maps at or beyond
+        ``TOC_MAX_NS``.
+
+    See Also
+    --------
+    to_gps_ns : the inverse conversion.
+    """
+    is_scalar = np.isscalar(gps_ns)
+    g = _as_u64(gps_ns, "gps_ns")
+    if g.size and int(g.max()) >= TOC_MAX_NS - GPS_EPOCH_NS:
+        raise ValueError(
+            "gps_ns input maps at or beyond the toc span ceiling "
+            "(~year 2142)")
+    internal = g + np.uint64(GPS_EPOCH_NS)
+    if is_scalar:
+        return int(internal[0])
+    return internal
+
+
+def to_gps_ns(t_ns):
+    """Convert internal ns to GPS time (ns since 1980-01-06T00:00:00).
+
+    The exact inverse of :func:`from_gps_ns`.  Internal times before the
+    GPS epoch have no non-negative GPS representation and are rejected.
+
+    Parameters
+    ----------
+    t_ns : int or array-like
+        Internal ns (``uint64``), each at or after ``GPS_EPOCH_NS``.
+
+    Returns
+    -------
+    int or ndarray
+        GPS ns (``uint64``); scalar in -> ``int`` out.
+
+    Raises
+    ------
+    ValueError
+        If any value is negative, non-integer-typed, or before the GPS
+        epoch.
+
+    See Also
+    --------
+    from_gps_ns : the inverse conversion.
+    """
+    is_scalar = np.isscalar(t_ns)
+    t = _as_u64(t_ns, "t_ns")
+    if t.size and int(t.min()) < GPS_EPOCH_NS:
+        raise ValueError(
+            "t_ns is before the GPS epoch 1980-01-06 (internal ns "
+            f"{GPS_EPOCH_NS}); no non-negative GPS time exists")
+    gps = t - np.uint64(GPS_EPOCH_NS)
+    if is_scalar:
+        return int(gps[0])
+    return gps

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -1764,6 +1764,13 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_common_ancestors, m)?)?;
     m.add_function(wrap_pyfunction!(rust_children_of, m)?)?;
     m.add_function(wrap_pyfunction!(rust_linestring_coverage, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_time2toc, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_span2toc, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_toc2time, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_toc_merge, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_toc_reduce, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_toc_is_range, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_toc_window, m)?)?;
     m.add_function(wrap_pyfunction!(rust_wkb_rings, m)?)?;
     m.add_function(wrap_pyfunction!(rust_wkbs_coverage_mocs, m)?)?;
     #[cfg(feature = "descent-stats")]

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -19,6 +19,7 @@ pub mod morton;
 pub mod prefix_trie;
 pub mod rank_xy;
 pub mod sphere;
+pub mod toc;
 pub mod wkb;
 
 use numpy::{

--- a/src_rust/src/toc.rs
+++ b/src_rust/src/toc.rs
@@ -38,6 +38,11 @@
 //! and fixture-pinned below; how they are computed (parallelism, chunking,
 //! error text) is not.
 
+use numpy::{IntoPyArray, PyArrayMethods, PyReadonlyArray1};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
 /// Discriminator bit position: 1 = timestamp, 0 = range.
 pub const FLAG_BIT: u32 = 31;
 /// Mask of the flag bit.
@@ -146,6 +151,193 @@ pub fn merge(a: u64, b: u64) -> u64 {
     let (sa, ea) = codes(a);
     let (sb, eb) = codes(b);
     (sa.min(sb) << 32) | ea.max(eb)
+}
+
+// ---------------------------------------------------------------------------
+// Python bindings (issue #175 phase 2). Array-in/array-out over the scalar
+// kernel; rayon under allow_threads per the house pattern. Validation
+// (dtype, shape, scalar/array symmetry) lives in mortie/toc.py.
+// ---------------------------------------------------------------------------
+
+/// Borrow a contiguous u64 numpy buffer, copying only when non-contiguous.
+macro_rules! as_slice_or_vec {
+    ($arr:expr, $owned:ident) => {
+        match $arr.as_slice() {
+            Ok(s) => s,
+            Err(_) => {
+                $owned = $arr.to_vec()?;
+                &$owned
+            }
+        }
+    };
+}
+
+/// Encode internal-ns instants as timestamp words (vectorized).
+///
+/// # Arguments
+/// * `t_ns` - Instants in internal ns (u64 NumPy array)
+///
+/// # Returns
+/// Timestamp words as a u64 NumPy array.  Raises `ValueError` on any
+/// instant at or beyond `TOC_MAX_NS`.
+#[pyfunction]
+pub fn rust_time2toc(py: Python<'_>, t_ns: PyReadonlyArray1<u64>) -> PyResult<PyObject> {
+    let owned;
+    let data: &[u64] = as_slice_or_vec!(t_ns, owned);
+    let result: Result<Vec<u64>, String> =
+        py.allow_threads(|| data.par_iter().map(|&t| encode_timestamp(t)).collect());
+    match result {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(msg) => Err(PyValueError::new_err(msg)),
+    }
+}
+
+/// Encode real closed intervals `[start, end]` as range words (vectorized).
+///
+/// # Arguments
+/// * `start_ns` - Interval starts in internal ns (u64 NumPy array)
+/// * `end_ns` - Interval ends in internal ns (u64 NumPy array, same length)
+///
+/// # Returns
+/// Range words as a u64 NumPy array.  Raises `ValueError` on a start after
+/// its end or an end at or beyond `TOC_MAX_NS`.
+#[pyfunction]
+pub fn rust_span2toc(
+    py: Python<'_>,
+    start_ns: PyReadonlyArray1<u64>,
+    end_ns: PyReadonlyArray1<u64>,
+) -> PyResult<PyObject> {
+    let s_owned;
+    let starts: &[u64] = as_slice_or_vec!(start_ns, s_owned);
+    let e_owned;
+    let ends: &[u64] = as_slice_or_vec!(end_ns, e_owned);
+    if starts.len() != ends.len() {
+        return Err(PyValueError::new_err(
+            "start and end arrays must have the same length",
+        ));
+    }
+    let result: Result<Vec<u64>, String> = py.allow_threads(|| {
+        starts
+            .par_iter()
+            .zip(ends.par_iter())
+            .map(|(&a, &b)| encode_range(a, b))
+            .collect()
+    });
+    match result {
+        Ok(words) => Ok(words.into_pyarray_bound(py).into_any().unbind()),
+        Err(msg) => Err(PyValueError::new_err(msg)),
+    }
+}
+
+/// Decode words to conservative `(start_ns, end_ns)` bounds (vectorized).
+///
+/// A timestamp yields `(t, t)`; a range yields its half-open envelope
+/// `[start, end)` — the end is exclusive.
+#[pyfunction]
+pub fn rust_toc2time(py: Python<'_>, words: PyReadonlyArray1<u64>) -> PyResult<PyObject> {
+    let owned;
+    let data: &[u64] = as_slice_or_vec!(words, owned);
+    let (starts, ends): (Vec<u64>, Vec<u64>) = py.allow_threads(|| {
+        data.par_iter()
+            .map(|&w| {
+                let (s, e, _) = decode(w);
+                (s, e)
+            })
+            .unzip()
+    });
+    let py_s = starts.into_pyarray_bound(py).into_any().unbind();
+    let py_e = ends.into_pyarray_bound(py).into_any().unbind();
+    Ok(pyo3::types::PyTuple::new_bound(py, &[py_s, py_e]).to_object(py))
+}
+
+/// Elementwise semilattice merge of two word arrays (vectorized).
+#[pyfunction]
+pub fn rust_toc_merge(
+    py: Python<'_>,
+    a: PyReadonlyArray1<u64>,
+    b: PyReadonlyArray1<u64>,
+) -> PyResult<PyObject> {
+    let a_owned;
+    let wa: &[u64] = as_slice_or_vec!(a, a_owned);
+    let b_owned;
+    let wb: &[u64] = as_slice_or_vec!(b, b_owned);
+    if wa.len() != wb.len() {
+        return Err(PyValueError::new_err(
+            "word arrays must have the same length",
+        ));
+    }
+    let merged: Vec<u64> = py.allow_threads(|| {
+        wa.par_iter()
+            .zip(wb.par_iter())
+            .map(|(&x, &y)| merge(x, y))
+            .collect()
+    });
+    Ok(merged.into_pyarray_bound(py).into_any().unbind())
+}
+
+/// Reduce a word array to its single merged word.
+///
+/// Raises `ValueError` on empty input (the merge has no identity element).
+/// The rayon reduction seeds each split with `data[0]` in place of an
+/// identity; that is sound *because* merge is idempotent, commutative and
+/// associative (pinned by the cargo tests) — extra copies of an input word
+/// are absorbed, and the fold tree's shape cannot change the result.
+#[pyfunction]
+pub fn rust_toc_reduce(py: Python<'_>, words: PyReadonlyArray1<u64>) -> PyResult<u64> {
+    let owned;
+    let data: &[u64] = as_slice_or_vec!(words, owned);
+    if data.is_empty() {
+        return Err(PyValueError::new_err(
+            "toc_reduce of an empty array (the merge has no identity element)",
+        ));
+    }
+    Ok(py.allow_threads(|| data.par_iter().copied().reduce(|| data[0], merge)))
+}
+
+/// Variant predicate: true where the word is a range (vectorized).
+#[pyfunction]
+pub fn rust_toc_is_range(py: Python<'_>, words: PyReadonlyArray1<u64>) -> PyResult<PyObject> {
+    let owned;
+    let data: &[u64] = as_slice_or_vec!(words, owned);
+    let flags: Vec<bool> = py.allow_threads(|| data.par_iter().map(|&w| is_range(w)).collect());
+    Ok(flags.into_pyarray_bound(py).into_any().unbind())
+}
+
+/// Window predicates: `mode = 0` overlaps, `mode = 1` contains (vectorized).
+///
+/// Both test the word's conservative encoded bounds against the half-open
+/// query window `[q_start, q_end)`; see `mortie/toc.py` for the
+/// over/under-report semantics.
+#[pyfunction]
+pub fn rust_toc_window(
+    py: Python<'_>,
+    words: PyReadonlyArray1<u64>,
+    q_start_ns: u64,
+    q_end_ns: u64,
+    mode: u8,
+) -> PyResult<PyObject> {
+    if q_start_ns > q_end_ns {
+        return Err(PyValueError::new_err("query window start is after its end"));
+    }
+    let owned;
+    let data: &[u64] = as_slice_or_vec!(words, owned);
+    let hits: Vec<bool> = py.allow_threads(|| {
+        data.par_iter()
+            .map(|&w| {
+                let (s, e, is_rng) = decode(w);
+                // A timestamp is the degenerate closed instant [t, t]; its
+                // half-open envelope for window tests is [t, t + 1) — the
+                // exact instant, one ns wide.
+                let e = if is_rng { e } else { e + 1 };
+                if mode == 0 {
+                    s < q_end_ns && q_start_ns < e
+                } else {
+                    q_start_ns <= s && e <= q_end_ns
+                }
+            })
+            .collect()
+    });
+    Ok(hits.into_pyarray_bound(py).into_any().unbind())
 }
 
 // ── tests ────────────────────────────────────────────────────────────────

--- a/src_rust/src/toc.rs
+++ b/src_rust/src/toc.rs
@@ -143,6 +143,10 @@ fn codes(word: u64) -> (u64, u64) {
 /// envelopes and emits a range word.  Exactly associative, commutative,
 /// and idempotent on the fixed epoch-anchored lattice, so the result is
 /// bit-identical under any fold tree (pinned by the tests below).
+///
+/// Defined over encoder-produced words; like [`decode`], an arbitrary bit
+/// pattern is garbage in, garbage out (an out-of-domain "timestamp" past
+/// `TOC_MAX_NS` can even merge to a word with the timestamp flag set).
 #[inline]
 pub fn merge(a: u64, b: u64) -> u64 {
     if a == b {
@@ -319,11 +323,18 @@ pub fn rust_toc_window(
     if q_start_ns > q_end_ns {
         return Err(PyValueError::new_err("query window start is after its end"));
     }
+    // An empty window intersects and contains nothing.  Short-circuited
+    // here because the overlap formula below assumes both intervals are
+    // nonempty (a word's envelope always is; the window need not be).
+    let empty = q_start_ns == q_end_ns;
     let owned;
     let data: &[u64] = as_slice_or_vec!(words, owned);
     let hits: Vec<bool> = py.allow_threads(|| {
         data.par_iter()
             .map(|&w| {
+                if empty {
+                    return false;
+                }
                 let (s, e, is_rng) = decode(w);
                 // A timestamp is the degenerate closed instant [t, t]; its
                 // half-open envelope for window tests is [t, t + 1) — the
@@ -389,10 +400,10 @@ mod tests {
     #[test]
     fn golden_2018_timestamp() {
         // 2018-01-01T00:00:00 UTC as internal ns, derived:
-        //   proleptic-Gregorian days 1850-01-01 -> 2018-01-01 = 61,362
+        //   proleptic-Gregorian days 1850-01-01 -> 2018-01-01 = 61,361
         //   (168 years * 365 + 41 leap days: 1852..2016 has 42 multiples of
         //   4, minus 1900, a century non-leap year);
-        //   naive ns = 61,362 * 86,400 * 10^9 = 5,301,590,400e9;
+        //   naive ns = 61,361 * 86,400 * 10^9 = 5,301,590,400e9;
         //   GPS - UTC at 2018 = TAI - UTC - 19 = 37 - 19 = 18 s;
         //   t = 5,301,590,400e9 + 18e9 = 5,301,590,418,000,000,000 ns.
         // (Cross-check: GPS seconds since 1980-01-06 for that instant are
@@ -537,6 +548,12 @@ mod tests {
             let (a, b, c) = (rand_word(&mut st), rand_word(&mut st), rand_word(&mut st));
             assert_eq!(merge(a, b), merge(b, a));
             assert_eq!(merge(merge(a, b), c), merge(a, merge(b, c)));
+            if a != b {
+                assert!(
+                    is_range(merge(a, b)),
+                    "unequal valid words merge to a range"
+                );
+            }
             // Mixed case: an equal-timestamp pair inside a triple.
             assert_eq!(merge(merge(a, a), c), merge(a, merge(a, c)));
         }

--- a/src_rust/src/toc.rs
+++ b/src_rust/src/toc.rs
@@ -1,0 +1,424 @@
+//! toc word — temporal order coverage (issue #175).
+//!
+//! One `u64`, a tagged union of an exact nanosecond **timestamp** and a
+//! quantized, conservative **time range**.  All internal times are u64
+//! nanoseconds since **1850-01-01T00:00:00** on a continuous, leap-free,
+//! GPS-aligned timescale (leap seconds exist only at the UTC boundary in
+//! `mortie/toc.py`).  This is *not* an IVOA T-MOC — see the design record.
+//!
+//! Layout (decision ledger on issue #175; design rationale on
+//! englacial/zagg#410):
+//!
+//! ```text
+//! [start: 32 bits, 2^31 ns units][flag: 1 bit][low: 31 bits]
+//!   flag = 1 → timestamp: the word is t_ns with the flag bit spliced in at
+//!              position 31 — bits 63..32 = t_ns >> 31, bits 30..0 =
+//!              t_ns & (2^31 - 1).  Monotone in t_ns.
+//!   flag = 0 → range: bits 63..32 = start code s (floor, 2^31 ns units),
+//!              bits 30..0 = end code e (31 bits, 2^32 ns units); the
+//!              encoded envelope is half-open [s * 2^31, e * 2^32) ns.
+//! ```
+//!
+//! Decisions pinned here (normative — words persist on disk):
+//! - 1 ns base quantum, 32/31 split
+//!   (<https://github.com/espg/mortie/issues/175#issuecomment-5230004941>);
+//! - flag at bit 31, polarity 1 = timestamp, and the `toc` name
+//!   (<https://github.com/espg/mortie/issues/175#issuecomment-5230049902>);
+//! - outward rounding with a strictly-greater end ceiling, the min/max
+//!   semilattice merge, and the 1850 GPS-aligned epoch
+//!   (<https://github.com/englacial/zagg/issues/410>).
+//!
+//! Sort property (normative): unsigned u64 order = order by conservative
+//! encoded start; within a tied start quantum, ranges (flag 0) sort before
+//! timestamps (flag 1) — correct, since a range's floored start is <= any
+//! timestamp inside that quantum; within timestamps, exact ns; within
+//! ranges, shorter-first by end code.
+//!
+//! The bit layout, constants, merge results, and sort order are normative
+//! and fixture-pinned below; how they are computed (parallelism, chunking,
+//! error text) is not.
+
+/// Discriminator bit position: 1 = timestamp, 0 = range.
+pub const FLAG_BIT: u32 = 31;
+/// Mask of the flag bit.
+pub const FLAG_MASK: u64 = 1 << FLAG_BIT;
+/// Mask of the 31-bit low field (fine ns-offset or end code).
+pub const LOW_MASK: u64 = FLAG_MASK - 1;
+/// Start quantum: 2^31 ns (~2.15 s).  A range's start code floors to this.
+pub const Q_START_NS: u64 = 1 << 31;
+/// End quantum: 2^32 ns (~4.29 s).  A range's end code ceils to this.
+pub const Q_END_NS: u64 = 1 << 32;
+/// Exclusive ceiling on internal times: 2^63 - 2^32 ns past the epoch
+/// (~4 s short of year 2142).  The bound is the end code's: the ceiling
+/// `e = (t >> 32) + 1` must fit 31 bits, i.e. `t < (2^31 - 1) * 2^32`.
+/// Applied to *both* encoders so that every encodable word is mergeable —
+/// a timestamp in the last 2^32 ns would encode fine but its merge
+/// envelope would overflow the end field, so it is rejected up front
+/// rather than wrapping silently.
+pub const TOC_MAX_NS: u64 = ((1u64 << 31) - 1) << 32;
+
+/// Encode an exact instant (internal ns) as a timestamp word.
+///
+/// The word is `t_ns` with a 1 flag bit spliced in at position 31, so the
+/// unsigned word order over timestamps is exactly the ns order.
+pub fn encode_timestamp(t_ns: u64) -> Result<u64, String> {
+    if t_ns >= TOC_MAX_NS {
+        return Err(format!(
+            "timestamp {t_ns} ns is at or beyond the toc span ceiling \
+             (2^63 - 2^32 ns past 1850-01-01, ~year 2142)"
+        ));
+    }
+    Ok(((t_ns >> 31) << 32) | FLAG_MASK | (t_ns & LOW_MASK))
+}
+
+/// Encode a real closed interval `[start_ns, end_ns]` as a range word.
+///
+/// Outward rounding with a strictly-greater end ceiling: `s = start >> 31`
+/// (floor) and `e = (end >> 32) + 1` — uniformly, *including* when `end`
+/// sits exactly on the 2^32 grid — so the half-open envelope
+/// `[s * 2^31, e * 2^32)` always properly contains `end`.
+pub fn encode_range(start_ns: u64, end_ns: u64) -> Result<u64, String> {
+    if start_ns > end_ns {
+        return Err(format!(
+            "range start {start_ns} ns is after its end {end_ns} ns"
+        ));
+    }
+    if end_ns >= TOC_MAX_NS {
+        return Err(format!(
+            "range end {end_ns} ns is at or beyond the toc span ceiling \
+             (2^63 - 2^32 ns past 1850-01-01, ~year 2142)"
+        ));
+    }
+    Ok(((start_ns >> 31) << 32) | ((end_ns >> 32) + 1))
+}
+
+/// True when `word` is a range (flag 0), false for a timestamp (flag 1).
+#[inline]
+pub fn is_range(word: u64) -> bool {
+    word & FLAG_MASK == 0
+}
+
+/// Decode a word to `(start_ns, end_ns, is_range)`.
+///
+/// A timestamp yields its exact instant twice, `(t, t, false)`.  A range
+/// yields its half-open envelope bounds `[start_ns, end_ns)` — `end_ns` is
+/// *exclusive*, and strictly greater than every instant the range covers.
+/// Total over encoder-produced words; an arbitrary bit pattern decodes
+/// without complaint (garbage in, garbage out).
+#[inline]
+pub fn decode(word: u64) -> (u64, u64, bool) {
+    if is_range(word) {
+        ((word >> 32) << 31, (word & LOW_MASK) << 32, true)
+    } else {
+        let t = ((word >> 32) << 31) | (word & LOW_MASK);
+        (t, t, false)
+    }
+}
+
+/// Conservative `(start_code, end_code)` of a word, for merging.
+///
+/// A range carries its codes verbatim.  A timestamp's envelope for merging
+/// purposes is `s = t >> 31` (= `word >> 32`, the shared high field) and
+/// `e = (t >> 32) + 1` (= `(word >> 33) + 1` — bit 31 of `t` is bit 0 of
+/// the high field, so `t >> 32` is one more shift of it).
+#[inline]
+fn codes(word: u64) -> (u64, u64) {
+    if is_range(word) {
+        (word >> 32, word & LOW_MASK)
+    } else {
+        (word >> 32, (word >> 33) + 1)
+    }
+}
+
+/// Semilattice join of two words: min of start codes, max of end codes.
+///
+/// **Bitwise-equal inputs return that word unchanged** — required for
+/// idempotence, because merging two equal timestamps must NOT produce
+/// their range envelope.  Any other pair decodes to conservative
+/// envelopes and emits a range word.  Exactly associative, commutative,
+/// and idempotent on the fixed epoch-anchored lattice, so the result is
+/// bit-identical under any fold tree (pinned by the tests below).
+#[inline]
+pub fn merge(a: u64, b: u64) -> u64 {
+    if a == b {
+        return a;
+    }
+    let (sa, ea) = codes(a);
+    let (sb, eb) = codes(b);
+    (sa.min(sb) << 32) | ea.max(eb)
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic PRNG (splitmix64) — no rand dependency.
+    fn splitmix64(state: &mut u64) -> u64 {
+        *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = *state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn rand_time(state: &mut u64) -> u64 {
+        splitmix64(state) % TOC_MAX_NS
+    }
+
+    /// A random valid word: timestamps, ranges, and grid-aligned ends mixed.
+    fn rand_word(state: &mut u64) -> u64 {
+        match splitmix64(state) % 4 {
+            0 => encode_timestamp(rand_time(state)).unwrap(),
+            1 => {
+                // End snapped exactly onto the 2^32 grid (the strictly-greater
+                // ceiling edge case must circulate through the law tests too).
+                let b = (rand_time(state) >> 32) << 32;
+                let a = b.saturating_sub(splitmix64(state) % Q_END_NS);
+                encode_range(a, b).unwrap()
+            }
+            _ => {
+                let (x, y) = (rand_time(state), rand_time(state));
+                encode_range(x.min(y), x.max(y)).unwrap()
+            }
+        }
+    }
+
+    // ── golden fixtures (normative; words persist on disk) ──────────────
+
+    #[test]
+    fn golden_epoch_timestamp() {
+        // The epoch instant 1850-01-01T00:00:00 (t = 0 ns): only the flag
+        // bit is set.
+        assert_eq!(encode_timestamp(0).unwrap(), 0x8000_0000);
+    }
+
+    #[test]
+    fn golden_2018_timestamp() {
+        // 2018-01-01T00:00:00 UTC as internal ns, derived:
+        //   proleptic-Gregorian days 1850-01-01 -> 2018-01-01 = 61,362
+        //   (168 years * 365 + 41 leap days: 1852..2016 has 42 multiples of
+        //   4, minus 1900, a century non-leap year);
+        //   naive ns = 61,362 * 86,400 * 10^9 = 5,301,590,400e9;
+        //   GPS - UTC at 2018 = TAI - UTC - 19 = 37 - 19 = 18 s;
+        //   t = 5,301,590,400e9 + 18e9 = 5,301,590,418,000,000,000 ns.
+        // (Cross-check: GPS seconds since 1980-01-06 for that instant are
+        // 1,198,800,018, the published GPS time of 2018-01-01 UTC, and
+        // 47,486 days separate 1850-01-01 from 1980-01-06:
+        // 4,102,790,400e9 + 1,198,800,018e9 = the same t.)
+        let t: u64 = 5_301_590_418_000_000_000;
+        let w = encode_timestamp(t).unwrap();
+        assert_eq!(w, 0x9326_10CA_E981_3400);
+        assert_eq!(w, 10_603_180_836_377_408_512);
+        assert_eq!(decode(w), (t, t, false));
+    }
+
+    #[test]
+    fn golden_range_straddling_quantum_boundary() {
+        // [3*2^32 - 5e8, 3*2^32 + 5e8] straddles the 2^32 grid line at
+        // 3*2^32: s = floor(a / 2^31) = 5, e = floor(b / 2^32) + 1 = 4.
+        let a: u64 = 3 * (1 << 32) - 500_000_000;
+        let b: u64 = 3 * (1 << 32) + 500_000_000;
+        let w = encode_range(a, b).unwrap();
+        assert_eq!(w, 0x5_0000_0004);
+        assert_eq!(w, 21_474_836_484);
+        let (s, e, is_rng) = decode(w);
+        assert!(is_rng);
+        assert_eq!((s, e), (5 << 31, 4u64 << 32));
+        assert!(s <= a && b < e);
+    }
+
+    #[test]
+    fn golden_range_end_exactly_on_grid() {
+        // b = 7*2^32 sits exactly on the 2^32 grid; the ceiling is
+        // strictly greater: e = (b >> 32) + 1 = 8, never 7 — the envelope
+        // must properly contain b.
+        let a: u64 = 7 * (1 << 32) - 1_000_000_000;
+        let b: u64 = 7 * (1 << 32);
+        let w = encode_range(a, b).unwrap();
+        assert_eq!(w, (13 << 32) | 8);
+        let (_, e, _) = decode(w);
+        assert_eq!(e, 8u64 << 32);
+        assert!(b < e, "end ceiling must be strictly greater than b");
+    }
+
+    // ── encoder domain ───────────────────────────────────────────────────
+
+    #[test]
+    fn top_of_span_is_rejected() {
+        assert!(encode_timestamp(TOC_MAX_NS).is_err());
+        assert!(encode_timestamp(u64::MAX).is_err());
+        assert!(encode_range(0, TOC_MAX_NS).is_err());
+        // The last valid instant fills the end field exactly.
+        let w = encode_range(0, TOC_MAX_NS - 1).unwrap();
+        assert_eq!(w & LOW_MASK, LOW_MASK);
+        assert!(encode_timestamp(TOC_MAX_NS - 1).is_ok());
+        // Inverted interval.
+        assert!(encode_range(5, 3).is_err());
+    }
+
+    #[test]
+    fn timestamp_roundtrip_and_monotonicity() {
+        let mut st = 0x175;
+        let mut prev_t = 0u64;
+        let mut prev_w = 0u64;
+        let mut times: Vec<u64> = (0..2000).map(|_| rand_time(&mut st)).collect();
+        times.extend([0, 1, Q_START_NS - 1, Q_START_NS, Q_END_NS, TOC_MAX_NS - 1]);
+        times.sort_unstable();
+        for &t in &times {
+            let w = encode_timestamp(t).unwrap();
+            assert_eq!(decode(w), (t, t, false), "roundtrip exact");
+            assert!(!is_range(w));
+            if t > prev_t {
+                assert!(w > prev_w, "word order must be monotone in t_ns");
+            }
+            (prev_t, prev_w) = (t, w);
+        }
+    }
+
+    // ── conservatism and width ───────────────────────────────────────────
+
+    #[test]
+    fn envelope_contains_interval_and_is_bounded() {
+        let mut st = 0xC0FFEE;
+        for i in 0..4000 {
+            let (x, y) = (rand_time(&mut st), rand_time(&mut st));
+            let (a, mut b) = (x.min(y), x.max(y));
+            if i % 8 == 0 {
+                // Force the strictly-greater ceiling edge: b on the 2^32 grid.
+                b = (b >> 32) << 32;
+                if b < a {
+                    continue;
+                }
+            }
+            let (s, e, _) = decode(encode_range(a, b).unwrap());
+            assert!(s <= a, "start floors");
+            assert!(b < e, "end is strictly greater, half-open envelope");
+            // Width bound: envelope <= real span + one quantum per end.
+            assert!(e - s <= (b - a) + Q_START_NS + Q_END_NS);
+        }
+    }
+
+    #[test]
+    fn merge_envelope_contains_every_input_instant() {
+        let mut st = 0xDECADE;
+        for _ in 0..1000 {
+            let n = 2 + (splitmix64(&mut st) % 6) as usize;
+            let words: Vec<u64> = (0..n).map(|_| rand_word(&mut st)).collect();
+            let folded = words.iter().copied().reduce(merge).unwrap();
+            let (fs, fe, _) = decode(folded);
+            for &w in &words {
+                let (s, e, is_rng) = decode(w);
+                assert!(fs <= s);
+                // A timestamp's instant must land inside; a range's whole
+                // envelope must land inside.
+                if is_rng {
+                    assert!(e <= fe);
+                } else {
+                    assert!(s < fe);
+                }
+            }
+        }
+    }
+
+    // ── semilattice laws ─────────────────────────────────────────────────
+
+    #[test]
+    fn merge_is_idempotent_including_timestamps() {
+        let mut st = 0x1DEA;
+        for _ in 0..2000 {
+            let w = rand_word(&mut st);
+            assert_eq!(merge(w, w), w, "merge(w, w) must return w unchanged");
+        }
+        // The load-bearing case: two equal timestamps must NOT become
+        // their range envelope.
+        let t = encode_timestamp(123_456_789_012).unwrap();
+        assert_eq!(merge(t, t), t);
+        assert!(!is_range(merge(t, t)));
+    }
+
+    #[test]
+    fn merge_is_commutative_and_associative() {
+        let mut st = 0xABBA;
+        for _ in 0..2000 {
+            let (a, b, c) = (rand_word(&mut st), rand_word(&mut st), rand_word(&mut st));
+            assert_eq!(merge(a, b), merge(b, a));
+            assert_eq!(merge(merge(a, b), c), merge(a, merge(b, c)));
+            // Mixed case: an equal-timestamp pair inside a triple.
+            assert_eq!(merge(merge(a, a), c), merge(a, merge(a, c)));
+        }
+    }
+
+    #[test]
+    fn fold_tree_independence() {
+        /// Fold `words` with a random binary tree shape.
+        fn fold_random(words: &[u64], st: &mut u64) -> u64 {
+            match words.len() {
+                1 => words[0],
+                n => {
+                    let cut = 1 + (splitmix64(st) % (n as u64 - 1)) as usize;
+                    merge(
+                        fold_random(&words[..cut], st),
+                        fold_random(&words[cut..], st),
+                    )
+                }
+            }
+        }
+        let mut st = 0xF01D;
+        for _ in 0..300 {
+            let n = 2 + (splitmix64(&mut st) % 14) as usize;
+            let mut words: Vec<u64> = (0..n).map(|_| rand_word(&mut st)).collect();
+            // Plant a duplicated timestamp so equal-word pairs occur inside
+            // larger reductions.
+            let dup = encode_timestamp(rand_time(&mut st)).unwrap();
+            words.push(dup);
+            words.push(dup);
+            let reference = words.iter().copied().reduce(merge).unwrap();
+            for _ in 0..8 {
+                assert_eq!(
+                    fold_random(&words, &mut st),
+                    reference,
+                    "every fold tree must produce the identical u64"
+                );
+            }
+        }
+    }
+
+    // ── sort property ────────────────────────────────────────────────────
+
+    #[test]
+    fn sort_order_is_conservative_start_order() {
+        let mut st = 0x50FA;
+        let mut words: Vec<u64> = (0..4000).map(|_| rand_word(&mut st)).collect();
+        words.sort_unstable();
+        let mut prev_start = 0u64;
+        for &w in &words {
+            let start = (w >> 32) << 31; // conservative encoded start, both kinds
+            assert!(start >= prev_start, "u64 order must be start order");
+            assert_eq!(decode(w).0 >> 31 << 31, start);
+            prev_start = start;
+        }
+    }
+
+    #[test]
+    fn tied_quantum_tiebreaks() {
+        // Within one start quantum q: ranges (flag 0) sort before
+        // timestamps (flag 1); ranges shorter-first by end code;
+        // timestamps in exact ns order.
+        let q: u64 = 1_000_000; // start quantum index
+        let base = q * Q_START_NS;
+        let ts_lo = encode_timestamp(base + 7).unwrap();
+        let ts_hi = encode_timestamp(base + Q_START_NS - 1).unwrap();
+        let rng_short = encode_range(base + 100, base + 200).unwrap();
+        let rng_long = encode_range(base + 100, base + 10 * Q_END_NS).unwrap();
+        assert_eq!(ts_lo >> 32, q);
+        assert_eq!(rng_short >> 32, q);
+        assert!(rng_short < rng_long, "shorter range first");
+        assert!(
+            rng_long < ts_lo,
+            "ranges before timestamps in a tied quantum"
+        );
+        assert!(ts_lo < ts_hi, "timestamps in exact ns order");
+    }
+}


### PR DESCRIPTION
Closes #175

## What this is

The **toc word** — temporal order coverage: one `u64`, a tagged union of an exact nanosecond **timestamp** and a quantized, conservative **time range**, sortable as a plain unsigned integer and closed under a semilattice merge. Design transferred from englacial/zagg#410; every layout decision follows the #175 ledger exactly:

- 1 ns base quantum, 32/31 split ([decision](https://github.com/espg/mortie/issues/175#issuecomment-5230004941))
- flag at **bit 31** (1 = timestamp, 0 = range), `toc` naming, and the normative line ([amendments](https://github.com/espg/mortie/issues/175#issuecomment-5230049902))
- window predicates in scope, interval-set algebra deferred to #177 ([scope](https://github.com/espg/mortie/issues/175#issuecomment-5230084582))
- flat-array ops in `mortie/toc.py`, mirroring the moc pattern; `batch.py` untouched ([ruling](https://github.com/espg/mortie/issues/175#issuecomment-5230097527))

Layout, restated:

```
[start: 32 bits, 2^31 ns units][flag: 1 bit][low: 31 bits]
  timestamp: word = t_ns with a 1 flag bit spliced in at position 31
  range:     low = end code, 31 bits at 2^32 ns; envelope [s*2^31, e*2^32) half-open
```

Outward rounding uses a **strictly-greater end ceiling**: `e = (b >> 32) + 1` uniformly, including when `b` sits exactly on the 2^32 grid, so the envelope always properly contains `b`. Consequence: internal times are range-checked against `TOC_MAX_NS = 2^63 - 2^32` (the end code must fit 31 bits, ~4 s short of the year-2142 span ceiling) — applied to *both* encoders so every encodable word is mergeable. Merge returns bitwise-equal inputs unchanged (idempotence: two equal timestamps must not become their range envelope); any other pair merges conservative envelopes into a range word.

## Phases

- [x] Phase 1 — Rust kernel `src_rust/src/toc.rs`: layout constants, scalar `encode_timestamp` / `encode_range` / `decode` / `is_range` / `merge`; cargo property tests (semilattice laws incl. `merge(w,w) = w` for timestamps, fold-tree independence, sort monotonicity + tied-quantum tiebreaks, containment/conservatism incl. the on-grid ceiling edge, width bound, roundtrip, top-of-span rejection) and golden u64 fixtures.
- [x] Phase 2 — pyfunctions + `mortie/toc.py`: `time2toc`, `span2toc`, `toc2time`, `toc_merge`, `toc_reduce`, `toc_is_range`, `toc_overlaps`, `toc_contains`; exports; pytest parity + mirrored property suite.
- [x] Phase 3 — timescale boundary: `from_datetime64` / `to_datetime64` (static leap table) and `from_gps_ns` / `to_gps_ns` (constant offset), with pinned boundary tests.
- [x] Phase 4 — docs: `docs/api/toc.md` + mkdocs nav; numpydoc on every public function.

## Golden fixtures (normative)

| fixture | word |
|---|---|
| epoch instant 1850-01-01T00:00:00 (t = 0) | `0x80000000` = 2147483648 |
| 2018-01-01T00:00:00 UTC = internal ns 5,301,590,418,000,000,000 (61,361 days × 86,400 s + 18 s GPS−UTC; cross-checked against GPS second 1,198,800,018) | `0x932610CAE9813400` = 10603180836377408512 |
| range [3·2^32 − 5e8, 3·2^32 + 5e8] straddling a 2^32 grid line (s = 5, e = 4) | `0x500000004` = 21474836484 |
| range ending exactly on the grid at 7·2^32 (e = 8, strictly greater) | `(13 << 32) \| 8` = 55834574856 |

## Testing

All phases green locally: `maturin develop --release`, `cargo test --lib` (330 tests, the 13 new toc tests included), `cargo fmt --check`, `cargo clippy` (no new warnings; the existing ones predate this branch), `flake8 mortie --select=E9,F63,F7,F82`, `pytest -v` (30 new tests in `mortie/tests/test_toc.py`, full suite passing), `numpydoc lint mortie/*.py`. One pre-existing environment quirk, flagged rather than fixed: `cargo test`'s *doctest* phase fails to link the cdylib on this macOS setup (plain cargo lacks maturin's `-undefined dynamic_lookup` link args) — verified identical on `origin/main`, and the repo has no Rust doctests, so `--lib` is the entire suite. The Rust property tests use a hand-rolled splitmix64 (no new dependency); the pytest suite mirrors them at array level and adds the timescale-boundary pins (GPS-epoch identity, the 2016-12-31 leap second, modern-era datetime64 roundtrips through a toc word).

## Questions for review

- **Pre-1972 UTC convention (phase 3)**: the plan is **zero offset before 1972** (naive proleptic day-count seconds, no leap adjustment), rather than freezing the 1972 offset of −9 s. Rationale: it pins the epoch identity exactly (`from_datetime64('1850-01-01') == 0`), and a frozen −9 s would push the epoch itself to a negative internal time, which u64 cannot hold. Cost: a 9 s backward step across the 1972-01-01 boundary, so the last 9 SI seconds of 1971 alias early 1972 and are not invertible; conversion is exact and invertible from 1972 on. Documented in the docstring. Historical data carries hours-level precision, so stakes are low — flagged here per the ledger so the choice is explicit.
- **Timestamp ceiling**: `TOC_MAX_NS` is enforced on `encode_timestamp` too (not only on range ends), so that merge is total over encodable words — a timestamp in the final 2^32 ns of the span would otherwise overflow the end field on first merge. This forfeits the last ~4.3 s before the 2142 ceiling for timestamps as well; flagging since the ledger's range-check wording named the range encoder only.
- **Phase-3 spellings** (`from_datetime64` / `to_datetime64` / `from_gps_ns` / `to_gps_ns`, exported flat) settle in review per the [naming amendment](https://github.com/espg/mortie/issues/175#issuecomment-5230049902).
- The example notebook lands as a follow-up, not in this PR ([ruling](https://github.com/espg/mortie/issues/175#issuecomment-5230097527)).
