### PR TITLE
Deterministic, order-independent ring chaining in dissolve (issue #155)

### DIFF
--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -177,59 +177,118 @@ fn tangent_azimuth(p: &Vec3, q: &Vec3) -> f64 {
     dot(&d, &east).atan2(dot(&d, &north))
 }
 
+/// Chain surviving directed edges into rings.
+///
+/// Deterministic and order-independent by construction (issue #155):
+/// permuting `survivors` cannot change the output.  The edge stream is
+/// canonicalized by sorting, `successor(edge)` is a **pure function of the
+/// edge set** computed up front (a rotational sweep at every vertex pairs
+/// each arriving edge with the first departing edge encountered sweeping in
+/// +azimuth from its reversed-arrival direction — the old smallest-turn rule
+/// freed of its history-dependent aliveness filter), and each emitted ring
+/// is rotated to a canonical start (minimal vertex id, ties by smallest id
+/// sequence).  The pairing is interior-consistent: at a non-manifold
+/// corner-touch vertex the boundary pinches into simple rings touching at a
+/// point, never a self-intersecting figure-eight.  Do not reintroduce
+/// history-dependent successor choices (e.g. filtering candidates by which
+/// edges an earlier ring consumed) — ring output must stay a pure function
+/// of the edge *set*, or dissolve's classification goes nondeterministic
+/// again (fan-anchor wrap, issue #155).
 fn chain_rings(survivors: &[(u32, u32)], id_xyz: &[Vec3]) -> Vec<Vec<Vec3>> {
-    let two_pi = std::f64::consts::TAU;
-    let az: Vec<f64> = survivors
-        .iter()
-        .map(|&(a, b)| tangent_azimuth(&id_xyz[a as usize], &id_xyz[b as usize]))
-        .collect();
-    let mut alive: Vec<bool> = vec![true; survivors.len()];
-    let mut by_start: HashMap<u32, Vec<usize>> = HashMap::new();
-    for (i, &(a, _)) in survivors.iter().enumerate() {
-        by_start.entry(a).or_default().push(i);
+    // Canonical edge stream: sorted, duplicate directed edges adjacent.
+    let mut edges: Vec<(u32, u32)> = survivors.to_vec();
+    edges.sort_unstable();
+    let n = edges.len();
+
+    // Rotational sweep entries per vertex: (angle, kind, edge) with kind
+    // 0 = arriving edge at its reversed-arrival azimuth, kind 1 = departing
+    // edge at its forward azimuth.  At equal angles an arrival sorts first,
+    // so a departing edge lying exactly along a reversed arrival pairs with
+    // it (zero turn — the old rule's minimum); remaining ties break by
+    // canonical edge index.
+    let mut at_vertex: HashMap<u32, Vec<(f64, u8, usize)>> = HashMap::new();
+    for (i, &(a, b)) in edges.iter().enumerate() {
+        let pa = &id_xyz[a as usize];
+        let pb = &id_xyz[b as usize];
+        at_vertex
+            .entry(a)
+            .or_default()
+            .push((tangent_azimuth(pa, pb), 1, i));
+        at_vertex
+            .entry(b)
+            .or_default()
+            .push((tangent_azimuth(pb, pa), 0, i));
     }
 
+    // successor[i] = the edge following edge i in its ring.  Cyclic bracket
+    // matching per vertex: sweep entries in ascending angle (twice, for the
+    // wrap-around); a departing edge closes the most recently opened arrival
+    // (LIFO), so nested wedges resolve to separate simple rings instead of
+    // crossing.  Balanced in/out degrees (guaranteed by edge cancellation)
+    // leave nothing unpaired; an unbalanced vertex leaves `None`, emitted
+    // below as an open chain exactly like the old dead-end break.
+    let mut successor: Vec<Option<usize>> = vec![None; n];
+    for entries in at_vertex.values_mut() {
+        entries.sort_by(|x, y| {
+            x.0.partial_cmp(&y.0)
+                .unwrap()
+                .then(x.1.cmp(&y.1))
+                .then(x.2.cmp(&y.2))
+        });
+        let mut pending: Vec<usize> = Vec::new();
+        let mut matched: Vec<bool> = vec![false; entries.len()];
+        for pass in 0..2 {
+            for (e, &(_, kind, i)) in entries.iter().enumerate() {
+                if kind == 0 {
+                    if pass == 0 {
+                        pending.push(i);
+                    }
+                } else if !matched[e] {
+                    if let Some(arrived) = pending.pop() {
+                        successor[arrived] = Some(i);
+                        matched[e] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // Ring extraction: cycle-following in the functional graph, seeds in
+    // canonical edge order.
     let mut rings = Vec::new();
-    for seed in 0..survivors.len() {
-        if !alive[seed] {
+    let mut visited = vec![false; n];
+    for seed in 0..n {
+        if visited[seed] {
             continue;
         }
-        let seed_start = survivors[seed].0;
-        let mut cur = seed;
         let mut chain: Vec<u32> = Vec::new();
+        let mut cur = seed;
         loop {
-            if !alive[cur] {
-                break;
+            visited[cur] = true;
+            chain.push(edges[cur].0);
+            match successor[cur] {
+                Some(nxt) if nxt == seed => break, // ring closed
+                Some(nxt) if !visited[nxt] => cur = nxt,
+                _ => break, // open chain (unbalanced vertex)
             }
-            alive[cur] = false;
-            chain.push(survivors[cur].0);
-            let v = survivors[cur].1;
-            if v == seed_start {
-                break; // ring closed
-            }
-            let cands: Vec<usize> = by_start
-                .get(&v)
-                .map(|ix| ix.iter().copied().filter(|&i| alive[i]).collect())
-                .unwrap_or_default();
-            if cands.is_empty() {
-                break;
-            }
-            cur = if cands.len() == 1 {
-                cands[0]
-            } else {
-                // smallest turn anticlockwise from the reversed arrival.
-                let back = tangent_azimuth(&id_xyz[v as usize], &id_xyz[survivors[cur].0 as usize]);
-                *cands
-                    .iter()
-                    .min_by(|&&i, &&j| {
-                        let ti = (az[i] - back).rem_euclid(two_pi);
-                        let tj = (az[j] - back).rem_euclid(two_pi);
-                        ti.partial_cmp(&tj).unwrap()
-                    })
-                    .unwrap()
-            };
         }
-        rings.push(chain.iter().map(|&i| id_xyz[i as usize]).collect());
+        // Canonical rotation: start at the minimal vertex id; if a ring
+        // passes through it more than once, the smallest id sequence.
+        let m = chain.len();
+        let min_id = *chain.iter().min().unwrap();
+        let mut best: Option<Vec<u32>> = None;
+        for s in (0..m).filter(|&s| chain[s] == min_id) {
+            let rot: Vec<u32> = (0..m).map(|k| chain[(s + k) % m]).collect();
+            if best.as_ref().is_none_or(|b| rot < *b) {
+                best = Some(rot);
+            }
+        }
+        rings.push(
+            best.unwrap()
+                .iter()
+                .map(|&i| id_xyz[i as usize])
+                .collect::<Vec<Vec3>>(),
+        );
     }
     rings
 }

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -7,9 +7,11 @@
 //!    boundary point is integer-snapped to a vertex id, so a corner/sub-edge
 //!    point shared by two neighbours collapses to one id and their shared edge
 //!    cancels exactly (no floating tolerance search).
-//! 2. The surviving directed edges chain into rings; at a non-manifold
-//!    corner-touch vertex the next edge is the smallest anticlockwise turn from
-//!    the reversed arrival (right-hand rule), keeping rings simple.
+//! 2. The surviving directed edges chain into rings via an upfront rotational
+//!    pairing — a pure, order-independent successor function (issue #155); at
+//!    a non-manifold corner-touch vertex each arriving edge pairs with the
+//!    smallest-turn departing edge, pinching the boundary into simple rings
+//!    touching at a point (never a self-intersecting figure-eight).
 //! 3. Rings are classified exterior/hole by spherical signed area (global
 //!    winding normalised so the covered area is positive), then crossing rings
 //!    are cut at +/-180 and reconnected by the GeoJSON convention — explicit
@@ -83,8 +85,16 @@ pub fn dissolve(morton: &[u64], step: u32) -> Result<ClassifiedRings, String> {
 // ── edge-cancellation: cover → boundary rings (unit vectors) ───────────────
 
 fn boundary_rings_xyz(morton: &[u64], step: u32) -> Vec<Vec<Vec3>> {
+    let (survivors, id_xyz) = survivor_edges(morton, step);
+    chain_rings(&survivors, &id_xyz)
+}
+
+/// Surviving directed boundary edges of a cover, plus the snapped vertex
+/// coordinates they index (split out of [`boundary_rings_xyz`] so tests can
+/// drive [`chain_rings`] with permuted edge slices, issue #155).
+fn survivor_edges(morton: &[u64], step: u32) -> (Vec<(u32, u32)>, Vec<Vec3>) {
     if morton.is_empty() {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     }
     // Decode depth per word; densify a mixed-order MOC to its finest order so
     // every cell carries unit-length edges that cancel against their neighbours.
@@ -153,7 +163,7 @@ fn boundary_rings_xyz(morton: &[u64], step: u32) -> Vec<Vec<Vec3>> {
             survivors.push((a, b));
         }
     }
-    chain_rings(&survivors, &id_xyz)
+    (survivors, id_xyz)
 }
 
 // ── ring chaining (angular / right-hand rule at non-manifold vertices) ─────
@@ -665,6 +675,102 @@ mod tests {
             let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("iteration {i} failed: {e}"));
             assert!(!got.shells.is_empty(), "iteration {i}: no shells");
         }
+    }
+
+    #[test]
+    fn dissolve_output_is_byte_identical_across_calls() {
+        // issue #155 phase 3: dissolve is a pure function of its input --
+        // two calls on identical input return byte-identical ClassifiedRings,
+        // on each fixture shape (plain cover, step > 1 densified edges, the
+        // pole/antimeridian stitch path, an equatorial cell).
+        let north: Vec<u64> = (0..16u64)
+            .map(|n| crate::morton::nested2mort(n, 1))
+            .collect();
+        let south: Vec<u64> = (32..48u64)
+            .map(|n| crate::morton::nested2mort(n, 1))
+            .collect();
+        let eq: Vec<u64> = (16..20u64)
+            .map(|n| crate::morton::nested2mort(n, 1))
+            .collect();
+        for (cover, step) in [(&north, 1u32), (&north, 4), (&south, 1), (&eq, 1), (&eq, 3)] {
+            let a = dissolve(cover, step).unwrap();
+            let b = dissolve(cover, step).unwrap();
+            assert_eq!(a.shells, b.shells);
+            assert_eq!(a.holes, b.holes);
+            assert!(!a.shells.is_empty());
+        }
+    }
+
+    #[test]
+    fn chain_rings_is_order_independent() {
+        // issue #155 phase 3: chain_rings output is a pure function of the
+        // edge *set* -- every permutation of the survivor slice yields the
+        // identical ring list (this is the invariant, not one lucky order).
+        let cover: Vec<u64> = (0..16u64)
+            .map(|n| crate::morton::nested2mort(n, 1))
+            .collect();
+        let (mut edges, id_xyz) = survivor_edges(&cover, 1);
+        let baseline = chain_rings(&edges, &id_xyz);
+        assert!(!baseline.is_empty());
+        // deterministic Fisher-Yates via an LCG (no rand dependency).
+        let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
+        let mut rng = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as usize
+        };
+        for _ in 0..200 {
+            for i in (1..edges.len()).rev() {
+                let j = rng() % (i + 1);
+                edges.swap(i, j);
+            }
+            assert_eq!(chain_rings(&edges, &id_xyz), baseline);
+        }
+        edges.sort_unstable();
+        edges.reverse();
+        assert_eq!(chain_rings(&edges, &id_xyz), baseline);
+    }
+
+    #[test]
+    fn corner_touch_pairs_into_simple_rings() {
+        // issue #155 ruling: at a non-manifold corner-touch vertex the
+        // rotational pairing pinches the boundary into simple rings touching
+        // at a point (GeoJSON-valid) -- never one self-intersecting
+        // figure-eight.  Two diamonds east and west of a shared vertex T,
+        // both wound anticlockwise (interior on the same side).
+        let ll = |lon: f64, lat: f64| -> Vec3 {
+            let (rlon, rlat) = (lon.to_radians(), lat.to_radians());
+            [rlat.cos() * rlon.cos(), rlat.cos() * rlon.sin(), rlat.sin()]
+        };
+        let id_xyz = [
+            ll(0.0, 0.0),   // 0: T, the corner-touch vertex
+            ll(5.0, 5.0),   // 1: east diamond, north corner
+            ll(10.0, 0.0),  // 2: east diamond, east corner
+            ll(5.0, -5.0),  // 3: east diamond, south corner
+            ll(-5.0, 5.0),  // 4: west diamond, north corner
+            ll(-10.0, 0.0), // 5: west diamond, west corner
+            ll(-5.0, -5.0), // 6: west diamond, south corner
+        ];
+        let edges = [
+            (0, 3),
+            (3, 2),
+            (2, 1),
+            (1, 0), // east: T -> S -> E -> N -> T
+            (0, 4),
+            (4, 5),
+            (5, 6),
+            (6, 0), // west: T -> N -> W -> S -> T
+        ];
+        let rings = chain_rings(&edges, &id_xyz);
+        assert_eq!(
+            rings.len(),
+            2,
+            "pinch must yield two rings, not a figure-eight"
+        );
+        // exact pairing: each ring stays inside its own diamond, T once each.
+        assert_eq!(rings[0], vec![id_xyz[0], id_xyz[3], id_xyz[2], id_xyz[1]]);
+        assert_eq!(rings[1], vec![id_xyz[0], id_xyz[4], id_xyz[5], id_xyz[6]]);
     }
 
     #[test]

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -584,6 +584,31 @@ mod tests {
     }
 
     #[test]
+    fn sub_hemisphere_cover_dissolves_deterministically() {
+        // issue #155: dissolve on this fixed cover (base cells 0-3 at order
+        // 1) flaked ~10-15% per call.  Phase-1 instrumentation finding: the
+        // cover's boundary graph is a single simple 16-cycle -- there is no
+        // branching vertex at all (neither a true corner-touch nor a
+        // snap-merge artifact; no near-coincident vertex pairs, no duplicate
+        // directed edges), so the ring *decomposition* is unique.  The
+        // nondeterminism was purely the HashMap-seeded starting rotation of
+        // that one ring: classify_and_split fans spherical_signed_area from
+        // ring[0], and 2 of the 16 possible anchors (the equatorial spike
+        // tips at lon +/-45, lat 0) wrap the fan to 0.790 sr vs the true
+        // 4.090 sr, tripping the hemisphere-ring guard -- predicting 2/16 =
+        // 12.5% (measured 48/400 pre-fix).  Each dissolve call builds fresh
+        // HashMaps, so the flake reproduces in-process: pre-fix, 50
+        // iterations fail with p ~= 1 - (7/8)^50 ~= 0.999.
+        let cover: Vec<u64> = (0..16u64)
+            .map(|nest| crate::morton::nested2mort(nest, 1))
+            .collect();
+        for i in 0..50 {
+            let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("iteration {i} failed: {e}"));
+            assert!(!got.shells.is_empty(), "iteration {i}: no shells");
+        }
+    }
+
+    #[test]
     fn pole_cap_stitches_to_one_ring_with_pole_vertex() {
         // one segment running +180 -> -180 around the pole, stitched through -90.
         let segs = vec![vec![

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -191,15 +191,22 @@ fn tangent_azimuth(p: &Vec3, q: &Vec3) -> f64 {
 ///
 /// Deterministic and order-independent by construction (issue #155):
 /// permuting `survivors` cannot change the output.  The edge stream is
-/// canonicalized by sorting, `successor(edge)` is a **pure function of the
-/// edge set** computed up front (a rotational sweep at every vertex pairs
-/// each arriving edge with the first departing edge encountered sweeping in
-/// +azimuth from its reversed-arrival direction — the old smallest-turn rule
-/// freed of its history-dependent aliveness filter), and each emitted ring
-/// is rotated to a canonical start (minimal vertex id, ties by smallest id
-/// sequence).  The pairing is interior-consistent: at a non-manifold
-/// corner-touch vertex the boundary pinches into simple rings touching at a
-/// point, never a self-intersecting figure-eight.  Do not reintroduce
+/// canonicalized by sorting, and `successor(edge)` is a **pure function of
+/// the edge set** computed up front by a rotational sweep at every vertex:
+/// arriving edges (at their reversed-arrival azimuth) and departing edges
+/// (at their forward azimuth) are swept in ascending angle, cyclically, and
+/// each departing edge closes the most recently opened arrival — **LIFO
+/// bracket matching**, which is the contract.  Where arrivals and
+/// departures alternate around the vertex (the generic case for a
+/// consistently wound boundary) LIFO coincides with the old smallest-turn
+/// rule freed of its history-dependent aliveness filter; where snap
+/// degeneracy breaks alternation, LIFO governs, because nested wedges then
+/// resolve to non-crossing rings.  The pairing is interior-consistent: at a
+/// non-manifold corner-touch vertex the boundary pinches into simple rings
+/// touching at a point, never a self-intersecting figure-eight.  Each
+/// emitted ring starts at its minimal vertex id — rings are seeded from
+/// their smallest sorted edge, whose start vertex is that minimum — giving
+/// [`classify_and_split`]'s fan a deterministic anchor.  Do not reintroduce
 /// history-dependent successor choices (e.g. filtering candidates by which
 /// edges an earlier ring consumed) — ring output must stay a pure function
 /// of the edge *set*, or dissolve's classification goes nondeterministic
@@ -282,23 +289,11 @@ fn chain_rings(survivors: &[(u32, u32)], id_xyz: &[Vec3]) -> Vec<Vec<Vec3>> {
                 _ => break, // open chain (unbalanced vertex)
             }
         }
-        // Canonical rotation: start at the minimal vertex id; if a ring
-        // passes through it more than once, the smallest id sequence.
-        let m = chain.len();
-        let min_id = *chain.iter().min().unwrap();
-        let mut best: Option<Vec<u32>> = None;
-        for s in (0..m).filter(|&s| chain[s] == min_id) {
-            let rot: Vec<u32> = (0..m).map(|k| chain[(s + k) % m]).collect();
-            if best.as_ref().is_none_or(|b| rot < *b) {
-                best = Some(rot);
-            }
-        }
-        rings.push(
-            best.unwrap()
-                .iter()
-                .map(|&i| id_xyz[i as usize])
-                .collect::<Vec<Vec3>>(),
-        );
+        // The seed is the ring's smallest sorted edge, so `chain` already
+        // starts at the ring's minimal vertex id (and, via the shared
+        // successor path, in its lexicographically smallest rotation) — no
+        // explicit re-rotation needed for a canonical start.
+        rings.push(chain.iter().map(|&i| id_xyz[i as usize]).collect());
     }
     rings
 }
@@ -701,58 +696,24 @@ mod tests {
         }
     }
 
-    #[test]
-    fn chain_rings_is_order_independent() {
-        // issue #155 phase 3: chain_rings output is a pure function of the
-        // edge *set* -- every permutation of the survivor slice yields the
-        // identical ring list (this is the invariant, not one lucky order).
-        let cover: Vec<u64> = (0..16u64)
-            .map(|n| crate::morton::nested2mort(n, 1))
-            .collect();
-        let (mut edges, id_xyz) = survivor_edges(&cover, 1);
-        let baseline = chain_rings(&edges, &id_xyz);
-        assert!(!baseline.is_empty());
-        // deterministic Fisher-Yates via an LCG (no rand dependency).
-        let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
-        let mut rng = || {
-            state = state
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            (state >> 33) as usize
-        };
-        for _ in 0..200 {
-            for i in (1..edges.len()).rev() {
-                let j = rng() % (i + 1);
-                edges.swap(i, j);
-            }
-            assert_eq!(chain_rings(&edges, &id_xyz), baseline);
-        }
-        edges.sort_unstable();
-        edges.reverse();
-        assert_eq!(chain_rings(&edges, &id_xyz), baseline);
+    fn lonlat_xyz(lon: f64, lat: f64) -> Vec3 {
+        let (rlon, rlat) = (lon.to_radians(), lat.to_radians());
+        [rlat.cos() * rlon.cos(), rlat.cos() * rlon.sin(), rlat.sin()]
     }
 
-    #[test]
-    fn corner_touch_pairs_into_simple_rings() {
-        // issue #155 ruling: at a non-manifold corner-touch vertex the
-        // rotational pairing pinches the boundary into simple rings touching
-        // at a point (GeoJSON-valid) -- never one self-intersecting
-        // figure-eight.  Two diamonds east and west of a shared vertex T,
-        // both wound anticlockwise (interior on the same side).
-        let ll = |lon: f64, lat: f64| -> Vec3 {
-            let (rlon, rlat) = (lon.to_radians(), lat.to_radians());
-            [rlat.cos() * rlon.cos(), rlat.cos() * rlon.sin(), rlat.sin()]
-        };
-        let id_xyz = [
-            ll(0.0, 0.0),   // 0: T, the corner-touch vertex
-            ll(5.0, 5.0),   // 1: east diamond, north corner
-            ll(10.0, 0.0),  // 2: east diamond, east corner
-            ll(5.0, -5.0),  // 3: east diamond, south corner
-            ll(-5.0, 5.0),  // 4: west diamond, north corner
-            ll(-10.0, 0.0), // 5: west diamond, west corner
-            ll(-5.0, -5.0), // 6: west diamond, south corner
+    // Two diamonds east and west of a shared corner-touch vertex T (id 0),
+    // both wound anticlockwise (interior on the same side).
+    fn corner_touch_fixture() -> (Vec<Vec3>, Vec<(u32, u32)>) {
+        let id_xyz = vec![
+            lonlat_xyz(0.0, 0.0),   // 0: T, the corner-touch vertex
+            lonlat_xyz(5.0, 5.0),   // 1: east diamond, north corner
+            lonlat_xyz(10.0, 0.0),  // 2: east diamond, east corner
+            lonlat_xyz(5.0, -5.0),  // 3: east diamond, south corner
+            lonlat_xyz(-5.0, 5.0),  // 4: west diamond, north corner
+            lonlat_xyz(-10.0, 0.0), // 5: west diamond, west corner
+            lonlat_xyz(-5.0, -5.0), // 6: west diamond, south corner
         ];
-        let edges = [
+        let edges = vec![
             (0, 3),
             (3, 2),
             (2, 1),
@@ -762,6 +723,69 @@ mod tests {
             (5, 6),
             (6, 0), // west: T -> N -> W -> S -> T
         ];
+        (id_xyz, edges)
+    }
+
+    // chain_rings on every LCG-shuffled permutation of `edges` (plus the
+    // reverse-sorted order) must equal its output on the canonical order.
+    fn assert_permutation_invariant(edges: &[(u32, u32)], id_xyz: &[Vec3]) {
+        let baseline = chain_rings(edges, id_xyz);
+        assert!(!baseline.is_empty());
+        // deterministic Fisher-Yates via an LCG (no rand dependency).
+        let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
+        let mut rng = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as usize
+        };
+        let mut shuffled = edges.to_vec();
+        for _ in 0..200 {
+            for i in (1..shuffled.len()).rev() {
+                let j = rng() % (i + 1);
+                shuffled.swap(i, j);
+            }
+            assert_eq!(chain_rings(&shuffled, id_xyz), baseline);
+        }
+        shuffled.sort_unstable();
+        shuffled.reverse();
+        assert_eq!(chain_rings(&shuffled, id_xyz), baseline);
+    }
+
+    #[test]
+    fn chain_rings_is_order_independent() {
+        // issue #155 phase 3: chain_rings output is a pure function of the
+        // edge *set* -- every permutation of the survivor slice yields the
+        // identical ring list (this is the invariant, not one lucky order).
+        // Three shapes: the real cover's survivors (a simple 16-cycle --
+        // pins seed/rotation order), the corner-touch fixture (a branching
+        // vertex -- pins the rotational pairing itself), and a net > 1
+        // duplicate-edge set (pins the canonical-index tie-break at
+        // identical azimuths).
+        let cover: Vec<u64> = (0..16u64)
+            .map(|n| crate::morton::nested2mort(n, 1))
+            .collect();
+        let (edges, id_xyz) = survivor_edges(&cover, 1);
+        assert_permutation_invariant(&edges, &id_xyz);
+
+        let (id_xyz, edges) = corner_touch_fixture();
+        assert_permutation_invariant(&edges, &id_xyz);
+
+        let mut dup = edges.clone();
+        dup.extend_from_slice(&edges[..4]); // east diamond twice (net = 2)
+        assert_permutation_invariant(&dup, &id_xyz);
+        let rings = chain_rings(&dup, &id_xyz);
+        assert_eq!(rings.len(), 3, "duplicated diamond must chain twice");
+        assert_eq!(rings[0], rings[1]); // the two east copies are identical
+    }
+
+    #[test]
+    fn corner_touch_pairs_into_simple_rings() {
+        // issue #155 ruling: at a non-manifold corner-touch vertex the
+        // rotational pairing pinches the boundary into simple rings touching
+        // at a point (GeoJSON-valid) -- never one self-intersecting
+        // figure-eight.
+        let (id_xyz, edges) = corner_touch_fixture();
         let rings = chain_rings(&edges, &id_xyz);
         assert_eq!(
             rings.len(),


### PR DESCRIPTION
Closes #155. Refs #147 (classifier successor — its territory untouched here), issue #28 (determinism precedent), PR #111 (guard behavior preserved).

Makes `dissolve`'s ring chaining deterministic and order-independent, killing the ~10–15% flake in `dissolve::tests::sub_hemisphere_cover_still_dissolves`. Scope is `src_rust/src/dissolve.rs` only, per the [implementation plan](https://github.com/espg/mortie/issues/155#issuecomment-5230222605) and the [2026-08-09 rulings](https://github.com/espg/mortie/issues/155#issuecomment-5230222606).

## Phases

- [x] **Phase 1 — pin the repro + instrument the failing geometry.** `sub_hemisphere_cover_dissolves_deterministically`: 50 in-process `dissolve` calls on the issue's cover (base cells 0–3 at order 1). **Pre-fix: 48/400 single calls fail (12.0%)**, and the 50-iteration loop fails with p ≈ 1 − (7/8)⁵⁰ ≈ 0.999.
- [x] **Phase 2 — order-independent `chain_rings`**: canonical sorted edge stream, upfront rotational pairing (pure successor function computed before any chain is walked — per-vertex rotational sweep with cyclic bracket matching, LIFO so nested wedges resolve to separate simple rings), ring extraction as cycle-following in the functional graph, seeded from each ring's smallest sorted edge — which makes every ring start at its minimal vertex id, so the classifier's fan anchor is deterministic. The old alive-filter and its history dependence are gone; azimuth ties break by canonical index. Classifier/guards untouched.
- [x] **Phase 3 — tests + doc note**: `dissolve_output_is_byte_identical_across_calls` (5 fixture shapes: north cover step 1/4, south polar cap exercising the pole/antimeridian stitch, equatorial cell step 1/3); `chain_rings_is_order_independent` (200 LCG-seeded Fisher–Yates permutations plus reverse-sorted order → identical ring list — pins the invariant, not one lucky order — over three edge sets: the real cover's survivors, the corner-touch fixture, and a net > 1 duplicate-edge set); `corner_touch_pairs_into_simple_rings` (two diamonds sharing a vertex → exactly two simple rings each visiting the touch point once, per the ruled pairing); doc comment on `chain_rings` stating the pure-successor/LIFO contract; `survivor_edges` split out of `boundary_rings_xyz` so tests drive `chain_rings` with the real edge pipeline.
- [x] **Review fold** (82065c3, addressing the [adversarial review](https://github.com/espg/mortie/pull/179#discussion_r3743052040)): explicit canonical-rotation block removed as dead code (the sorted seeding already yields it), doc comment states LIFO bracket matching as the contract, permutation test extended to the branching and duplicate-edge shapes. The review's blocking finding is a decision for espg — see "Questions for review".

## Phase-1 finding: the branch-geometry question has a third answer

The [ruling](https://github.com/espg/mortie/issues/155#issuecomment-5230222606) left open whether the cover's branching vertex is a true corner-touch or a snap-merge artifact. Instrumentation says: **neither — there is no branching vertex at all.**

- The 0–3 cover's boundary graph is a **single simple 16-cycle**: 25 snapped vertices, 16 surviving directed edges, every ring vertex has in-degree = out-degree = 1, **zero duplicate directed edges** (no `net > 1`), and **zero near-coincident vertex pairs** (< 1e-8 chord) — the integer snap merged everything cleanly. 2000 fresh-`HashMap` chainings produced exactly **one** ring decomposition. The ring is a 4-pointed star around the north pole: 4 spike tips on the equator (lon ±45°/±135°, lat 0°), 4 peaks at lat 41.81°, 8 mid vertices at lat 19.47°.
- The nondeterminism is therefore purely the **starting rotation** of that one ring — the seed edge comes from `HashMap` iteration order (`counts` at `boundary_rings_xyz`), and `classify_and_split` fans `spherical_signed_area` from `ring[0]`. Sweeping all 16 rotations: 14 anchors give the honest fan sum **4.089857 sr** (true cover area 4.188790 sr), but the 2 equatorial spike-tip anchors at (±45°, 0°) wrap the fan to **0.790082 sr**, tripping the PR #111 Σ-vs-exact-area guard. Predicted failure rate 2/16 = **12.5%**; measured **48/400 = 12.0%**; issue records ~10–15%. Exact mechanism match.
- This *refines* the plan's hypothesis (different ring decompositions at branching vertices): on this cover the decomposition is unique and the original issue body's anchor-fan hypothesis was the operative one. The fix still presses exactly where the plan said — chaining canonicalization — because the ring's starting rotation is chaining output: sorting the edge stream and seeding each ring from its smallest sorted edge makes every ring start at its minimal vertex id, deterministically. Vertex ids are insertion-ordered (deterministic), and the minimal ring id (vertex 1, at lon 22.5° lat 19.47°) is a non-wrapping anchor for this cover, so the guard passes deterministically. Neither snap handling nor the classifier needs to change; the fan's anchor-fragility itself remains #147's territory.

## Approach (phase 2)

- Collect `survivors`, then `sort_unstable` — the canonical edge stream (the `HashMap` stays for O(1) counting; one O(E log E) sort of boundary edges is noise).
- Replace the alive-filtered, history-dependent successor selection with an upfront **rotational pairing**: at each vertex, sweep in-edges and out-edges by azimuth cyclically and pair them by LIFO bracket matching (interior-consistent, per the ruling — at a branching vertex the boundary pinches into simple rings touching at a point, never a figure-eight; where arrivals and departures alternate this coincides with the old smallest-turn rule). `successor(edge)` becomes a pure function computed before any chain is walked; ring extraction is cycle-following in a functional graph. Azimuth ties (duplicate directed edges) break by canonical index.
- Each emitted ring starts at its minimal vertex id, because rings are seeded from their smallest sorted edge.
- The classifier, the hemisphere/wrap guards, and everything from `classify_and_split` down are untouched.

## How tested

- Phase 1: `cargo test --lib dissolve` — the new loop test fails pre-fix as designed (48/400 single-call failures measured); all pre-existing dissolve tests pass.
- Post-fix: full `cargo test --lib` green (335 passed, 1 ignored), dissolve suite run 10+ consecutive times green (500+ loop iterations — pre-fix expectation ~62 failures); the rejection fixtures `hemisphere_cover_fails_loud` and `equatorial_band_fails_loud_not_cryptic` unchanged and passing (guard behavior preserved per PR #111).
- `cargo fmt --check` clean; `cargo clippy --lib --tests` — zero warnings in `dissolve.rs` (the 7 remaining sites are pre-existing in other modules, unchanged).
- Python gate in a clean venv (rerun after the review fold): `maturin develop --release` OK, `flake8 mortie --select=E9,F63,F7,F82` clean, `pytest -q` **1364 passed, 16 skipped**, `numpydoc lint mortie/*.py` clean. No Python-surface changes (the diff is `src_rust/src/dissolve.rs` only); the Rust↔Python differential dissolve tests compare rotation-invariantly (symmetric difference + structural fingerprint), so the canonical ring start is transparent to them.

## Questions for review

- **The deterministic anchor converts the per-call lottery into a per-cover verdict** — quantified by the [review's 3145-cover sweep](https://github.com/espg/mortie/pull/179#discussion_r3743052040): nondeterminism 2972/3145 covers → **0**; ring topology byte-identical old-vs-new throughout; zero regressions in the realistic order-2–5 families; but in the coarse order-1 base-cell family, **249 covers that sometimes passed the PR #111 guards now deterministically fail** (191 passed ≥50% of calls pre-fix; 27 ≥90%; 1 passed 40/40), while 752 flaky covers become always-pass and the aggregate pass rate is essentially unchanged (91.5% → 91.3%). Failure incidence scales with cover area (0% at 1–2 base cells → 24% at 5). How to weigh this — land as-is, make the rotation fan-aware (scope change), or hold behind #147 — is posed as a [decision on the thread](https://github.com/espg/mortie/pull/179#issuecomment-5230428447), recommendation first.
- Two candidate follow-up issues named in that decision comment (the review's two named covers as #147 acceptance fixtures; the pre-existing stitcher `assert!` surfacing as `PanicException` instead of a curated `ValueError`) — not opened unilaterally.
