### PR TITLE
Winding-free dissolve classifier: hemisphere+ covers dissolve instead of raising (issue #147)

### DIFF
--- a/mortie/dissolve.py
+++ b/mortie/dissolve.py
@@ -259,9 +259,13 @@ def _split_at_revisits(chain):
     diagonally, so the covered face's own boundary passes the pinch twice)
     the traced walk legitimately revisits that vertex — a correct even-odd
     boundary, but not an OGC-simple ring.  Splitting at each revisit yields
-    the equivalent decomposition into simple rings touching at a point.
-    Each cycle is rotated to start at its minimal vertex id.  Mirrors
-    ``split_at_revisits`` in ``src_rust/src/dissolve.rs`` (issue #147).
+    the equivalent decomposition into simple rings touching at a point.  A
+    split at a *pole* vertex re-pairs that pole's passages onto their
+    adjacent wedges; :func:`_ring_to_planar`'s empty-bracket span rule
+    renders each re-paired passage over exactly its own wedge, keeping the
+    planar shoelace budget consistent.  Each cycle is rotated to start at
+    its minimal vertex id.  Mirrors ``split_at_revisits`` in
+    ``src_rust/src/dissolve.rs`` (issue #147).
 
     Parameters
     ----------
@@ -356,16 +360,64 @@ def _normalized_lonlat(ring_xyz):
     return lat, lon
 
 
-def _ring_to_planar(ring_xyz):
+def _pole_run(out, start, stop, pole):
+    """Append a monotone lat-±90 run from *start* to *stop* (exclusive of
+    *start*), subdivided so no planar step reaches 180° — a covered polar
+    wedge can legitimately span more than 180° of longitude, which
+    :func:`_cut_at_antimeridian` would misread as a seam wrap if emitted as
+    one step.  Mirrors ``pole_run`` in ``src_rust/src/dissolve.rs``.
+    """
+    direction = 1.0 if stop > start else -1.0
+    cur = start
+    while abs(stop - cur) > 150.0:
+        cur += direction * 120.0
+        out.append((cur, pole))
+    out.append((stop, pole))
+
+
+def _pole_meridians(rings_xyz):
+    """Pole-incident boundary meridians over a ring set.
+
+    For every pole vertex, the arriving and departing neighbours'
+    (normalized) longitudes.  Feeds :func:`_ring_to_planar`'s empty-bracket
+    cap rule.  Mirrors the collection in ``classify_and_split``
+    (``src_rust/src/dissolve.rs``).
+
+    Parameters
+    ----------
+    rings_xyz : list of numpy.ndarray
+        The oriented boundary rings.
+
+    Returns
+    -------
+    tuple of list
+        ``(north, south)`` meridian longitude lists (degrees).
+    """
+    north, south = [], []
+    for ring in rings_xyz:
+        n = len(ring)
+        _, lon = _normalized_lonlat(ring)
+        for i in range(n):
+            if abs(ring[i][2]) > 1.0 - 1e-9:
+                dst = north if ring[i][2] > 0 else south
+                dst.append(float(lon[(i - 1) % n]))
+                dst.append(float(lon[(i + 1) % n]))
+    return north, south
+
+
+def _ring_to_planar(ring_xyz, north_m, south_m):
     """Convert an oriented spherical ring to planar ``(lon, lat)`` vertices.
 
     Expands any pole vertex into an explicit lat-±90 traverse: a vertex at
     the pole has no longitude (``atan2(0, 0)``); its planar image is a
-    lat-±90 *edge* from the arriving meridian's longitude to the departing
-    one's, run in the direction that keeps the covered region on the left —
-    westward across the top at +90, eastward across the bottom at -90 —
-    inserting an explicit ±180 seam pair when the direct step would run the
-    wrong way round.  Mirrors ``ring_to_planar`` in
+    lat-±90 *edge* — a cap over the wedge of longitudes this passage
+    encloses at the pole.  Which wedge is the **empty-bracket rule**: of the
+    two lon-intervals between the arriving and departing meridians, the
+    enclosed one contains no *other* pole-incident boundary meridian; at a
+    degree-2 pole both are empty and the covered side wins (westward of the
+    arrival at +90, eastward at -90).  A cap through the seam inserts an
+    exact ±180 pair that :func:`_cut_at_antimeridian` splits without
+    interpolation.  Mirrors ``ring_to_planar`` in
     ``src_rust/src/dissolve.rs`` (issue #147).
 
     Parameters
@@ -373,6 +425,8 @@ def _ring_to_planar(ring_xyz):
     ring_xyz : numpy.ndarray
         An ``(M, 3)`` array of unit vectors (open ring, covered region on
         the left).
+    north_m, south_m : list of float
+        The pole-incident meridians from :func:`_pole_meridians`.
 
     Returns
     -------
@@ -385,18 +439,37 @@ def _ring_to_planar(ring_xyz):
     for i in range(n):
         if abs(ring_xyz[i][2]) > 1.0 - 1e-9:
             pole = 90.0 if ring_xyz[i][2] > 0 else -90.0
-            lon_arr = float(lon[(i - 1) % n])
-            lon_dep = float(lon[(i + 1) % n])
-            out.append((lon_arr, pole))
-            direct_ok = lon_dep < lon_arr if pole > 0 else lon_dep > lon_arr
-            if not direct_ok:
-                # through the seam: an exact ±180 crossing that
-                # `_cut_at_antimeridian` splits without interpolation.
-                if pole > 0:
-                    out.extend([(-180.0, pole), (180.0, pole)])
+            arr = float(lon[(i - 1) % n])
+            dep = float(lon[(i + 1) % n])
+            meridians = north_m if pole > 0 else south_m
+
+            def rel_w(x):
+                return (arr - x) % 360.0
+
+            def rel_e(x):
+                return (x - arr) % 360.0
+
+            dw = rel_w(dep) or 360.0
+            de = rel_e(dep) or 360.0
+            west_clear = all(
+                rel_w(m) == 0.0 or rel_w(m) >= dw for m in meridians)
+            east_clear = all(
+                rel_e(m) == 0.0 or rel_e(m) >= de for m in meridians)
+            go_west = (pole > 0) if (west_clear and east_clear) else west_clear
+            out.append((arr, pole))
+            if go_west:
+                if dep < arr:
+                    _pole_run(out, arr, dep, pole)
                 else:
-                    out.extend([(180.0, pole), (-180.0, pole)])
-            out.append((lon_dep, pole))
+                    _pole_run(out, arr, -180.0, pole)
+                    out.append((180.0, pole))
+                    _pole_run(out, 180.0, dep, pole)
+            elif dep > arr:
+                _pole_run(out, arr, dep, pole)
+            else:
+                _pole_run(out, arr, 180.0, pole)
+                out.append((-180.0, pole))
+                _pole_run(out, -180.0, dep, pole)
         else:
             out.append((float(lon[i]), float(lat[i])))
     return out
@@ -433,10 +506,14 @@ def _cut_at_antimeridian(coords):
         cur.append((lo0, la0))
         if abs(lo1 - lo0) > 180.0:
             lo1u = lo1 - 360.0 if lo1 > lo0 else lo1 + 360.0
-            boundary = 180.0 if lo1u > lo0 else -180.0
             # An exact ±180 → ∓180 pair (a pole traverse's explicit seam
-            # crossing, `_ring_to_planar`) unwraps to a zero-length step;
-            # there is nothing to interpolate.
+            # crossing, `_ring_to_planar`) unwraps to a zero-length step:
+            # nothing to interpolate, and the cut side is the pair's own
+            # first side (the generic ``lo1u > lo0`` test cannot tell).
+            if lo1u == lo0:
+                boundary = lo0
+            else:
+                boundary = 180.0 if lo1u > lo0 else -180.0
             frac = 0.0 if lo1u == lo0 else (boundary - lo0) / (lo1u - lo0)
             la_x = la0 + frac * (la1 - la0)
             cur.append((boundary, la_x))
@@ -634,6 +711,46 @@ def _planar_signed_area(ring):
     return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
 
 
+def _split_planar_at_revisits(ring):
+    """Split a closed planar ring at exactly-repeated vertices.
+
+    The planar mirror of :func:`_split_at_revisits`, keyed on exact
+    coordinates; drops degenerate two-vertex slivers.  Mirrors
+    ``split_planar_at_revisits`` in ``src_rust/src/dissolve.rs`` (issue
+    #147).
+
+    Parameters
+    ----------
+    ring : list of tuple
+        A closed list of ``(lon, lat)`` degree pairs.
+
+    Returns
+    -------
+    list of list of tuple
+        Simple closed rings (each last vertex repeats the first).
+    """
+    out = []
+    stack = []
+    pos = {}
+
+    def emit(cycle):
+        if len(cycle) >= 3:
+            out.append(cycle + [cycle[0]])
+
+    for p in ring[:-1]:
+        if p in pos:
+            at = pos[p]
+            cycle = stack[at:]
+            del stack[at:]
+            for c in cycle:
+                pos.pop(c, None)
+            emit(cycle)
+        pos[p] = len(stack)
+        stack.append(p)
+    emit(stack)
+    return out
+
+
 def _frame_ring():
     """Return the whole-map frame shell, CCW (positive shoelace).
 
@@ -736,20 +853,29 @@ def _dissolved_rings_py(morton, step):
     ext_pieces = []
     holes = []
     segments = []
+
+    def classify(ring):
+        # A planar ring can revisit a vertex exactly — e.g. a ring that both
+        # expands a pole traverse and wraps the same pole's seam passes the
+        # ±180/±90 corner twice — which even-odd fill reads correctly but
+        # OGC does not allow in one ring; split into simple rings touching
+        # at the point.
+        for piece in _split_planar_at_revisits(ring):
+            (ext_pieces if _planar_signed_area(piece) >= 0.0 else holes).append(
+                piece
+            )
+
+    north_m, south_m = _pole_meridians(rings_xyz)
     for ring in rings_xyz:
-        ll = _ring_to_planar(ring)
+        ll = _ring_to_planar(ring, north_m, south_m)
         whole, segs = _cut_at_antimeridian(ll)
         if whole is not None:
-            (ext_pieces if _planar_signed_area(whole) >= 0.0 else holes).append(
-                whole
-            )
+            classify(whole)
         else:
             segments.extend(segs)
     if segments:
         for piece in _stitch_segments(segments):
-            (ext_pieces if _planar_signed_area(piece) >= 0.0 else holes).append(
-                piece
-            )
+            classify(piece)
 
     # Frame rule: Σ shoelace is the covered region's planar area when its
     # boundary is complete, and that minus the full map when the region

--- a/mortie/dissolve.py
+++ b/mortie/dissolve.py
@@ -348,9 +348,10 @@ def _stitch_segments(segments, pole):
 
     Raises
     ------
-    RuntimeError
+    ValueError
         If the stitch fails to converge (a guard), or if the segments are
-        unbalanced with no pole enclosed.
+        unbalanced with no pole enclosed — the curated fail-loud convention
+        (mirrors ``src_rust/src/dissolve.rs``, issue #181).
     """
     segs = [list(s) for s in segments]
     used = [False] * len(segs)
@@ -364,7 +365,11 @@ def _stitch_segments(segments, pole):
         while idx is not None and not used[idx]:
             guard += 1
             if guard > 8 * len(segs) + 16:  # pragma: no cover - convergence guard
-                raise RuntimeError("antimeridian stitch did not converge")
+                raise ValueError(
+                    "dissolved cover's antimeridian stitch did not converge "
+                    "(an internal dissolve inconsistency); pass dissolve=False "
+                    "for per-cell polygons"
+                )
             used[idx] = True
             ring.extend(segs[idx])
             idx = _next_segment(segs, used, ring, pole, seed)
@@ -406,8 +411,10 @@ def _next_segment(segs, used, ring, pole, seed):
 
     Raises
     ------
-    RuntimeError
-        If the segments are unbalanced but no pole is enclosed.
+    ValueError
+        If the segments are unbalanced but no pole is enclosed — the curated
+        fail-loud convention (mirrors ``src_rust/src/dissolve.rs``, issue
+        #181).
     """
     side, end_lat = ring[-1]
     cands = [(segs[i][0][1], i) for i in range(len(segs))
@@ -427,8 +434,13 @@ def _next_segment(segs, used, ring, pole, seed):
 
     # No same-side start in that direction: the region wraps ``pole``.  Run the
     # seam to the pole, cross to the other side, and resume from the pole.
-    if pole == 0:  # pragma: no cover - guarded by the caller's pole detection
-        raise RuntimeError("unbalanced antimeridian segments but no pole enclosed")
+    if pole == 0:
+        raise ValueError(
+            "dissolved cover's antimeridian segments are unbalanced but no "
+            "pole is enclosed, so the stitch cannot close the outline; split "
+            "the cover into smaller parts or pass dissolve=False for per-cell "
+            "polygons (issue #181)"
+        )
     other = -side
     ring.append((side, pole))
     ring.append((other, pole))

--- a/mortie/dissolve.py
+++ b/mortie/dissolve.py
@@ -361,11 +361,13 @@ def _normalized_lonlat(ring_xyz):
 
 
 def _pole_run(out, start, stop, pole):
-    """Append a monotone lat-±90 run from *start* to *stop* (exclusive of
-    *start*), subdivided so no planar step reaches 180° — a covered polar
-    wedge can legitimately span more than 180° of longitude, which
-    :func:`_cut_at_antimeridian` would misread as a seam wrap if emitted as
-    one step.  Mirrors ``pole_run`` in ``src_rust/src/dissolve.rs``.
+    """Append a monotone lat-±90 run from *start* to *stop*.
+
+    Exclusive of *start*, subdivided so no planar step reaches 180° — a
+    covered polar wedge can legitimately span more than 180° of longitude,
+    which :func:`_cut_at_antimeridian` would misread as a seam wrap if
+    emitted as one step.  Mirrors ``pole_run`` in
+    ``src_rust/src/dissolve.rs``.
     """
     direction = 1.0 if stop > start else -1.0
     cur = start

--- a/mortie/dissolve.py
+++ b/mortie/dissolve.py
@@ -246,29 +246,160 @@ def _chain_rings(survivors, id_xyz):
                 # walk on the same face (no crossing) at a non-manifold vertex.
                 back = _tangent_azimuth(id_xyz[v], id_xyz[cur[0]])
                 cur = min(cand, key=lambda r: (az[(r[0], r[1])] - back) % (2 * math.pi))
-        rings.append(id_xyz[np.asarray(chain)])
+        for cycle in _split_at_revisits(chain):
+            rings.append(id_xyz[np.asarray(cycle)])
     return rings
 
 
-def _antimeridian_winding(lon):
-    """Measure a ring's net longitude winding and antimeridian crossings.
+def _split_at_revisits(chain):
+    """Split a closed vertex-id walk into minimal simple cycles.
+
+    The angular chaining traces boundaries of the *covered* faces; where the
+    covered region is pinched at a vertex (two uncovered cells touching only
+    diagonally, so the covered face's own boundary passes the pinch twice)
+    the traced walk legitimately revisits that vertex — a correct even-odd
+    boundary, but not an OGC-simple ring.  Splitting at each revisit yields
+    the equivalent decomposition into simple rings touching at a point.
+    Each cycle is rotated to start at its minimal vertex id.  Mirrors
+    ``split_at_revisits`` in ``src_rust/src/dissolve.rs`` (issue #147).
 
     Parameters
     ----------
-    lon : numpy.ndarray
-        The longitudes (degrees) of a closed ring, first vertex not repeated.
+    chain : list of int
+        The closed walk as vertex ids (first vertex not repeated).
 
     Returns
     -------
-    tuple
-        ``(net, crossings)`` — the net signed longitude winding in degrees and
-        the antimeridian-crossing count.  Net ≈ ±360 ⟺ the ring encircles a
-        pole.
+    list of list of int
+        The simple cycles (each open, first vertex not repeated).
     """
-    deltas = np.diff(np.concatenate([lon, lon[:1]]))
-    crossings = int(np.sum(np.abs(deltas) > 180.0))
-    net = float(np.sum((deltas + 180.0) % 360.0 - 180.0))
-    return net, crossings
+    out = []
+    stack = []
+    pos = {}
+
+    def _rotated(cycle):
+        k = cycle.index(min(cycle))
+        return cycle[k:] + cycle[:k]
+
+    for vid in chain:
+        if vid in pos:
+            p = pos[vid]
+            cycle = stack[p:]
+            del stack[p:]
+            for c in cycle:
+                pos.pop(c, None)
+            out.append(_rotated(cycle))
+        pos[vid] = len(stack)
+        stack.append(vid)
+    if stack:
+        out.append(_rotated(stack))
+    return out
+
+
+def _normalized_lonlat(ring_xyz):
+    """Per-vertex ``(lat, lon)`` with seam vertices' longitude signs fixed.
+
+    A vertex exactly on the ±180° meridian gets an arbitrary sign from
+    ``atan2`` (its ``y`` is a rounding residual), and a whole boundary edge
+    can lie on the seam (base-cell meridians at lon 180) — mixed signs there
+    fabricate spurious ±360° cuts mid-edge.  With the covered region on the
+    ring's left, a seam-lying edge walked northward has the covered side
+    west, so it belongs on the map's east edge (+180°); southward, on -180°.
+    A vertex with a seam (or pole) neighbour takes that edge's direction; an
+    isolated seam touch takes its off-seam neighbours' side.  Mirrors
+    ``normalized_lonlat`` in ``src_rust/src/dissolve.rs`` (issue #147).
+
+    Parameters
+    ----------
+    ring_xyz : numpy.ndarray
+        An ``(M, 3)`` array of unit vectors (open ring).
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        The ``(lat, lon)`` degree arrays with normalized seam longitudes.
+    """
+    lat, lon = _xyz_to_latlon(ring_xyz)
+    lon = lon.copy()
+    n = len(ring_xyz)
+
+    def is_pole(j):
+        return abs(ring_xyz[j][2]) > 1.0 - 1e-9
+
+    def on_seam(j):
+        return not is_pole(j) and abs(abs(orig[j]) - 180.0) < 1e-9
+
+    def seam_lat(j):
+        # effective seam latitude when the edge to neighbour j runs along
+        # the seam (a pole neighbour's meridian edge is the seam meridian).
+        if is_pole(j):
+            return 90.0 if ring_xyz[j][2] > 0 else -90.0
+        if on_seam(j):
+            return float(lat[j])
+        return None
+
+    orig = lon.copy()
+    for i in range(n):
+        if not on_seam(i):
+            continue
+        prev, nxt = (i - 1) % n, (i + 1) % n
+        la = seam_lat(nxt)
+        if la is not None:
+            side = 180.0 if la > lat[i] else -180.0
+        else:
+            la = seam_lat(prev)
+            if la is not None:
+                side = 180.0 if lat[i] > la else -180.0
+            else:
+                side = 180.0 if orig[prev] >= 0.0 else -180.0
+        lon[i] = side
+    return lat, lon
+
+
+def _ring_to_planar(ring_xyz):
+    """Convert an oriented spherical ring to planar ``(lon, lat)`` vertices.
+
+    Expands any pole vertex into an explicit lat-±90 traverse: a vertex at
+    the pole has no longitude (``atan2(0, 0)``); its planar image is a
+    lat-±90 *edge* from the arriving meridian's longitude to the departing
+    one's, run in the direction that keeps the covered region on the left —
+    westward across the top at +90, eastward across the bottom at -90 —
+    inserting an explicit ±180 seam pair when the direct step would run the
+    wrong way round.  Mirrors ``ring_to_planar`` in
+    ``src_rust/src/dissolve.rs`` (issue #147).
+
+    Parameters
+    ----------
+    ring_xyz : numpy.ndarray
+        An ``(M, 3)`` array of unit vectors (open ring, covered region on
+        the left).
+
+    Returns
+    -------
+    list of tuple
+        The open planar ring as ``(lon, lat)`` degree pairs.
+    """
+    lat, lon = _normalized_lonlat(ring_xyz)
+    n = len(ring_xyz)
+    out = []
+    for i in range(n):
+        if abs(ring_xyz[i][2]) > 1.0 - 1e-9:
+            pole = 90.0 if ring_xyz[i][2] > 0 else -90.0
+            lon_arr = float(lon[(i - 1) % n])
+            lon_dep = float(lon[(i + 1) % n])
+            out.append((lon_arr, pole))
+            direct_ok = lon_dep < lon_arr if pole > 0 else lon_dep > lon_arr
+            if not direct_ok:
+                # through the seam: an exact ±180 crossing that
+                # `_cut_at_antimeridian` splits without interpolation.
+                if pole > 0:
+                    out.extend([(-180.0, pole), (180.0, pole)])
+                else:
+                    out.extend([(180.0, pole), (-180.0, pole)])
+            out.append((lon_dep, pole))
+        else:
+            out.append((float(lon[i]), float(lat[i])))
+    return out
 
 
 def _cut_at_antimeridian(coords):
@@ -303,7 +434,10 @@ def _cut_at_antimeridian(coords):
         if abs(lo1 - lo0) > 180.0:
             lo1u = lo1 - 360.0 if lo1 > lo0 else lo1 + 360.0
             boundary = 180.0 if lo1u > lo0 else -180.0
-            frac = (boundary - lo0) / (lo1u - lo0)
+            # An exact ±180 → ∓180 pair (a pole traverse's explicit seam
+            # crossing, `_ring_to_planar`) unwraps to a zero-length step;
+            # there is nothing to interpolate.
+            frac = 0.0 if lo1u == lo0 else (boundary - lo0) / (lo1u - lo0)
             la_x = la0 + frac * (la1 - la0)
             cur.append((boundary, la_x))
             segments.append(cur)
@@ -314,16 +448,21 @@ def _cut_at_antimeridian(coords):
     return None, segments
 
 
-def _stitch_segments(segments, pole):
+def _stitch_segments(segments):
     """Reconnect antimeridian-cut *segments* into closed lon/lat rings.
 
     Every segment runs from a free end on ±180° to another on ±180°.  Walking
     from a segment's end, the next segment is the one whose **start** sits on the
     **same ±180° side** at the next latitude inward — on +180° the next start
     above, on -180° the next start below — so the connector edge runs straight
-    along the meridian without crossing the boundary.  When no same-side start
-    lies in that direction the region wraps a pole: insert the ``pole`` (±90°)
-    vertex, cross to the other side at that pole, and resume.
+    along the meridian without crossing the boundary.  Pole seams are chosen
+    **locally** (issue #147): with the covered region on every ring's left
+    (the phase-1 orientation contract), the covered seam interval always runs
+    upward from a cut end on +180° and downward on -180°, so an end with no
+    same-side start in that direction wraps the pole on that side,
+    unconditionally.  One ring may wrap both poles.  This replaces the global
+    net-winding ``pole`` parameter, whose single value mis-stitched covers
+    mixing a pole region with other seam-crossing parts.
 
     This is the GeoJSON / ``antimeridian``-package convention: a single split
     ``MultiPolygon`` with explicit ±90° pole vertices stitched down ±180°.  It
@@ -336,10 +475,6 @@ def _stitch_segments(segments, pole):
     segments : list of list of tuple
         The cut segments from :func:`_cut_at_antimeridian`, each an open
         polyline of ``(lon, lat)`` degree pairs.
-    pole : float
-        The pole the **filled** region encloses (``+90``/``-90``), or ``0``
-        when none is enclosed.  It is only ever reached when the segments are
-        genuinely unbalanced, so a non-pole cover never touches it.
 
     Returns
     -------
@@ -349,9 +484,9 @@ def _stitch_segments(segments, pole):
     Raises
     ------
     ValueError
-        If the stitch fails to converge (a guard), or if the segments are
-        unbalanced with no pole enclosed — the curated fail-loud convention
-        (mirrors ``src_rust/src/dissolve.rs``, issue #181).
+        If the stitch fails to converge (a guard), or if no partner segment
+        exists after a pole seam — the curated fail-loud convention (mirrors
+        ``src_rust/src/dissolve.rs``, issue #181).
     """
     segs = [list(s) for s in segments]
     used = [False] * len(segs)
@@ -372,13 +507,13 @@ def _stitch_segments(segments, pole):
                 )
             used[idx] = True
             ring.extend(segs[idx])
-            idx = _next_segment(segs, used, ring, pole, seed)
+            idx = _next_segment(segs, used, ring, seed)
         ring.append(ring[0])
         rings.append(ring)
     return rings
 
 
-def _next_segment(segs, used, ring, pole, seed):
+def _next_segment(segs, used, ring, seed):
     """Append meridian/pole connectors and pick the next segment.
 
     Appends the connectors from the current ring end and returns the next
@@ -399,8 +534,6 @@ def _next_segment(segs, used, ring, pole, seed):
         Per-segment consumed flags, updated by the caller.
     ring : list of tuple
         The ring being built; connector vertices are appended in place.
-    pole : float
-        The pole the filled region encloses (``+90``/``-90``), or ``0``.
     seed : int
         Index of the segment this ring started from.
 
@@ -412,9 +545,9 @@ def _next_segment(segs, used, ring, pole, seed):
     Raises
     ------
     ValueError
-        If the segments are unbalanced but no pole is enclosed — the curated
-        fail-loud convention (mirrors ``src_rust/src/dissolve.rs``, issue
-        #181).
+        If no partner segment exists on the other side after a pole seam —
+        the curated fail-loud convention (mirrors
+        ``src_rust/src/dissolve.rs``, issue #181).
     """
     side, end_lat = ring[-1]
     cands = [(segs[i][0][1], i) for i in range(len(segs))
@@ -432,26 +565,24 @@ def _next_segment(segs, used, ring, pole, seed):
         ring.append((side, la))
         return None if (i == seed and used[seed]) else i
 
-    # No same-side start in that direction: the region wraps ``pole``.  Run the
-    # seam to the pole, cross to the other side, and resume from the pole.
-    if pole == 0:
-        raise ValueError(
-            "dissolved cover's antimeridian segments are unbalanced but no "
-            "pole is enclosed, so the stitch cannot close the outline; split "
-            "the cover into smaller parts or pass dissolve=False for per-cell "
-            "polygons (issue #181)"
-        )
+    # No same-side start in that direction: the covered seam interval runs to
+    # the pole on this side, so the region wraps it.  Cross the pole and
+    # resume on the other side at the start nearest it: the highest start
+    # after a north wrap (walking down -180°), the lowest after a south wrap
+    # (walking up +180°).
+    pole = 90.0 if side > 0 else -90.0
     other = -side
     ring.append((side, pole))
     ring.append((other, pole))
     ocands = [(segs[i][0][1], i) for i in range(len(segs))
               if abs(segs[i][0][0] - other) < 1e-9 and (not used[i] or i == seed)]
-    if not ocands:  # pragma: no cover - a closed boundary always has a partner
-        return None
-    if other > 0:
-        la, i = min(ocands) if pole < 0 else max(ocands)
-    else:
-        la, i = max(ocands) if pole < 0 else min(ocands)
+    if not ocands:
+        raise ValueError(
+            "dissolved cover's antimeridian stitch found no partner segment "
+            "after a pole seam (an internal dissolve inconsistency, issue "
+            "#181); pass dissolve=False for per-cell polygons"
+        )
+    la, i = max(ocands) if pole > 0 else min(ocands)
     ring.append((other, la))
     return None if (i == seed and used[seed]) else i
 
@@ -503,58 +634,35 @@ def _planar_signed_area(ring):
     return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
 
 
-def _ring_signed_area_lonlat(ring):
-    """Compute the spherical signed area of a closed lon/lat-degree ring.
+def _frame_ring():
+    """Return the whole-map frame shell, CCW (positive shoelace).
 
-    Used to classify a stitched ring whose seam runs through a pole, where the
-    planar shoelace sign is unreliable but the spherical area stays exact.
-
-    Parameters
-    ----------
-    ring : list of tuple
-        A closed list of ``(lon, lat)`` degree pairs (last vertex repeats the
-        first).
-
-    Returns
-    -------
-    float
-        The signed area in steradians.  Positive ⟺ the ring winds CCW (an
-        exterior); negative ⟺ a hole.
+    The planar boundary of a covered region that encloses the entire
+    antimeridian seam and both poles (e.g. world-minus-hole), which no
+    spherical boundary ring supplies.  Mirrors ``frame_ring`` in
+    ``src_rust/src/dissolve.rs`` (issue #147).
     """
-    a = np.asarray(ring[:-1], dtype=np.float64)
-    rlat = np.radians(a[:, 1])
-    rlon = np.radians(a[:, 0])
-    v = np.column_stack(
-        [np.cos(rlat) * np.cos(rlon), np.cos(rlat) * np.sin(rlon), np.sin(rlat)]
-    )
-    return _spherical_signed_area(v)
+    return [(-180.0, -90.0), (180.0, -90.0), (180.0, 90.0),
+            (-180.0, 90.0), (-180.0, -90.0)]
 
 
-def _reject_hemisphere_cover(morton):
-    """Mirror of the Rust hemisphere guard (``src_rust/src/dissolve.rs``, issue
-    #108): exterior/hole classification keys off the sign of the mod-4π
-    spherical signed area, which is ambiguous once the cover nears 2π — fail
-    loud on the exact covered area (Σ π/(3·4^depth), cells are equal-area)
-    instead of silently swapping shells and holes.  Assumes disjoint,
-    non-duplicated cells (the dissolve precondition anyway — duplicate words
-    would break edge cancellation); duplicates double-count.  Returns the
-    exact covered area (steradians) for the wrap cross-check downstream.
+def _emission_is_ccw(morton, step):
+    """Whether cell boundary loops are emitted CCW (interior on the left).
+
+    The issue #147 phase-1 orientation calibration: emission handedness is
+    uniform over every cell and order (CCW at ``step == 1``, CW at
+    ``step > 1`` — pinned by the phase-1 audit tests), so one cell's own fan
+    area (~π/3·4^order, far above float noise) is the per-call witness.
     """
+    from . import _healpix as hp
     from .orders import _rust_mort2nested
 
-    morton = np.atleast_1d(np.asarray(morton, dtype=np.uint64))
-    if morton.size == 0:
-        return 0.0
-    _, depths = _rust_mort2nested(np.ascontiguousarray(morton))
-    area = float(np.sum(np.pi / (3.0 * 4.0 ** depths.astype(np.float64))))
-    if area > 2.0 * np.pi * 0.98:
-        raise ValueError(
-            f"dissolved cover spans {area:.6f} sr — within 2% of a hemisphere "
-            "(2π sr) or beyond — so its exterior/hole winding is ambiguous; "
-            "split the cover into sub-hemisphere parts or pass dissolve=False "
-            "for per-cell polygons"
-        )
-    return area
+    first = np.ascontiguousarray(np.asarray(morton[:1], dtype=np.uint64))
+    nested, depths = _rust_mort2nested(first)
+    bnd = hp.boundaries(int(depths[0]), nested.astype(np.int64), step=step)
+    if bnd.ndim == 2:
+        bnd = bnd[np.newaxis, ...]
+    return _spherical_signed_area(np.transpose(bnd, (0, 2, 1))[0]) > 0.0
 
 
 def _dissolved_rings_py(morton, step):
@@ -562,10 +670,17 @@ def _dissolved_rings_py(morton, step):
 
     This is the exact-verified reference engine kept as the test oracle for the
     Rust fast path (:func:`_dissolved_polygons` calls ``_rustie.rust_dissolve``
-    at runtime — §7's Rust-only contract).  Rings that cross the ±180° meridian
-    are cut and reconnected by the GeoJSON-convention splitter
-    (:func:`_cut_at_antimeridian` / :func:`_stitch_segments`), which inserts
-    explicit ±90° pole vertices for a pole-enclosing region.
+    at runtime — §7's Rust-only contract), mirroring the winding-free
+    classifier of ``src_rust/src/dissolve.rs`` (issue #147): rings are
+    oriented covered-region-on-the-left by one per-call calibration
+    (:func:`_emission_is_ccw`), gated on per-ring simplicity
+    (:func:`mortie.ring_is_simple`), cut and reconnected by the
+    GeoJSON-convention splitter (:func:`_cut_at_antimeridian` /
+    :func:`_stitch_segments`, pole seams locally decided), and classified in
+    the plane by shoelace sign — positive (CCW, covered inside) is an
+    exterior, negative a hole, with the explicit map-frame shell added when
+    the covered region encloses the whole frame.  Hemisphere+ covers
+    dissolve instead of raising.
 
     Parameters
     ----------
@@ -579,69 +694,70 @@ def _dissolved_rings_py(morton, step):
     tuple of list
         ``(ext_pieces, holes)`` — each entry a closed list of ``(lon, lat)``
         degree pairs; ``([], [])`` for an empty cover.
+
+    Raises
+    ------
+    ValueError
+        If a boundary ring is self-crossing, or a stitch state cannot close
+        (issue #181) — the curated fail-loud convention (PR #111).
     """
-    cover_area = _reject_hemisphere_cover(morton)
+    from .coverage import ring_is_simple
+
+    morton = np.atleast_1d(np.asarray(morton, dtype=np.uint64))
+    if morton.size == 0:
+        return [], []
     rings_xyz = _boundary_rings_xyz(morton, step)
     if not rings_xyz:
-        return [], []
+        # A nonempty cover with no surviving boundary edge is the whole
+        # sphere: every edge cancelled, and the planar image is the frame.
+        return [_frame_ring()], []
 
-    # Normalise global winding: the cover's net signed area (exteriors minus
-    # holes) is the covered area, always positive.  HEALPix orders boundary
-    # points one way for step==1 and the other for step>1, so key the
-    # exterior/hole sign off this invariant rather than a fixed convention.
-    # The fan formula wraps mod 4π when a single ring encloses more than a
-    # hemisphere (possible even for a small cover, e.g. an equatorial band),
-    # which would flip the sign here; an honest |Σ| matches the exact covered
-    # area to within chord discretization (≲0.1 sr at step==1) while any wrap
-    # is off by ~4π, so a π tolerance separates them cleanly (mirrors the Rust
-    # cross-check in `src_rust/src/dissolve.rs::classify_and_split`).
-    areas = [_spherical_signed_area(r) for r in rings_xyz]
-    total = sum(areas)
-    if abs(abs(total) - cover_area) > np.pi:
-        raise ValueError(
-            "dissolved cover has a boundary ring enclosing more than a "
-            f"hemisphere (|Σ ring areas| = {abs(total):.6f} sr vs covered area "
-            f"{cover_area:.6f} sr), so its exterior/hole winding cannot be "
-            "classified; split the cover into sub-hemisphere parts or pass "
-            "dissolve=False for per-cell polygons"
-        )
-    if total < 0.0:
+    if not _emission_is_ccw(morton, step):
         rings_xyz = [r[::-1] for r in rings_xyz]
-        areas = [-a for a in areas]
 
-    # Rings that never cross the antimeridian are emitted whole; crossing rings
-    # contribute open segments that are stitched together below.  The pole the
-    # filled region encloses is set by the cover's *total* net longitude winding
-    # (an exterior and a hole that both wrap the pole cancel to net 0 — a band
-    # that does not enclose the pole — so per-ring winding would be wrong here).
+    # Validity gate: a self-crossing ring has no consistent "left", so the
+    # orientation contract cannot classify it.  (Identity conflicts — one
+    # snapped coordinate at two non-adjacent positions — are accepted: they
+    # are the working representation of corner-touch pinches resolved into
+    # touching simple rings, the issue #155 ruling.)
+    for r, ring in enumerate(rings_xyz):
+        lat, lon = _xyz_to_latlon(ring)
+        if not ring_is_simple(lat, lon):
+            raise ValueError(
+                f"dissolved cover produced a self-crossing boundary ring "
+                f"(ring {r}), so its outline is not classifiable; pass "
+                "dissolve=False for per-cell polygons"
+            )
+
+    # Rings that never cross the antimeridian are emitted whole; crossing
+    # rings contribute open segments stitched back together with locally
+    # decided pole seams.  Classification is planar: shoelace sign, with the
+    # covered region on every ring's left.
     ext_pieces = []
     holes = []
     segments = []
-    total_net = 0.0
-    for ring, area in zip(rings_xyz, areas):
-        lat, lon = _xyz_to_latlon(ring)
-        ll = list(zip(lon.tolist(), lat.tolist()))
-        net, _ = _antimeridian_winding(lon)
-        total_net += net
+    for ring in rings_xyz:
+        ll = _ring_to_planar(ring)
         whole, segs = _cut_at_antimeridian(ll)
         if whole is not None:
-            (holes if area < 0.0 else ext_pieces).append(whole)
+            (ext_pieces if _planar_signed_area(whole) >= 0.0 else holes).append(
+                whole
+            )
         else:
             segments.extend(segs)
-
     if segments:
-        pole = 0.0
-        if abs(total_net) > 180.0:  # net ≈ ±360° ⟺ the filled region wraps a pole
-            pole = 90.0 if total_net > 0.0 else -90.0
-        for piece in _stitch_segments(segments, pole):
-            # Classify by spherical signed area — a pole-spanning ring's planar
-            # shoelace sign is unreliable, but its spherical area is exact.  The
-            # sign is meaningful because the global winding was normalised above
-            # (exteriors CCW → positive); a stitched piece always encloses a
-            # finite covered/uncovered region, so its area is never exactly zero.
-            (ext_pieces if _ring_signed_area_lonlat(piece) >= 0.0 else holes).append(
+        for piece in _stitch_segments(segments):
+            (ext_pieces if _planar_signed_area(piece) >= 0.0 else holes).append(
                 piece
             )
+
+    # Frame rule: Σ shoelace is the covered region's planar area when its
+    # boundary is complete, and that minus the full map when the region
+    # encloses the frame — separated by sign, since a nonempty cover has
+    # positive planar area.
+    total = sum(_planar_signed_area(p) for p in ext_pieces + holes)
+    if total < 0.0:
+        ext_pieces.insert(0, _frame_ring())
     return ext_pieces, holes
 
 

--- a/mortie/tests/test_dissolve_hemisphere.py
+++ b/mortie/tests/test_dissolve_hemisphere.py
@@ -1,0 +1,118 @@
+"""Hemisphere+ dissolve: the winding-free classifier (issue #147).
+
+Phase 1 pins the orientation contract the classifier rests on, for the Python
+reference oracle (:func:`mortie.dissolve._dissolved_rings_py`) side by side
+with the Rust tests in ``src_rust/src/dissolve.rs``:
+
+* every HEALPix cell boundary loop is emitted with a fixed handedness —
+  interior on the LEFT at ``step == 1`` (CCW, positive spherical signed area)
+  and on the RIGHT at ``step > 1`` (CW, negative), uniformly over every base
+  cell and order;
+* therefore, after one per-call calibration (reverse every chained ring iff
+  the emission handedness is CW), every ring carries the covered region on
+  its LEFT.  The property is local — each surviving directed edge bounds
+  exactly one covered cell, on the emission side, and chaining preserves edge
+  direction — so it holds at any cover scale, including exact-hemisphere and
+  over-hemisphere covers the classifier used to reject.
+
+Later phases add the classifier behaviour tests (hemisphere+ covers dissolve
+to point-sampled-correct outlines) on both engines.
+"""
+
+import numpy as np
+import pytest
+
+import mortie
+from mortie import _healpix as hp
+from mortie import dissolve
+from mortie.orders import _rust_mort2nested, _rust_nested2mort
+
+
+def _cells(bases, order):
+    """All nested cells of the given base cells at *order*."""
+    n = 4 ** order
+    return [b * n + i for b in bases for i in range(n)]
+
+
+def _to_morton(nested, order):
+    """Morton words for nested ids at a single order."""
+    arr = np.ascontiguousarray(np.asarray(nested, dtype=np.uint64))
+    return _rust_nested2mort(arr, np.full(len(nested), order, dtype=np.uint8))
+
+
+def _cell_loop(order, nest, step):
+    """One cell's boundary loop as an (M, 3) unit-vector array."""
+    bnd = hp.boundaries(order, np.asarray([nest], dtype=np.int64), step=step)
+    if bnd.ndim == 2:
+        bnd = bnd[np.newaxis, ...]
+    return np.transpose(bnd, (0, 2, 1))[0]
+
+
+def _world_minus_one():
+    nested = list(range(192))
+    del nested[100]
+    return nested
+
+
+_AUDIT_COVERS = [
+    ("base 0-3", _cells([0, 1, 2, 3], 1), 1),
+    ("hemisphere 0-5", _cells([0, 1, 2, 3, 4, 5], 1), 1),
+    ("over-hemisphere 0-6", _cells([0, 1, 2, 3, 4, 5, 6], 1), 1),
+    ("exemplar 4/6/7/10", _cells([4, 6, 7, 10], 1), 1),
+    ("exemplar 1/2/7", _cells([1, 2, 7], 1), 1),
+    ("scattered", [16, 24, 25, 28, 40, 43], 1),
+    ("world minus one order-2 cell", _world_minus_one(), 2),
+]
+
+
+# ── phase 1: the orientation contract ──────────────────────────────────────
+
+
+def test_cell_boundary_emission_orientation_is_uniform():
+    # Mirror of the Rust `cell_boundary_emission_orientation_is_uniform`.
+    for order in range(6):
+        n = 4 ** order
+        exact = np.pi / (3.0 * 4.0 ** order)
+        for step in (1, 2, 3, 4, 8):
+            for base in range(12):
+                for nest in (base * n, base * n + n // 2, base * n + n - 1):
+                    a = dissolve._spherical_signed_area(
+                        _cell_loop(order, nest, step))
+                    assert (a > 0) == (step == 1), (order, step, nest, a)
+                    assert abs(abs(a) - exact) < 0.35 * exact, \
+                        (order, step, nest, a)
+
+
+@pytest.mark.parametrize("name,nested,order", _AUDIT_COVERS,
+                         ids=[c[0] for c in _AUDIT_COVERS])
+@pytest.mark.parametrize("step", [1, 3])
+def test_oracle_chained_rings_carry_cover_on_left(name, nested, order, step):
+    # Mirror of the Rust `chained_rings_carry_cover_on_left`: drives the
+    # oracle's `_boundary_rings_xyz` directly (below any guard), calibrates
+    # once from one cell's own loop, and probes each ring edge's midpoint a
+    # quarter edge-length to the left (must be covered) and right (must not).
+    cover = _to_morton(nested, order)
+    covered = set(int(w) for w in cover)
+    rings = dissolve._boundary_rings_xyz(cover, step)
+    assert rings, name
+    ccw = dissolve._spherical_signed_area(_cell_loop(order, nested[0], step)) > 0
+    if not ccw:
+        rings = [r[::-1] for r in rings]
+    for ring in rings:
+        n = len(ring)
+        for i in range(n):
+            a, b = ring[i], ring[(i + 1) % n]
+            t = b - a
+            elen = float(np.linalg.norm(t))
+            m = a + b
+            m /= np.linalg.norm(m)
+            left = np.cross(m, t)
+            left /= np.linalg.norm(left)
+            for s, want in ((1.0, True), (-1.0, False)):
+                p = m + s * 0.25 * elen * left
+                p /= np.linalg.norm(p)
+                lat = float(np.degrees(np.arcsin(np.clip(p[2], -1.0, 1.0))))
+                lon = float(np.degrees(np.arctan2(p[1], p[0])))
+                w = int(mortie.geo2mort(
+                    np.asarray([lat]), np.asarray([lon]), order)[0])
+                assert (w in covered) == want, (name, step, s, lon, lat)

--- a/mortie/tests/test_dissolve_hemisphere.py
+++ b/mortie/tests/test_dissolve_hemisphere.py
@@ -199,6 +199,130 @@ def test_multipart_both_polar_caps_both_engines():
             assert mp.covers(shapely.Point(lo, la)) == (w in covered), (lo, la)
 
 
+def test_sweep_corpus_slice_oracle_matches_rust():
+    # A deterministic slice of the regenerated order-1 sweep corpus (all 1-
+    # and 2-base-cell masks, plus every 25th of the larger masks): the
+    # Python oracle must mirror the Rust emit to machine precision — the
+    # corpus-scale mirror-drift detector (the full 1585-mask corpus is
+    # point-sampled Rust-side in `sweep_corpus_order1_combos...`).
+    import shapely
+
+    from mortie import geometry
+
+    idx = 0
+    checked = 0
+    for mask in range(1, 1 << 12):
+        bits = bin(mask).count("1")
+        if bits > 5:
+            continue
+        idx += 1
+        if bits > 2 and idx % 25:
+            continue
+        bases = [b for b in range(12) if mask >> b & 1]
+        cover = _to_morton(_cells(bases, 1), 1)
+        mp = geometry.to_geometry(cover)
+        ext_py, holes_py = dissolve._dissolved_rings_py(cover, 1)
+        mp_py = shapely.MultiPolygon(
+            dissolve._nest_and_build(shapely, ext_py, holes_py))
+        assert mp.symmetric_difference(mp_py).area < 1e-9, bases
+        checked += 1
+    assert checked > 100
+
+
+# ── phase 4: spherely goldens and the round-trip invariant ─────────────────
+
+# spherely (s2geometry) areas of the emitted outlines, pinned 2026-08-09:
+# Σ shell areas − Σ hole areas, with the map-frame shell counting 4π.  An
+# inverted exterior/hole classification would land near 4π − A, far outside
+# the chord-discretization band the assertion allows (step-1 order-1 chords
+# carry a ~2-3% area deficit; order 2 ~0.006%).
+_SPHERELY_GOLDENS = {
+    "base 0-3": 4.089856949,
+    "hemisphere 0-5": 6.283185307,
+    "over-hemisphere 0-6": 7.379849486,
+    "exemplar 4/6/7/10": 4.312456774,
+    "exemplar 1/2/7": 3.141592654,
+    "scattered": 1.621696737,
+    "world minus one order-2 cell": 12.500225105,
+}
+
+
+def _spherely_ring(ring):
+    """Planar closed ring -> spherely-ready open ring (spherical dedup).
+
+    Seam pairs like (-180, φ)/(180, φ) and pole corners are one spherical
+    point; s2 rejects the degenerate zero-length edges they form.
+    """
+    def sph(p):
+        rlat, rlon = np.radians(p[1]), np.radians(p[0])
+        return (np.cos(rlat) * np.cos(rlon), np.cos(rlat) * np.sin(rlon),
+                np.sin(rlat))
+
+    out, last = [], None
+    for p in ring:
+        x = sph(p)
+        if last is not None and max(abs(a - b) for a, b in zip(x, last)) < 1e-12:
+            continue
+        out.append((float(p[0]), float(p[1])))
+        last = x
+    while len(out) > 1 and max(
+            abs(a - b) for a, b in zip(sph(out[0]), sph(out[-1]))) < 1e-12:
+        out.pop()
+    return out
+
+
+@pytest.mark.parametrize("name,nested,order", _AUDIT_COVERS,
+                         ids=[c[0] for c in _AUDIT_COVERS])
+def test_dissolve_outline_areas_match_spherely(name, nested, order):
+    # External sphere-truth oracle on the *classification* (issue #147
+    # phase 4, the #144/#145 golden route): s2 measures the emitted
+    # outline's area — shells positive, holes negative, frame 4π — which
+    # must match the cover's exact area within chord discretization, and
+    # the pinned golden to machine precision.
+    spherely = pytest.importorskip("spherely")
+    from mortie import _rustie
+
+    cover = _to_morton(nested, order)
+    shells, holes = _rustie.rust_dissolve(np.ascontiguousarray(cover), 1)
+    total = 0.0
+    for s in shells:
+        ring = [tuple(map(float, v)) for v in s]
+        if ring == dissolve._frame_ring():
+            total += 4.0 * np.pi
+            continue
+        p = spherely.create_polygon(shell=_spherely_ring(ring), oriented=True)
+        total += spherely.area(p) / spherely.EARTH_RADIUS_METERS ** 2
+    for h in holes:
+        ring = _spherely_ring([tuple(map(float, v)) for v in h])
+        p = spherely.create_polygon(shell=ring[::-1], oriented=True)
+        total -= spherely.area(p) / spherely.EARTH_RADIUS_METERS ** 2
+    exact = len(nested) * np.pi / (3.0 * 4.0 ** order)
+    assert abs(total / exact - 1.0) < 0.05, (name, total, exact)
+    assert abs(total - _SPHERELY_GOLDENS[name]) < 1e-6, (name, total)
+
+
+def test_roundtrip_coverage_contains_cover_normalize_false():
+    # Open question (2) of issue #147: cover → dissolve →
+    # from_geometry(..., normalize=False) → cover?  Exact set equality is
+    # structurally impossible — coverage is an *overlap* cover, so
+    # boundary-touching neighbour cells always join — but the containment
+    # half (every source cell survives the round trip) holds for every
+    # hole-free emit, hemisphere+ included, and is pinned here.  Emits with
+    # holes are excluded: the parity fill under normalize=False reads a
+    # CW-wound (RFC 7946) hole ring as selecting its complement, which
+    # re-fills the hole — see the PR discussion for the full report.
+    from mortie import geometry
+
+    for name, nested, order in _AUDIT_COVERS:
+        if name == "world minus one order-2 cell":
+            continue  # holed emit (see above)
+        cover = _to_morton(nested, order)
+        mp = geometry.to_geometry(cover)
+        back = geometry.from_geometry(mp, order=order, normalize=False)
+        missing = set(int(w) for w in cover) - set(int(w) for w in back)
+        assert not missing, (name, len(missing))
+
+
 @pytest.mark.parametrize("name,nested,order", _AUDIT_COVERS,
                          ids=[c[0] for c in _AUDIT_COVERS])
 @pytest.mark.parametrize("step", [1, 3])

--- a/mortie/tests/test_dissolve_hemisphere.py
+++ b/mortie/tests/test_dissolve_hemisphere.py
@@ -65,6 +65,34 @@ _AUDIT_COVERS = [
 ]
 
 
+# ── issue #181: stitcher failure states are curated ValueErrors ────────────
+
+
+def test_stitcher_error_is_curated_not_a_panic():
+    # Issue #181: the stitching path's failure states must surface as the
+    # curated ValueError convention (PR #111) on both engines — never as a
+    # raw panic crossing the FFI (Rust) or a RuntimeError (oracle).  Base
+    # cells {1, 2, 7} at order 1 deterministically reach the
+    # unbalanced-segments state under the current global pole selection.
+    # (Issue #147's classifier makes this cover dissolve instead; the direct
+    # stitch pin below keeps the contract on the defensive path either way.)
+    from mortie import _rustie
+
+    cover = _to_morton(_cells([1, 2, 7], 1), 1)
+    with pytest.raises(ValueError, match="no pole is enclosed"):
+        _rustie.rust_dissolve(np.ascontiguousarray(cover), 1)
+    with pytest.raises(ValueError, match="no pole is enclosed"):
+        dissolve._dissolved_rings_py(cover, 1)
+
+
+def test_stitch_unbalanced_without_pole_raises_curated():
+    # Direct unit pin of the oracle's curated message: one segment whose free
+    # ends cannot pair on their own side, with no enclosed pole.
+    segs = [[(180.0, 10.0), (0.0, 10.0), (-180.0, 10.0)]]
+    with pytest.raises(ValueError, match="no pole is enclosed"):
+        dissolve._stitch_segments(segs, 0.0)
+
+
 # ── phase 1: the orientation contract ──────────────────────────────────────
 
 

--- a/mortie/tests/test_dissolve_hemisphere.py
+++ b/mortie/tests/test_dissolve_hemisphere.py
@@ -68,29 +68,18 @@ _AUDIT_COVERS = [
 # ── issue #181: stitcher failure states are curated ValueErrors ────────────
 
 
-def test_stitcher_error_is_curated_not_a_panic():
-    # Issue #181: the stitching path's failure states must surface as the
-    # curated ValueError convention (PR #111) on both engines — never as a
-    # raw panic crossing the FFI (Rust) or a RuntimeError (oracle).  Base
-    # cells {1, 2, 7} at order 1 deterministically reach the
-    # unbalanced-segments state under the current global pole selection.
-    # (Issue #147's classifier makes this cover dissolve instead; the direct
-    # stitch pin below keeps the contract on the defensive path either way.)
-    from mortie import _rustie
-
-    cover = _to_morton(_cells([1, 2, 7], 1), 1)
-    with pytest.raises(ValueError, match="no pole is enclosed"):
-        _rustie.rust_dissolve(np.ascontiguousarray(cover), 1)
-    with pytest.raises(ValueError, match="no pole is enclosed"):
-        dissolve._dissolved_rings_py(cover, 1)
-
-
-def test_stitch_unbalanced_without_pole_raises_curated():
-    # Direct unit pin of the oracle's curated message: one segment whose free
-    # ends cannot pair on their own side, with no enclosed pole.
-    segs = [[(180.0, 10.0), (0.0, 10.0), (-180.0, 10.0)]]
-    with pytest.raises(ValueError, match="no pole is enclosed"):
-        dissolve._stitch_segments(segs, 0.0)
+def test_stitch_missing_partner_raises_curated():
+    # Issue #181: the stitching path's defensive failure states surface as
+    # the curated ValueError convention (PR #111), never as a raw panic
+    # crossing the FFI (Rust) or a RuntimeError (oracle).  A lone segment
+    # starting and ending on +180° with no start above its end wraps the
+    # north pole and finds no partner on -180°.  (The cover that used to
+    # reach the old unbalanced-no-pole assert deterministically — base cells
+    # {1, 2, 7} at order 1 — now dissolves; see the hemisphere+ family
+    # below.)
+    segs = [[(180.0, 10.0), (0.0, 15.0), (180.0, 20.0)]]
+    with pytest.raises(ValueError, match="no partner segment"):
+        dissolve._stitch_segments(segs)
 
 
 # ── phase 1: the orientation contract ──────────────────────────────────────
@@ -109,6 +98,105 @@ def test_cell_boundary_emission_orientation_is_uniform():
                     assert (a > 0) == (step == 1), (order, step, nest, a)
                     assert abs(abs(a) - exact) < 0.35 * exact, \
                         (order, step, nest, a)
+
+
+# ── phases 2+3: hemisphere+ covers dissolve, identically on both engines ───
+
+
+def _both_caps_cover():
+    lats, lons = np.meshgrid(np.arange(-88.0, 88.5, 2.0),
+                             np.arange(-180.0, 180.0, 2.0))
+    keep = np.abs(lats.ravel()) > 62.0
+    return sorted(set(
+        int(w) for w in mortie.geo2mort(
+            lats.ravel()[keep], lons.ravel()[keep], 3)))
+
+
+def _assert_centre_sampled(mp, cover, sample_order):
+    """Point-sample *mp* against exact cover membership at cell centres.
+
+    Every cell centre of ``sample_order`` (whole sphere) must be inside the
+    emitted planar geometry iff its ancestor cell is in the cover — the
+    Python mirror of the Rust ``assert_point_sampled`` oracle.  Centres are
+    strictly interior to their covering cell, hence bounded away from the
+    emitted outline (centres exactly on the ±180 seam are nudged west, with
+    membership re-evaluated at the nudged point).
+    """
+    import shapely
+
+    nested, depths = _rust_mort2nested(
+        np.ascontiguousarray(np.asarray(cover, dtype=np.uint64)))
+    order = int(depths.max())
+    assert int(depths.min()) == order  # single-order fixtures
+    assert sample_order >= order
+    covered = set(int(c) for c in nested)
+    npix = 12 * 4 ** sample_order
+    pix = np.arange(npix, dtype=np.int64)
+    lon, lat = hp.pix2ang(sample_order, pix)
+    lon = np.where(lon > 180.0, lon - 360.0, lon)
+    seam = np.abs(np.abs(lon) - 180.0) < 1e-9
+    lon = np.where(seam, 180.0 - 1e-4, lon)
+    fine = np.asarray(
+        mortie.geo2mort(lat, lon, sample_order), dtype=np.uint64)
+    fine_nested, _ = _rust_mort2nested(np.ascontiguousarray(fine))
+    anc = fine_nested >> np.uint64(2 * (sample_order - order))
+    want = np.array([int(a) in covered for a in anc])
+    got = shapely.contains_xy(mp, lon, lat)
+    mismatch = np.nonzero(want != got)[0]
+    # The emit is a straight-chord discretization of the true cell-edge
+    # arcs, so pointwise agreement is only required for samples farther
+    # from the emitted boundary than the chord-vs-arc gap (band shrinks
+    # with cell size); mirrors the Rust `assert_point_sampled` oracle.
+    band = 4.0 / 2 ** order
+    boundary = mp.boundary
+    for i in mismatch:
+        d = boundary.distance(shapely.Point(lon[i], lat[i]))
+        assert d < band, (float(lon[i]), float(lat[i]), float(d))
+
+
+@pytest.mark.parametrize("name,nested,order", _AUDIT_COVERS,
+                         ids=[c[0] for c in _AUDIT_COVERS])
+def test_hemisphere_plus_family_both_engines(name, nested, order):
+    # Issues #147 phases 2/3: every audit cover — exact-hemisphere,
+    # over-hemisphere, the PR #179 sweep exemplars, pole-touching,
+    # world-minus-cell — dissolves on the Rust engine, the Python oracle
+    # mirrors it to machine precision (same fixtures, so mirror drift is
+    # caught here), the emit is valid, and every cell centre two orders
+    # finer point-samples correctly against exact cover membership.
+    import shapely
+
+    from mortie import geometry
+
+    cover = _to_morton(nested, order)
+    mp = geometry.to_geometry(cover)
+    assert mp.is_valid, name
+    ext_py, holes_py = dissolve._dissolved_rings_py(cover, 1)
+    mp_py = shapely.MultiPolygon(dissolve._nest_and_build(shapely, ext_py, holes_py))
+    assert mp_py.is_valid, name
+    assert mp.symmetric_difference(mp_py).area < 1e-9, name
+    _assert_centre_sampled(mp, cover, order + 2)
+
+
+def test_multipart_both_polar_caps_both_engines():
+    # A multipart hemisphere-straddling cover: both polar caps (|lat| > 62°),
+    # whose two boundary circles have cancelling net longitude windings — the
+    # case the old global pole selection could not stitch (each cap must wrap
+    # its own pole).  Two clean parts, both engines identical.
+    import shapely
+
+    from mortie import geometry
+
+    cover = np.asarray(_both_caps_cover(), dtype=np.uint64)
+    covered = set(int(w) for w in cover)
+    mp = geometry.to_geometry(cover)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 2
+    ext_py, holes_py = dissolve._dissolved_rings_py(cover, 1)
+    mp_py = shapely.MultiPolygon(dissolve._nest_and_build(shapely, ext_py, holes_py))
+    assert mp.symmetric_difference(mp_py).area < 1e-9
+    for la in (-88.0, -70.0, -40.0, 0.0, 40.0, 70.0, 88.0):
+        for lo in (-170.0, -60.0, 0.0, 60.0, 170.0):
+            w = int(mortie.geo2mort(np.asarray([la]), np.asarray([lo]), 3)[0])
+            assert mp.covers(shapely.Point(lo, la)) == (w in covered), (lo, la)
 
 
 @pytest.mark.parametrize("name,nested,order", _AUDIT_COVERS,

--- a/mortie/tests/test_dissolve_hemisphere.py
+++ b/mortie/tests/test_dissolve_hemisphere.py
@@ -224,9 +224,48 @@ def test_sweep_corpus_slice_oracle_matches_rust():
         ext_py, holes_py = dissolve._dissolved_rings_py(cover, 1)
         mp_py = shapely.MultiPolygon(
             dissolve._nest_and_build(shapely, ext_py, holes_py))
+        assert mp.is_valid, bases
         assert mp.symmetric_difference(mp_py).area < 1e-9, bases
         checked += 1
     assert checked > 100
+
+
+def test_sweep_silent_inversion_mask_206_now_correct():
+    # Base cells {1, 2, 3, 6, 7} at order 1 (5.24 sr, sub-hemisphere): under
+    # the old classifier this cover passed every guard and silently emitted
+    # its **complement** (all 12 base-cell probes inverted, measured against
+    # the d4e62d0 build for the divergence report).  The winding-free
+    # classifier emits the true region; both engines agree.
+    import shapely
+
+    from mortie import geometry
+
+    cover = _to_morton(_cells([1, 2, 3, 6, 7], 1), 1)
+    mp = geometry.to_geometry(cover)
+    assert mp.is_valid
+    _assert_centre_sampled(mp, cover, 3)
+    ext_py, holes_py = dissolve._dissolved_rings_py(cover, 1)
+    mp_py = shapely.MultiPolygon(dissolve._nest_and_build(shapely, ext_py, holes_py))
+    assert mp.symmetric_difference(mp_py).area < 1e-9
+
+
+def test_pole_corner_revisit_mask_3408_emits_valid():
+    # Base cells {4, 6, 8, 10, 11} at order 1: the boundary both passes
+    # through the south pole (a pole traverse) and wraps its seam, so one
+    # planar walk revisits the ±180/-90 corner — even-odd-correct but not an
+    # OGC ring.  `split_planar_at_revisits` decomposes it into simple rings
+    # touching at the corner; shapely accepts the emit.
+    import shapely
+
+    from mortie import geometry
+
+    cover = _to_morton(_cells([4, 6, 8, 10, 11], 1), 1)
+    mp = geometry.to_geometry(cover)
+    assert mp.is_valid, shapely.is_valid_reason(mp)
+    _assert_centre_sampled(mp, cover, 3)
+    ext_py, holes_py = dissolve._dissolved_rings_py(cover, 1)
+    mp_py = shapely.MultiPolygon(dissolve._nest_and_build(shapely, ext_py, holes_py))
+    assert mp.symmetric_difference(mp_py).area < 1e-9
 
 
 # ── phase 4: spherely goldens and the round-trip invariant ─────────────────

--- a/mortie/tests/test_geometry.py
+++ b/mortie/tests/test_geometry.py
@@ -775,38 +775,49 @@ def test_dissolve_empty_cover():
     assert mp.geom_type == "MultiPolygon" and mp.is_empty
 
 
-def test_dissolve_hemisphere_cover_fails_loud():
-    # The dissolve keys exterior/hole off the sign of the mod-4π spherical
-    # signed area, ambiguous once the cover nears a hemisphere (2π sr): the
-    # guard on the exact covered area raises instead of silently swapping
-    # shells and holes (issue #108).  Rust runtime path and Python oracle agree.
-    # 24 order-1 cells (base cells 0-5) tile exactly half the sphere; the polar
-    # cap reaching past the equator is a polar-scale cover beyond it.
+def test_dissolve_hemisphere_cover_dissolves():
+    # Issue #147: the winding-free classifier dissolves hemisphere+ covers
+    # instead of raising (the PR #111 guards are retired).  24 order-1 cells
+    # (base cells 0-5) tile exactly half the sphere; the polar cap reaching
+    # past the equator is a polar-scale cover beyond it.  Both engines agree
+    # and the emitted outline conserves the covered area.
+    # (Emitted-ring fan areas are no oracle out here — the anchor fan wraps
+    # on seam-closed hemisphere+ rings — so validate by interior/exterior
+    # probes; the exhaustive centre-sampled validation lives in
+    # test_dissolve_hemisphere.py and the Rust corpus tests.)
     hemi = mortie.norm2mort(np.tile(np.arange(4), 6), np.repeat(np.arange(6), 4), 1)
     over = _polar_cap(-2.0, 89.9, order=3)
-    for cov in (hemi, over):
-        with pytest.raises(ValueError, match="hemisphere"):
-            geometry.to_geometry(cov)
-        with pytest.raises(ValueError, match="hemisphere"):
-            dissolve._dissolved_rings_py(cov, 1)
-    # The documented fallback stays available: per-cell emit, one quad per cell.
-    per_cell = geometry.to_geometry(hemi, dissolve=False)
-    assert shapely.get_num_geometries(per_cell) == hemi.size
+    for cov, inside, outside in (
+        (hemi, (0.0, 85.0), (0.0, -85.0)),
+        (over, (120.0, 45.0), (0.0, -45.0)),
+    ):
+        mp = geometry.to_geometry(cov)
+        assert mp.is_valid
+        assert mp.covers(shapely.Point(*inside))
+        assert not mp.covers(shapely.Point(*outside))
+        ext_py, holes_py = dissolve._dissolved_rings_py(cov, 1)
+        mp_py = shapely.MultiPolygon(
+            dissolve._nest_and_build(shapely, ext_py, holes_py))
+        assert mp.symmetric_difference(mp_py).area < 1e-9
 
 
-def test_dissolve_hemisphere_enclosing_ring_fails_loud():
-    # A thin equatorial band (~1.3 sr, far under the covered-area guard) has
-    # two boundary rings that each enclose more than a hemisphere, so the
-    # mod-4π fan sum wraps (Σ = A − 4π < 0) — without the Σ-vs-exact-area
-    # cross-check the global flip fires on a correctly-wound cover and the
-    # antimeridian stitcher dies with a cryptic error (issue #108 review).
+def test_dissolve_hemisphere_enclosing_ring_dissolves():
+    # A thin equatorial band (~1.3 sr): both boundary rings enclose more than
+    # a hemisphere, which wrapped the old mod-4π fan sum (rejected by PR #111,
+    # then a stitcher panic before that).  The planar classifier stitches the
+    # two circles into one seam-closed shell (issue #147); both engines agree.
     lats, lons = np.meshgrid(np.arange(-3.5, 3.6, 0.5),
                              np.arange(-180.0, 180.0, 1.0))
     band = np.unique(mortie.geo2mort(lats.ravel(), lons.ravel(), order=4))
-    with pytest.raises(ValueError, match="enclosing more than a hemisphere"):
-        geometry.to_geometry(band)
-    with pytest.raises(ValueError, match="enclosing more than a hemisphere"):
-        dissolve._dissolved_rings_py(band, 1)
+    mp = geometry.to_geometry(band)
+    assert mp.is_valid and shapely.get_num_geometries(mp) == 1
+    assert mp.covers(shapely.Point(0.0, 0.0))
+    assert mp.covers(shapely.Point(179.9, 0.0))
+    assert not mp.covers(shapely.Point(0.0, 30.0))
+    ext_py, holes_py = dissolve._dissolved_rings_py(band, 1)
+    mp_py = shapely.MultiPolygon(
+        dissolve._nest_and_build(shapely, ext_py, holes_py))
+    assert mp.symmetric_difference(mp_py).area < 1e-9
 
 
 def _interleave(x, y, order):

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -365,8 +365,12 @@ fn chain_rings(survivors: &[(u32, u32)], id_xyz: &[Vec3]) -> Vec<Vec<Vec3>> {
 /// even-odd boundary, but not an OGC-simple ring.  Splitting at each
 /// revisit yields the equivalent decomposition into simple rings touching
 /// at a point (the dual of the covered-side corner-touch pinch the pairing
-/// already resolves).  Each cycle is rotated to start at its minimal vertex
-/// id, keeping the canonical-start determinism of issue #155.
+/// already resolves).  A split at a *pole* vertex re-pairs that pole's
+/// passages onto their adjacent wedges; [`ring_to_planar`]'s empty-bracket
+/// span rule renders each re-paired passage over exactly its own wedge, so
+/// the planar shoelace budget stays consistent.  Each cycle is rotated to
+/// start at its minimal vertex id, keeping the canonical-start determinism
+/// of issue #155.
 fn split_at_revisits(chain: Vec<u32>) -> Vec<Vec<u32>> {
     let mut out: Vec<Vec<u32>> = Vec::new();
     let mut stack: Vec<u32> = Vec::new();
@@ -385,6 +389,37 @@ fn split_at_revisits(chain: Vec<u32>) -> Vec<Vec<u32>> {
     if !stack.is_empty() {
         out.push(rotate_to_min(stack));
     }
+    out
+}
+
+/// Split a **closed** planar ring at exactly-repeated vertices into simple
+/// closed rings (the planar mirror of [`split_at_revisits`], keyed on exact
+/// coordinate bits; drops degenerate two-vertex slivers).
+fn split_planar_at_revisits(ring: Ring) -> Vec<Ring> {
+    let open = &ring[..ring.len() - 1];
+    let key = |p: &(f64, f64)| (p.0.to_bits(), p.1.to_bits());
+    let mut out: Vec<Ring> = Vec::new();
+    let mut stack: Vec<(f64, f64)> = Vec::new();
+    let mut pos: HashMap<(u64, u64), usize> = HashMap::new();
+    let mut emit = |cycle: Vec<(f64, f64)>| {
+        if cycle.len() >= 3 {
+            let mut closed = cycle;
+            closed.push(closed[0]);
+            out.push(closed);
+        }
+    };
+    for &p in open {
+        if let Some(&at) = pos.get(&key(&p)) {
+            let cycle: Vec<(f64, f64)> = stack.drain(at..).collect();
+            for c in &cycle {
+                pos.remove(&key(c));
+            }
+            emit(cycle);
+        }
+        pos.insert(key(&p), stack.len());
+        stack.push(p);
+    }
+    emit(stack);
     out
 }
 
@@ -430,16 +465,24 @@ fn xyz_to_lonlat(v: &Vec3) -> (f64, f64) {
 /// any pole vertex into an explicit lat-±90 traverse.
 ///
 /// A vertex at the pole has no longitude (`atan2(0, 0)`); its planar image
-/// is a lat-±90 *edge* from the arriving meridian's longitude to the
-/// departing one's, run in the direction that keeps the covered region on
-/// the left — westward across the top at +90, eastward across the bottom at
-/// -90 — inserting an explicit ±180 seam pair when the direct step would
-/// run the wrong way round.  (The old single `atan2(0,0) = 0` planar vertex
+/// is a lat-±90 *edge* — a cap over the wedge of longitudes this passage
+/// encloses at the pole.  (The old single `atan2(0,0) = 0` planar vertex
 /// silently sliced off planar area next to the pole: pointwise-wrong emit
 /// for any cover whose boundary passes *through* a pole, e.g. base cells
 /// {0, 1} at order 1 — a defect predating issue #147, exposed by its
 /// point-sampled acceptance tests.)
-fn ring_to_planar(ring: &[Vec3]) -> Vec<(f64, f64)> {
+///
+/// Which wedge a passage encloses is the **empty-bracket rule**: of the two
+/// lon-intervals between the arriving and departing meridians, the enclosed
+/// one contains no *other* pole-incident boundary meridian (`meridians`,
+/// collected over the whole ring set by [`classify_and_split`]) — after
+/// [`split_at_revisits`], each passage brackets exactly its own wedge.  At
+/// a degree-2 pole both intervals are empty and the covered side wins: the
+/// walk pairs the passage across the covered wedge, which lies westward of
+/// the arrival at +90 and eastward at -90 (covered-on-left along the
+/// meridians).  A cap through the seam inserts an exact ±180 pair that
+/// [`cut_at_antimeridian`] splits without interpolation.
+fn ring_to_planar(ring: &[Vec3], north_m: &[f64], south_m: &[f64]) -> Vec<(f64, f64)> {
     let n = ring.len();
     let lonlat = normalized_lonlat(ring);
     let mut out: Vec<(f64, f64)> = Vec::with_capacity(n + 4);
@@ -447,31 +490,59 @@ fn ring_to_planar(ring: &[Vec3]) -> Vec<(f64, f64)> {
         let v = ring[i];
         if v[2].abs() > 1.0 - 1e-9 {
             let pole = if v[2] > 0.0 { 90.0 } else { -90.0 };
-            let (lon_arr, _) = lonlat[(i + n - 1) % n];
-            let (lon_dep, _) = lonlat[(i + 1) % n];
-            out.push((lon_arr, pole));
-            let direct_ok = if pole > 0.0 {
-                lon_dep < lon_arr // top edge runs westward
+            let (arr, _) = lonlat[(i + n - 1) % n];
+            let (dep, _) = lonlat[(i + 1) % n];
+            let meridians = if pole > 0.0 { north_m } else { south_m };
+            // spans measured from the arrival, mod 360, exclusive of the
+            // endpoints (rel 0 is arr itself; rel >= d is dep or beyond).
+            let rel_w = |x: f64| (arr - x).rem_euclid(360.0);
+            let rel_e = |x: f64| (x - arr).rem_euclid(360.0);
+            let dw = if rel_w(dep) == 0.0 { 360.0 } else { rel_w(dep) };
+            let de = if rel_e(dep) == 0.0 { 360.0 } else { rel_e(dep) };
+            let west_clear = meridians.iter().all(|&m| rel_w(m) == 0.0 || rel_w(m) >= dw);
+            let east_clear = meridians.iter().all(|&m| rel_e(m) == 0.0 || rel_e(m) >= de);
+            let go_west = if west_clear && east_clear {
+                pole > 0.0 // covered side: westward at +90, eastward at -90
             } else {
-                lon_dep > lon_arr // bottom edge runs eastward
+                west_clear
             };
-            if !direct_ok {
-                // through the seam: the pair is an exact ±180 crossing that
-                // `cut_at_antimeridian` splits without interpolation.
-                if pole > 0.0 {
-                    out.push((-180.0, pole));
-                    out.push((180.0, pole));
+            out.push((arr, pole));
+            if go_west {
+                if dep < arr {
+                    pole_run(&mut out, arr, dep, pole);
                 } else {
+                    pole_run(&mut out, arr, -180.0, pole);
                     out.push((180.0, pole));
-                    out.push((-180.0, pole));
+                    pole_run(&mut out, 180.0, dep, pole);
                 }
+            } else if dep > arr {
+                pole_run(&mut out, arr, dep, pole);
+            } else {
+                pole_run(&mut out, arr, 180.0, pole);
+                out.push((-180.0, pole));
+                pole_run(&mut out, -180.0, dep, pole);
             }
-            out.push((lon_dep, pole));
         } else {
             out.push(lonlat[i]);
         }
     }
     out
+}
+
+/// Append a monotone lat-±90 run from `from` to `to` (exclusive of `from`),
+/// subdivided so no planar step reaches 180° — the pole edge is spherically
+/// degenerate, so extra vertices are free, and a covered polar wedge can
+/// legitimately span more than 180° of longitude (e.g. three of the four
+/// polar base cells), which `cut_at_antimeridian` would misread as a seam
+/// wrap if emitted as one step.
+fn pole_run(out: &mut Vec<(f64, f64)>, from: f64, to: f64, pole: f64) {
+    let dir = (to - from).signum();
+    let mut cur = from;
+    while (to - cur).abs() > 150.0 {
+        cur += dir * 120.0;
+        out.push((cur, pole));
+    }
+    out.push((to, pole));
 }
 
 /// Per-vertex `(lon, lat)` with seam-lying vertices' longitude **signs
@@ -581,10 +652,17 @@ fn cut_at_antimeridian(coords: &[(f64, f64)]) -> Result<Ring, Vec<Ring>> {
         cur.push((lo0, la0));
         if (lo1 - lo0).abs() > 180.0 {
             let lo1u = if lo1 > lo0 { lo1 - 360.0 } else { lo1 + 360.0 };
-            let boundary = if lo1u > lo0 { 180.0 } else { -180.0 };
             // An exact ±180 → ∓180 pair (a pole traverse's explicit seam
-            // crossing, `ring_to_planar`) unwraps to a zero-length step;
-            // there is nothing to interpolate.
+            // crossing, `ring_to_planar`) unwraps to a zero-length step:
+            // nothing to interpolate, and the cut side is the pair's own
+            // first side (the generic `lo1u > lo0` test cannot tell).
+            let boundary = if lo1u == lo0 {
+                lo0
+            } else if lo1u > lo0 {
+                180.0
+            } else {
+                -180.0
+            };
             let frac = if lo1u == lo0 {
                 0.0
             } else {
@@ -779,27 +857,51 @@ fn classify_and_split(rings_xyz: Vec<Vec<Vec3>>) -> Result<ClassifiedRings, Stri
         ));
     }
 
-    let mut segments: Vec<Vec<(f64, f64)>> = Vec::new();
-    for ring in rings_xyz.iter() {
-        let ll = ring_to_planar(ring);
-        match cut_at_antimeridian(&ll) {
-            Ok(whole) => {
-                if planar_shoelace(&whole) >= 0.0 {
-                    out.shells.push(whole);
-                } else {
-                    out.holes.push(whole);
-                }
-            }
-            Err(segs) => segments.extend(segs),
-        }
-    }
-    if !segments.is_empty() {
-        for piece in stitch_segments(segments)? {
+    let classify = |ring: Ring, out: &mut ClassifiedRings| {
+        // A planar ring can revisit a vertex exactly — e.g. a ring that both
+        // expands a pole traverse and wraps the same pole's seam passes the
+        // ±180/±90 corner twice — which even-odd fill reads correctly but
+        // OGC does not allow in one ring; split into simple rings touching
+        // at the point.
+        for piece in split_planar_at_revisits(ring) {
             if planar_shoelace(&piece) >= 0.0 {
                 out.shells.push(piece);
             } else {
                 out.holes.push(piece);
             }
+        }
+    };
+    // Pole-incident boundary meridians over the whole ring set, for
+    // `ring_to_planar`'s empty-bracket cap rule.
+    let mut north_m: Vec<f64> = Vec::new();
+    let mut south_m: Vec<f64> = Vec::new();
+    for ring in rings_xyz.iter() {
+        let n = ring.len();
+        let lonlat = normalized_lonlat(ring);
+        for i in 0..n {
+            if ring[i][2].abs() > 1.0 - 1e-9 {
+                let m = if ring[i][2] > 0.0 {
+                    &mut north_m
+                } else {
+                    &mut south_m
+                };
+                m.push(lonlat[(i + n - 1) % n].0);
+                m.push(lonlat[(i + 1) % n].0);
+            }
+        }
+    }
+
+    let mut segments: Vec<Vec<(f64, f64)>> = Vec::new();
+    for ring in rings_xyz.iter() {
+        let ll = ring_to_planar(ring, &north_m, &south_m);
+        match cut_at_antimeridian(&ll) {
+            Ok(whole) => classify(whole, &mut out),
+            Err(segs) => segments.extend(segs),
+        }
+    }
+    if !segments.is_empty() {
+        for piece in stitch_segments(segments)? {
+            classify(piece, &mut out);
         }
     }
 

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -12,11 +12,21 @@
 //!    a non-manifold corner-touch vertex each arriving edge pairs with the
 //!    smallest-turn departing edge, pinching the boundary into simple rings
 //!    touching at a point (never a self-intersecting figure-eight).
-//! 3. Rings are classified exterior/hole by spherical signed area (global
-//!    winding normalised so the covered area is positive), then crossing rings
-//!    are cut at +/-180 and reconnected by the GeoJSON convention — explicit
-//!    +/-90 pole vertices stitched down the antimeridian for a pole-enclosing
-//!    region.
+//! 3. Rings are oriented **covered-region-on-the-left** by one per-call
+//!    calibration (the phase-1 contract of issue #147: cell loops are emitted
+//!    with a uniform handedness, so at most one global reversal is needed and
+//!    the orientation is a *local* fact — valid at any cover scale, hemisphere
+//!    and beyond).  Crossing rings are cut at +/-180 and reconnected by the
+//!    GeoJSON convention, with pole seams chosen locally from the seam side
+//!    (covered-on-left puts the covered seam interval *upward* of a cut end
+//!    on +180 and *downward* on -180).
+//! 4. Exterior/hole classification happens in the **plane**, where "inside"
+//!    is absolute: an emitted planar ring with the covered region on its left
+//!    is an exterior iff its shoelace area is positive.  A covered region
+//!    enclosing the whole map frame (e.g. world-minus-hole) makes the total
+//!    emitted shoelace negative and gets the explicit world-frame shell.
+//!    No step keys off a mod-4π winding sign — hemisphere+ covers dissolve
+//!    instead of raising (issue #147).
 //!
 //! The entry point returns classified planar rings (shells and holes) as
 //! `(lon, lat)` degree pairs; the Python side builds the backend Polygons and
@@ -43,46 +53,99 @@ pub struct ClassifiedRings {
     pub holes: Vec<Ring>,
 }
 
-// Hemisphere guard (issue #108): exterior/hole classification keys off the
-// sign of Σ ring signed areas, which is defined mod 4π — at 2π a cover reads
-// the same as its complement wound the other way, and past 2π the sign
-// silently inverts (the fan formula can also wrap per-ring at that scale).
-// The covered area itself is exact (equal-area cells), so gate on it: 2% of 2π
-// keeps a comfortable distance from the breakdown point while excluding only
-// covers within 2% of half the sphere.
-const HEMISPHERE_MARGIN: f64 = std::f64::consts::TAU * 0.02;
-
-/// Exact covered area (steradians) of a morton cover: Σ π/(3·4^depth).
-/// Assumes disjoint, non-duplicated cells (the dissolve precondition anyway —
-/// duplicate words would break edge cancellation); duplicates double-count.
-fn cover_area(morton: &[u64]) -> f64 {
-    morton
-        .iter()
-        .map(|&w| std::f64::consts::PI / (3.0 * 4f64.powi(mort2nested(w).1 as i32)))
-        .sum()
-}
-
 /// Dissolve a morton cover into classified planar (lon, lat) rings.
 ///
-/// Errs (with a message for a Python `ValueError`) when the cover spans
-/// near or over a hemisphere, or when a boundary ring encloses more than a
-/// hemisphere (the mod-4π fan sum wraps) — both make the winding-sign
-/// normalisation of [`classify_and_split`] untrustworthy.
+/// Handles covers of any size — hemisphere and beyond (issue #147): the
+/// classifier keys off the phase-1 orientation contract (covered region on
+/// each ring's left after one per-call calibration) plus planar shoelace
+/// signs, never a mod-4π winding sum.  Errs (with a message for a Python
+/// `ValueError`, the curated PR #111 convention) only on genuinely ill-posed
+/// boundary output: a self-crossing boundary ring, or a stitch state that
+/// cannot close (issue #181).
 pub fn dissolve(morton: &[u64], step: u32) -> Result<ClassifiedRings, String> {
-    let area = cover_area(morton);
-    if area > std::f64::consts::TAU - HEMISPHERE_MARGIN {
-        return Err(format!(
-            "dissolved cover spans {area:.6} sr — within 2% of a hemisphere \
-             (2π sr) or beyond — so its exterior/hole winding is ambiguous; \
-             split the cover into sub-hemisphere parts or pass dissolve=False \
-             for per-cell polygons"
-        ));
+    if morton.is_empty() {
+        return Ok(ClassifiedRings {
+            shells: Vec::new(),
+            holes: Vec::new(),
+        });
     }
-    let rings = boundary_rings_xyz(morton, step);
-    classify_and_split(rings, area)
+    let mut rings = boundary_rings_xyz(morton, step);
+    // Orientation calibration (issue #147 phase 1): cell loops are emitted
+    // with one uniform handedness (CCW at step == 1, CW at step > 1 — pinned
+    // by `cell_boundary_emission_orientation_is_uniform`), each surviving
+    // directed edge bounds exactly one covered cell on the emission side, and
+    // chaining preserves edge direction — so one reversal iff the emission
+    // reads CW puts the covered region on every ring's LEFT, at any cover
+    // scale.  One cell's own fan area (~π/3·4^order, far above float noise)
+    // is the per-call witness.
+    let (nest0, order0) = mort2nested(morton[0]);
+    let ccw = spherical_signed_area(&cell_boundary_loop(order0, nest0, step)) > 0.0;
+    if !ccw {
+        for r in rings.iter_mut() {
+            r.reverse();
+        }
+    }
+    #[cfg(debug_assertions)]
+    debug_assert_cover_on_left(&rings, morton);
+    classify_and_split(rings)
+}
+
+/// The retired PR #111 guards (`HEMISPHERE_MARGIN`, the Σ-vs-exact-area wrap
+/// cross-check), reduced to what they actually protected: debug-build
+/// verification that every oriented ring carries the covered region on its
+/// left.  Each ring's first edge midpoint, displaced a quarter edge-length
+/// leftward, must land in a covered cell.  (A Σ-fan-area cross-check is
+/// *not* usable at hemisphere+ scale: the fan formula's wraps are
+/// anchor-dependent and not clean 4π multiples — PR #179 measured 4.0899 sr
+/// vs 0.7901 sr fans for the same ring — so no area identity survives; the
+/// membership probe is exact instead.)
+#[cfg(debug_assertions)]
+fn debug_assert_cover_on_left(rings: &[Vec<Vec3>], morton: &[u64]) {
+    use crate::sphere::normalize;
+    let depths: Vec<u8> = morton.iter().map(|&w| mort2nested(w).1).collect();
+    let max_depth = *depths.iter().max().unwrap();
+    let flat: Vec<u64> = if depths.iter().any(|&d| d != max_depth) {
+        moc::to_order(morton, max_depth)
+    } else {
+        morton.to_vec()
+    };
+    let covered: std::collections::HashSet<u64> = flat.into_iter().collect();
+    for ring in rings {
+        if ring.len() < 2 {
+            continue;
+        }
+        let (a, b) = (ring[0], ring[1]);
+        let t = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let elen = (t[0] * t[0] + t[1] * t[1] + t[2] * t[2]).sqrt();
+        let m = normalize(&[a[0] + b[0], a[1] + b[1], a[2] + b[2]]);
+        let left = normalize(&cross(&m, &t));
+        let p = normalize(&[
+            m[0] + 0.25 * elen * left[0],
+            m[1] + 0.25 * elen * left[1],
+            m[2] + 0.25 * elen * left[2],
+        ]);
+        let (lon, lat) = xyz_to_lonlat(&p);
+        debug_assert!(
+            covered.contains(&crate::geo2mort::geo2mort_scalar(lat, lon, max_depth)),
+            "dissolve internal inconsistency: a boundary ring does not carry \
+             the covered region on its left"
+        );
+    }
 }
 
 // ── edge-cancellation: cover → boundary rings (unit vectors) ───────────────
+
+/// One cell's boundary loop as unit vectors, exactly as emitted (`step`
+/// points per edge) — the traversal order every surviving directed edge and
+/// the per-call orientation calibration inherit.
+fn cell_boundary_loop(order: u8, nest: u64, step: u32) -> Vec<Vec3> {
+    if step == 1 {
+        let xyz = boundaries_scalar(order, nest); // [[x;4],[y;4],[z;4]]
+        (0..4).map(|c| [xyz[0][c], xyz[1][c], xyz[2][c]]).collect()
+    } else {
+        boundaries_step_scalar(order, nest, step) // Vec<[f64;3]>
+    }
+}
 
 fn boundary_rings_xyz(morton: &[u64], step: u32) -> Vec<Vec<Vec3>> {
     let (survivors, id_xyz) = survivor_edges(morton, step);
@@ -111,14 +174,7 @@ fn survivor_edges(morton: &[u64], step: u32) -> (Vec<(u32, u32)>, Vec<Vec3>) {
     // Boundary points per cell, in boundary order, as unit vectors.
     let mut all_pts: Vec<Vec<Vec3>> = Vec::with_capacity(flat.len());
     for &w in &flat {
-        let nest = mort2nested(w).0;
-        if step == 1 {
-            let xyz = boundaries_scalar(order, nest); // [[x;4],[y;4],[z;4]]
-            let cell: Vec<Vec3> = (0..4).map(|c| [xyz[0][c], xyz[1][c], xyz[2][c]]).collect();
-            all_pts.push(cell);
-        } else {
-            all_pts.push(boundaries_step_scalar(order, nest, step)); // Vec<[f64;3]>
-        }
+        all_pts.push(cell_boundary_loop(order, mort2nested(w).0, step));
     }
 
     // Integer-snap every boundary point to a vertex id.
@@ -293,9 +349,56 @@ fn chain_rings(survivors: &[(u32, u32)], id_xyz: &[Vec3]) -> Vec<Vec<Vec3>> {
         // starts at the ring's minimal vertex id (and, via the shared
         // successor path, in its lexicographically smallest rotation) — no
         // explicit re-rotation needed for a canonical start.
-        rings.push(chain.iter().map(|&i| id_xyz[i as usize]).collect());
+        for cycle in split_at_revisits(chain) {
+            rings.push(cycle.iter().map(|&i| id_xyz[i as usize]).collect());
+        }
     }
     rings
+}
+
+/// Split a closed vertex-id walk into minimal simple cycles.
+///
+/// The rotational pairing traces boundaries of the *covered* faces; where
+/// the covered region is pinched at a vertex (two uncovered cells touching
+/// only diagonally, so the covered face's own boundary passes the pinch
+/// twice) the traced walk legitimately revisits that vertex — a correct
+/// even-odd boundary, but not an OGC-simple ring.  Splitting at each
+/// revisit yields the equivalent decomposition into simple rings touching
+/// at a point (the dual of the covered-side corner-touch pinch the pairing
+/// already resolves).  Each cycle is rotated to start at its minimal vertex
+/// id, keeping the canonical-start determinism of issue #155.
+fn split_at_revisits(chain: Vec<u32>) -> Vec<Vec<u32>> {
+    let mut out: Vec<Vec<u32>> = Vec::new();
+    let mut stack: Vec<u32> = Vec::new();
+    let mut pos: HashMap<u32, usize> = HashMap::new();
+    for id in chain {
+        if let Some(&p) = pos.get(&id) {
+            let cycle: Vec<u32> = stack.drain(p..).collect();
+            for &c in &cycle {
+                pos.remove(&c);
+            }
+            out.push(rotate_to_min(cycle));
+        }
+        pos.insert(id, stack.len());
+        stack.push(id);
+    }
+    if !stack.is_empty() {
+        out.push(rotate_to_min(stack));
+    }
+    out
+}
+
+/// Rotate a simple cycle to start at its minimal vertex id (unique, since a
+/// simple cycle visits each vertex once).
+fn rotate_to_min(mut cycle: Vec<u32>) -> Vec<u32> {
+    let k = cycle
+        .iter()
+        .enumerate()
+        .min_by_key(|&(_, &v)| v)
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    cycle.rotate_left(k);
+    cycle
 }
 
 // ── classification + pole/antimeridian split (GeoJSON convention) ──────────
@@ -323,16 +426,146 @@ fn xyz_to_lonlat(v: &Vec3) -> (f64, f64) {
     (lon, lat)
 }
 
-fn net_winding(coords: &[(f64, f64)]) -> f64 {
-    let n = coords.len();
-    let mut net = 0.0;
+/// Convert an oriented spherical ring to planar lon/lat vertices, expanding
+/// any pole vertex into an explicit lat-±90 traverse.
+///
+/// A vertex at the pole has no longitude (`atan2(0, 0)`); its planar image
+/// is a lat-±90 *edge* from the arriving meridian's longitude to the
+/// departing one's, run in the direction that keeps the covered region on
+/// the left — westward across the top at +90, eastward across the bottom at
+/// -90 — inserting an explicit ±180 seam pair when the direct step would
+/// run the wrong way round.  (The old single `atan2(0,0) = 0` planar vertex
+/// silently sliced off planar area next to the pole: pointwise-wrong emit
+/// for any cover whose boundary passes *through* a pole, e.g. base cells
+/// {0, 1} at order 1 — a defect predating issue #147, exposed by its
+/// point-sampled acceptance tests.)
+fn ring_to_planar(ring: &[Vec3]) -> Vec<(f64, f64)> {
+    let n = ring.len();
+    let lonlat = normalized_lonlat(ring);
+    let mut out: Vec<(f64, f64)> = Vec::with_capacity(n + 4);
     for i in 0..n {
-        let lo0 = coords[i].0;
-        let lo1 = coords[(i + 1) % n].0;
-        let d = lo1 - lo0;
-        net += (d + 180.0).rem_euclid(360.0) - 180.0;
+        let v = ring[i];
+        if v[2].abs() > 1.0 - 1e-9 {
+            let pole = if v[2] > 0.0 { 90.0 } else { -90.0 };
+            let (lon_arr, _) = lonlat[(i + n - 1) % n];
+            let (lon_dep, _) = lonlat[(i + 1) % n];
+            out.push((lon_arr, pole));
+            let direct_ok = if pole > 0.0 {
+                lon_dep < lon_arr // top edge runs westward
+            } else {
+                lon_dep > lon_arr // bottom edge runs eastward
+            };
+            if !direct_ok {
+                // through the seam: the pair is an exact ±180 crossing that
+                // `cut_at_antimeridian` splits without interpolation.
+                if pole > 0.0 {
+                    out.push((-180.0, pole));
+                    out.push((180.0, pole));
+                } else {
+                    out.push((180.0, pole));
+                    out.push((-180.0, pole));
+                }
+            }
+            out.push((lon_dep, pole));
+        } else {
+            out.push(lonlat[i]);
+        }
     }
-    net
+    out
+}
+
+/// Per-vertex `(lon, lat)` with seam-lying vertices' longitude **signs
+/// normalized by traversal direction**.  A vertex exactly on the ±180
+/// meridian gets an arbitrary sign from `atan2` (its `y` is a rounding
+/// residual), and a whole boundary *edge* can lie on the seam (base-cell
+/// meridians at lon 180, e.g. base cells {9, 10}'s shared edge) — mixed
+/// signs there fabricate spurious ±360 cuts mid-edge.  With the covered
+/// region on the ring's left, a seam-lying edge walked *northward* has the
+/// covered side west, so it belongs on the map's east edge (+180);
+/// southward, on −180.  A vertex with a seam neighbour takes that edge's
+/// direction; an isolated seam touch takes its off-seam neighbours' side.
+fn normalized_lonlat(ring: &[Vec3]) -> Vec<(f64, f64)> {
+    let n = ring.len();
+    let mut lonlat: Vec<(f64, f64)> = ring.iter().map(xyz_to_lonlat).collect();
+    let is_pole = |j: usize| ring[j][2].abs() > 1.0 - 1e-9;
+    let on_seam = |ll: &[(f64, f64)], j: usize| !is_pole(j) && (ll[j].0.abs() - 180.0).abs() < 1e-9;
+    // Effective seam latitude of a neighbour when the edge to it runs along
+    // the seam: a seam vertex's own latitude, or ±90 for a pole vertex (any
+    // great-circle edge into a pole from a seam vertex is the seam meridian).
+    let seam_lat = |ll: &[(f64, f64)], j: usize| -> Option<f64> {
+        if is_pole(j) {
+            Some(if ring[j][2] > 0.0 { 90.0 } else { -90.0 })
+        } else if on_seam(ll, j) {
+            Some(ll[j].1)
+        } else {
+            None
+        }
+    };
+    let orig = lonlat.clone();
+    for i in 0..n {
+        if !on_seam(&orig, i) {
+            continue;
+        }
+        let (prev, next) = ((i + n - 1) % n, (i + 1) % n);
+        let side = if let Some(la) = seam_lat(&orig, next) {
+            // seam edge onward: northward ⟹ covered west ⟹ map east (+180).
+            if la > orig[i].1 {
+                180.0
+            } else {
+                -180.0
+            }
+        } else if let Some(la) = seam_lat(&orig, prev) {
+            if orig[i].1 > la {
+                180.0
+            } else {
+                -180.0
+            }
+        } else {
+            // isolated touch: stay on the off-seam neighbours' side.
+            if orig[prev].0 >= 0.0 {
+                180.0
+            } else {
+                -180.0
+            }
+        };
+        lonlat[i].0 = side;
+    }
+    lonlat
+}
+
+/// Shoelace signed area (deg²) of a closed planar lon/lat ring (first vertex
+/// repeated) — positive iff the traversal is CCW in the plane.  With every
+/// ring carrying the covered region on its left (the phase-1 orientation
+/// contract survives the cylindrical projection and the seam stitch),
+/// positive ⟺ exterior shell, negative ⟺ hole; the sign is decisive because
+/// an emitted ring bounds at least one cell's planar image.
+fn planar_shoelace(ring: &[(f64, f64)]) -> f64 {
+    let open = &ring[..ring.len() - 1];
+    let n = open.len();
+    let mut acc = 0.0;
+    for i in 0..n {
+        let (x0, y0) = open[i];
+        let (x1, y1) = open[(i + 1) % n];
+        acc += x0 * y1 - x1 * y0;
+    }
+    0.5 * acc
+}
+
+/// Planar area (deg²) of the whole lon/lat map — the frame ring's shoelace.
+const MAP_AREA: f64 = 360.0 * 180.0;
+
+/// The whole-map frame shell `[-180, 180] × [-90, 90]`, CCW (positive
+/// shoelace): the planar boundary of a covered region that encloses the
+/// entire antimeridian seam and both poles (e.g. world-minus-hole), which no
+/// spherical boundary ring supplies.
+fn frame_ring() -> Ring {
+    vec![
+        (-180.0, -90.0),
+        (180.0, -90.0),
+        (180.0, 90.0),
+        (-180.0, 90.0),
+        (-180.0, -90.0),
+    ]
 }
 
 /// Cut an open lon/lat ring at +/-180.  `Ok(whole)` when the ring never
@@ -349,7 +582,14 @@ fn cut_at_antimeridian(coords: &[(f64, f64)]) -> Result<Ring, Vec<Ring>> {
         if (lo1 - lo0).abs() > 180.0 {
             let lo1u = if lo1 > lo0 { lo1 - 360.0 } else { lo1 + 360.0 };
             let boundary = if lo1u > lo0 { 180.0 } else { -180.0 };
-            let frac = (boundary - lo0) / (lo1u - lo0);
+            // An exact ±180 → ∓180 pair (a pole traverse's explicit seam
+            // crossing, `ring_to_planar`) unwraps to a zero-length step;
+            // there is nothing to interpolate.
+            let frac = if lo1u == lo0 {
+                0.0
+            } else {
+                (boundary - lo0) / (lo1u - lo0)
+            };
             let la_x = la0 + frac * (la1 - la0);
             cur.push((boundary, la_x));
             segments.push(std::mem::take(&mut cur));
@@ -368,17 +608,23 @@ fn cut_at_antimeridian(coords: &[(f64, f64)]) -> Result<Ring, Vec<Ring>> {
     Err(segments)
 }
 
-/// Reconnect antimeridian-cut `segments` into closed lon/lat rings.  `pole` is
-/// the pole (+/-90) the filled region encloses (0.0 = none).
+/// Reconnect antimeridian-cut `segments` into closed lon/lat rings.
+///
+/// Pole seams are chosen **locally** (issue #147): the phase-1 orientation
+/// contract (covered region on every ring's left) means the covered seam
+/// interval always runs *upward* from a cut end on +180 and *downward* on
+/// -180 — so an end with no same-side start in that direction wraps the pole
+/// on that side, unconditionally.  No global winding parameter exists to be
+/// wrong, and one ring may wrap both poles (a covered region enclosing the
+/// whole seam).  This replaces the net-longitude-winding `pole` argument,
+/// whose single global value mis-stitched covers mixing a pole region with
+/// other seam-crossing parts.
 ///
 /// Errs (with a message for a Python `ValueError`, the curated convention
 /// from PR #111 — issue #181) instead of panicking on stitch states that
-/// cannot be closed: unbalanced segments with no enclosed pole, or a
+/// cannot be closed: a missing partner segment after a pole seam, or a
 /// non-converging walk.
-fn stitch_segments(
-    segments: Vec<Vec<(f64, f64)>>,
-    pole: f64,
-) -> Result<Vec<Vec<(f64, f64)>>, String> {
+fn stitch_segments(segments: Vec<Vec<(f64, f64)>>) -> Result<Vec<Vec<(f64, f64)>>, String> {
     let segs = segments;
     let n = segs.len();
     let mut used = vec![false; n];
@@ -405,7 +651,7 @@ fn stitch_segments(
             }
             used[i] = true;
             ring.extend_from_slice(&segs[i]);
-            idx = next_segment(&segs, &used, &mut ring, pole, seed)?;
+            idx = next_segment(&segs, &used, &mut ring, seed)?;
         }
         if let Some(&first) = ring.first() {
             ring.push(first);
@@ -419,7 +665,6 @@ fn next_segment(
     segs: &[Vec<(f64, f64)>],
     used: &[bool],
     ring: &mut Vec<(f64, f64)>,
-    pole: f64,
     seed: usize,
 ) -> Result<Option<usize>, String> {
     let &(side, end_lat) = ring.last().unwrap();
@@ -450,16 +695,13 @@ fn next_segment(
         });
     }
 
-    // No same-side start in that direction: the region wraps `pole`.
-    if pole == 0.0 {
-        return Err(
-            "dissolved cover's antimeridian segments are unbalanced but no \
-             pole is enclosed, so the stitch cannot close the outline; split \
-             the cover into smaller parts or pass dissolve=False for per-cell \
-             polygons (issue #181)"
-                .to_string(),
-        );
-    }
+    // No same-side start in that direction: the covered seam interval runs to
+    // the pole on this side (upward on +180, downward on -180 — the phase-1
+    // orientation contract), so the region wraps that pole.  Cross it and
+    // resume on the other side at the start nearest the pole: the highest
+    // start after a north wrap (walking down -180), the lowest after a south
+    // wrap (walking up +180).
+    let pole = if side > 0.0 { 90.0 } else { -90.0 };
     let other = -side;
     ring.push((side, pole));
     ring.push((other, pole));
@@ -468,18 +710,22 @@ fn next_segment(
         .map(|i| (segs[i][0].1, i))
         .collect();
     if ocands.is_empty() {
-        return Ok(None);
+        return Err(
+            "dissolved cover's antimeridian stitch found no partner segment \
+             after a pole seam (an internal dissolve inconsistency, issue \
+             #181); pass dissolve=False for per-cell polygons"
+                .to_string(),
+        );
     }
-    let want_min = (other > 0.0) == (pole < 0.0);
-    let (la, i) = if want_min {
+    let (la, i) = if pole > 0.0 {
         *ocands
             .iter()
-            .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
             .unwrap()
     } else {
         *ocands
             .iter()
-            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+            .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
             .unwrap()
     };
     ring.push((other, la));
@@ -490,492 +736,98 @@ fn next_segment(
     })
 }
 
-fn ring_signed_area_lonlat(ring: &[(f64, f64)]) -> f64 {
-    // ring is closed (first == last); drop the repeat for the area fan.
-    let open = &ring[..ring.len() - 1];
-    let v: Vec<Vec3> = open
-        .iter()
-        .map(|&(lon, lat)| {
-            let rlat = lat.to_radians();
-            let rlon = lon.to_radians();
-            [rlat.cos() * rlon.cos(), rlat.cos() * rlon.sin(), rlat.sin()]
-        })
-        .collect();
-    spherical_signed_area(&v)
-}
-
-fn classify_and_split(
-    mut rings_xyz: Vec<Vec<Vec3>>,
-    cover_area: f64,
-) -> Result<ClassifiedRings, String> {
+/// Classify covered-on-left boundary rings into planar shells and holes —
+/// the winding-free classifier (issue #147).
+///
+/// `rings_xyz` must already carry the covered region on every ring's left
+/// (the phase-1 orientation contract, established per-call in [`dissolve`]).
+/// Classification is then planar and local: cut/stitch at the antimeridian
+/// (pole seams locally decided), and read each emitted planar ring's
+/// shoelace sign — positive (CCW, covered inside) ⟹ shell, negative ⟹ hole.
+/// A negative *total* shoelace means the covered region encloses the whole
+/// map frame (world-minus-hole covers), which gets the explicit
+/// [`frame_ring`] shell.  Nothing consults a mod-4π winding sum: the PR #111
+/// guards this replaces (`HEMISPHERE_MARGIN`, the Σ-vs-exact-area wrap
+/// cross-check) survive only as [`dissolve`]'s debug assertion on the
+/// orientation contract ([`debug_assert_cover_on_left`]).
+///
+/// Errs (curated, for a Python `ValueError`) only on genuinely ill-posed
+/// boundary output: a self-crossing boundary ring
+/// ([`crate::sphere::ring_set_validity`]), or a stitch state that cannot
+/// close (issue #181).  Identity conflicts — one snapped coordinate at two
+/// non-adjacent ring positions — are *accepted*: they are the working
+/// representation of a corner-touch pinch resolved into touching simple
+/// rings (the issue #155 ruling), pinned by the corner-touch dissolve tests.
+fn classify_and_split(rings_xyz: Vec<Vec<Vec3>>) -> Result<ClassifiedRings, String> {
     let mut out = ClassifiedRings {
         shells: Vec::new(),
         holes: Vec::new(),
     };
     if rings_xyz.is_empty() {
+        // A nonempty cover with no surviving boundary edge is the whole
+        // sphere: every edge cancelled, and the planar image is the frame.
+        out.shells.push(frame_ring());
         return Ok(out);
     }
-    // Normalise global winding so the covered area (exteriors minus holes) is
-    // positive — the boundary point order differs between step==1 and step>1.
-    // The fan formula wraps mod 4π when a single ring encloses more than a
-    // hemisphere (possible even for a small cover, e.g. an equatorial band),
-    // which would flip the sign here; an honest |Σ| matches the exact covered
-    // area to within chord discretization (≲0.1 sr at step==1) while any wrap
-    // is off by ~4π, so a π tolerance separates them cleanly.
-    let mut areas: Vec<f64> = rings_xyz.iter().map(|r| spherical_signed_area(r)).collect();
-    let total: f64 = areas.iter().sum();
-    if (total.abs() - cover_area).abs() > std::f64::consts::PI {
+
+    let validity = crate::sphere::ring_set_validity(&rings_xyz);
+    if let Some((r, i, j)) = validity.crossing {
         return Err(format!(
-            "dissolved cover has a boundary ring enclosing more than a \
-             hemisphere (|Σ ring areas| = {:.6} sr vs covered area {cover_area:.6} \
-             sr), so its exterior/hole winding cannot be classified; split the \
-             cover into sub-hemisphere parts or pass dissolve=False for \
-             per-cell polygons",
-            total.abs()
+            "dissolved cover produced a self-crossing boundary ring (ring \
+             {r}, edges at vertices {i} and {j}), so its outline is not \
+             classifiable; pass dissolve=False for per-cell polygons"
         ));
-    }
-    if total < 0.0 {
-        for r in rings_xyz.iter_mut() {
-            r.reverse();
-        }
-        for a in areas.iter_mut() {
-            *a = -*a;
-        }
     }
 
     let mut segments: Vec<Vec<(f64, f64)>> = Vec::new();
-    let mut total_net = 0.0;
-    for (ring, &area) in rings_xyz.iter().zip(areas.iter()) {
-        let ll: Vec<(f64, f64)> = ring.iter().map(xyz_to_lonlat).collect();
-        total_net += net_winding(&ll);
+    for ring in rings_xyz.iter() {
+        let ll = ring_to_planar(ring);
         match cut_at_antimeridian(&ll) {
             Ok(whole) => {
-                if area < 0.0 {
-                    out.holes.push(whole);
-                } else {
+                if planar_shoelace(&whole) >= 0.0 {
                     out.shells.push(whole);
+                } else {
+                    out.holes.push(whole);
                 }
             }
             Err(segs) => segments.extend(segs),
         }
     }
-
     if !segments.is_empty() {
-        let pole = if total_net.abs() > 180.0 {
-            if total_net > 0.0 {
-                90.0
-            } else {
-                -90.0
-            }
-        } else {
-            0.0
-        };
-        for piece in stitch_segments(segments, pole)? {
-            if ring_signed_area_lonlat(&piece) >= 0.0 {
+        for piece in stitch_segments(segments)? {
+            if planar_shoelace(&piece) >= 0.0 {
                 out.shells.push(piece);
             } else {
                 out.holes.push(piece);
             }
         }
     }
+
+    // Frame rule: Σ shoelace over the emitted rings is the covered region's
+    // planar area when its boundary is complete, and that minus the full map
+    // when the region encloses the frame (both poles and the whole seam
+    // covered, with no ring crossing the seam) — the two cases are separated
+    // by sign, since a nonempty cover has positive planar area.
+    let total: f64 = out
+        .shells
+        .iter()
+        .chain(out.holes.iter())
+        .map(|r| planar_shoelace(r))
+        .sum();
+    let framed = total < 0.0;
+    if framed {
+        out.shells.insert(0, frame_ring());
+    }
+    let planar_area = total + if framed { MAP_AREA } else { 0.0 };
+    debug_assert!(
+        planar_area > 0.0 && planar_area < MAP_AREA + 1.0,
+        "dissolve internal inconsistency: emitted planar area {planar_area} \
+         deg^2 outside (0, whole map]"
+    );
     Ok(out)
 }
 
+// ── tests ───────────────────────────────────────────────────────────────
+
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cut_no_crossing_returns_whole() {
-        let ring = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)];
-        let got = cut_at_antimeridian(&ring).unwrap();
-        assert_eq!(got.len(), ring.len() + 1); // closed
-        assert_eq!(got[0], got[got.len() - 1]);
-    }
-
-    #[test]
-    fn cut_two_crossings_splits_each_side() {
-        // box straddling +/-180: two segments, one per hemisphere side.
-        let ring = [(170.0, 0.0), (-170.0, 0.0), (-170.0, 10.0), (170.0, 10.0)];
-        let segs = cut_at_antimeridian(&ring).unwrap_err();
-        assert_eq!(segs.len(), 2);
-        for s in &segs {
-            assert!((s[0].0.abs() - 180.0).abs() < 1e-9);
-            assert!((s[s.len() - 1].0.abs() - 180.0).abs() < 1e-9);
-        }
-        // no pole enclosed -> each segment closes on its own side.
-        let rings = stitch_segments(segs, 0.0).unwrap();
-        assert_eq!(rings.len(), 2);
-        for r in &rings {
-            let span = r.iter().map(|p| p.0).fold(f64::MIN, f64::max)
-                - r.iter().map(|p| p.0).fold(f64::MAX, f64::min);
-            assert!(span <= 180.0 + 1e-9);
-        }
-    }
-
-    #[test]
-    fn net_winding_detects_pole_wrap() {
-        // a ring marching once around the globe wraps a pole (net ~ +/-360).
-        let ring: Vec<(f64, f64)> = (-180..180)
-            .step_by(30)
-            .map(|lo| (lo as f64, -80.0))
-            .collect();
-        assert!(net_winding(&ring).abs() > 180.0);
-    }
-
-    #[test]
-    fn hemisphere_cover_fails_loud() {
-        // 24 order-1 cells (base cells 0-5) tile exactly half the sphere
-        // (area = 2π), where exterior/hole winding is ambiguous (issue #108).
-        let cover: Vec<u64> = (0..24u64)
-            .map(|nest| crate::morton::nested2mort(nest, 1))
-            .collect();
-        assert!((cover_area(&cover) - std::f64::consts::TAU).abs() < 1e-12);
-        let err = dissolve(&cover, 1)
-            .err()
-            .expect("hemisphere must be rejected");
-        assert!(err.contains("hemisphere"), "{err}");
-    }
-
-    #[test]
-    fn equatorial_band_fails_loud_not_cryptic() {
-        // A thin equatorial band (~1.3 sr, far under the area guard) has two
-        // boundary rings that each enclose more than a hemisphere, so the fan
-        // sum wraps mod 4π: the Σ-vs-exact-area cross-check must reject it
-        // with the curated message, not die in the antimeridian stitcher.
-        let mut band: Vec<u64> = Vec::new();
-        for ilon in 0..720 {
-            for ilat in -7..8 {
-                let lat = ilat as f64 * 0.5;
-                let lon = -180.0 + ilon as f64 * 0.5;
-                band.push(crate::geo2mort::geo2mort_scalar(lat, lon, 4));
-            }
-        }
-        band.sort_unstable();
-        band.dedup();
-        let err = dissolve(&band, 1).err().expect("band must be rejected");
-        assert!(err.contains("hemisphere"), "{err}");
-    }
-
-    #[test]
-    fn stitcher_error_is_curated_not_a_panic() {
-        // Issue #181: the stitching path's failure states must cross the FFI
-        // as the curated Err convention (PR #111), never as a raw panic.
-        // Base cells {1, 2, 7} at order 1 (π sr — one of the 79 covers the
-        // PR #179 review sweep measured on this path) deterministically
-        // reaches the unbalanced-segments state under the current global
-        // pole selection.  (Issue #147's classifier makes this cover dissolve
-        // instead — this fixture then moves to the working set — but the
-        // curated-Err contract on the remaining defensive stitch paths is
-        // pinned by `stitch_unbalanced_without_pole_errs` below either way.)
-        let cover: Vec<u64> = [1u64, 2, 7]
-            .iter()
-            .flat_map(|&b| (b * 4..(b + 1) * 4).map(|n| crate::morton::nested2mort(n, 1)))
-            .collect();
-        let err = dissolve(&cover, 1).err().expect("must reject, not panic");
-        assert!(err.contains("no pole is enclosed"), "{err}");
-    }
-
-    #[test]
-    fn stitch_unbalanced_without_pole_errs() {
-        // Direct unit pin of the curated message: one segment whose free ends
-        // cannot pair on their own side, with no enclosed pole.
-        let segs = vec![vec![(180.0, 10.0), (0.0, 10.0), (-180.0, 10.0)]];
-        let err = stitch_segments(segs, 0.0).expect_err("must err");
-        assert!(err.contains("no pole is enclosed"), "{err}");
-    }
-
-    #[test]
-    fn sub_hemisphere_cover_still_dissolves() {
-        // Base cells 0-3 (2/3 of a hemisphere) stay outside the guard.
-        let cover: Vec<u64> = (0..16u64)
-            .map(|nest| crate::morton::nested2mort(nest, 1))
-            .collect();
-        let got = dissolve(&cover, 1).unwrap();
-        assert!(!got.shells.is_empty());
-    }
-
-    #[test]
-    fn sub_hemisphere_cover_dissolves_deterministically() {
-        // issue #155: dissolve on this fixed cover (base cells 0-3 at order
-        // 1) flaked ~10-15% per call.  Phase-1 instrumentation finding: the
-        // cover's boundary graph is a single simple 16-cycle -- there is no
-        // branching vertex at all (neither a true corner-touch nor a
-        // snap-merge artifact; no near-coincident vertex pairs, no duplicate
-        // directed edges), so the ring *decomposition* is unique.  The
-        // nondeterminism was purely the HashMap-seeded starting rotation of
-        // that one ring: classify_and_split fans spherical_signed_area from
-        // ring[0], and 2 of the 16 possible anchors (the equatorial spike
-        // tips at lon +/-45, lat 0) wrap the fan to 0.790 sr vs the true
-        // 4.090 sr, tripping the hemisphere-ring guard -- predicting 2/16 =
-        // 12.5% (measured 48/400 pre-fix).  Each dissolve call builds fresh
-        // HashMaps, so the flake reproduces in-process: pre-fix, 50
-        // iterations fail with p ~= 1 - (7/8)^50 ~= 0.999.
-        let cover: Vec<u64> = (0..16u64)
-            .map(|nest| crate::morton::nested2mort(nest, 1))
-            .collect();
-        for i in 0..50 {
-            let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("iteration {i} failed: {e}"));
-            assert!(!got.shells.is_empty(), "iteration {i}: no shells");
-        }
-    }
-
-    #[test]
-    fn dissolve_output_is_byte_identical_across_calls() {
-        // issue #155 phase 3: dissolve is a pure function of its input --
-        // two calls on identical input return byte-identical ClassifiedRings,
-        // on each fixture shape (plain cover, step > 1 densified edges, the
-        // pole/antimeridian stitch path, an equatorial cell).
-        let north: Vec<u64> = (0..16u64)
-            .map(|n| crate::morton::nested2mort(n, 1))
-            .collect();
-        let south: Vec<u64> = (32..48u64)
-            .map(|n| crate::morton::nested2mort(n, 1))
-            .collect();
-        let eq: Vec<u64> = (16..20u64)
-            .map(|n| crate::morton::nested2mort(n, 1))
-            .collect();
-        for (cover, step) in [(&north, 1u32), (&north, 4), (&south, 1), (&eq, 1), (&eq, 3)] {
-            let a = dissolve(cover, step).unwrap();
-            let b = dissolve(cover, step).unwrap();
-            assert_eq!(a.shells, b.shells);
-            assert_eq!(a.holes, b.holes);
-            assert!(!a.shells.is_empty());
-        }
-    }
-
-    fn lonlat_xyz(lon: f64, lat: f64) -> Vec3 {
-        let (rlon, rlat) = (lon.to_radians(), lat.to_radians());
-        [rlat.cos() * rlon.cos(), rlat.cos() * rlon.sin(), rlat.sin()]
-    }
-
-    // Two diamonds east and west of a shared corner-touch vertex T (id 0),
-    // both wound anticlockwise (interior on the same side).
-    fn corner_touch_fixture() -> (Vec<Vec3>, Vec<(u32, u32)>) {
-        let id_xyz = vec![
-            lonlat_xyz(0.0, 0.0),   // 0: T, the corner-touch vertex
-            lonlat_xyz(5.0, 5.0),   // 1: east diamond, north corner
-            lonlat_xyz(10.0, 0.0),  // 2: east diamond, east corner
-            lonlat_xyz(5.0, -5.0),  // 3: east diamond, south corner
-            lonlat_xyz(-5.0, 5.0),  // 4: west diamond, north corner
-            lonlat_xyz(-10.0, 0.0), // 5: west diamond, west corner
-            lonlat_xyz(-5.0, -5.0), // 6: west diamond, south corner
-        ];
-        let edges = vec![
-            (0, 3),
-            (3, 2),
-            (2, 1),
-            (1, 0), // east: T -> S -> E -> N -> T
-            (0, 4),
-            (4, 5),
-            (5, 6),
-            (6, 0), // west: T -> N -> W -> S -> T
-        ];
-        (id_xyz, edges)
-    }
-
-    // chain_rings on every LCG-shuffled permutation of `edges` (plus the
-    // reverse-sorted order) must equal its output on the canonical order.
-    fn assert_permutation_invariant(edges: &[(u32, u32)], id_xyz: &[Vec3]) {
-        let baseline = chain_rings(edges, id_xyz);
-        assert!(!baseline.is_empty());
-        // deterministic Fisher-Yates via an LCG (no rand dependency).
-        let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
-        let mut rng = || {
-            state = state
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            (state >> 33) as usize
-        };
-        let mut shuffled = edges.to_vec();
-        for _ in 0..200 {
-            for i in (1..shuffled.len()).rev() {
-                let j = rng() % (i + 1);
-                shuffled.swap(i, j);
-            }
-            assert_eq!(chain_rings(&shuffled, id_xyz), baseline);
-        }
-        shuffled.sort_unstable();
-        shuffled.reverse();
-        assert_eq!(chain_rings(&shuffled, id_xyz), baseline);
-    }
-
-    #[test]
-    fn chain_rings_is_order_independent() {
-        // issue #155 phase 3: chain_rings output is a pure function of the
-        // edge *set* -- every permutation of the survivor slice yields the
-        // identical ring list (this is the invariant, not one lucky order).
-        // Three shapes: the real cover's survivors (a simple 16-cycle --
-        // pins seed/rotation order), the corner-touch fixture (a branching
-        // vertex -- pins the rotational pairing itself), and a net > 1
-        // duplicate-edge set (pins the canonical-index tie-break at
-        // identical azimuths).
-        let cover: Vec<u64> = (0..16u64)
-            .map(|n| crate::morton::nested2mort(n, 1))
-            .collect();
-        let (edges, id_xyz) = survivor_edges(&cover, 1);
-        assert_permutation_invariant(&edges, &id_xyz);
-
-        let (id_xyz, edges) = corner_touch_fixture();
-        assert_permutation_invariant(&edges, &id_xyz);
-
-        let mut dup = edges.clone();
-        dup.extend_from_slice(&edges[..4]); // east diamond twice (net = 2)
-        assert_permutation_invariant(&dup, &id_xyz);
-        let rings = chain_rings(&dup, &id_xyz);
-        assert_eq!(rings.len(), 3, "duplicated diamond must chain twice");
-        assert_eq!(rings[0], rings[1]); // the two east copies are identical
-    }
-
-    #[test]
-    fn corner_touch_pairs_into_simple_rings() {
-        // issue #155 ruling: at a non-manifold corner-touch vertex the
-        // rotational pairing pinches the boundary into simple rings touching
-        // at a point (GeoJSON-valid) -- never one self-intersecting
-        // figure-eight.
-        let (id_xyz, edges) = corner_touch_fixture();
-        let rings = chain_rings(&edges, &id_xyz);
-        assert_eq!(
-            rings.len(),
-            2,
-            "pinch must yield two rings, not a figure-eight"
-        );
-        // exact pairing: each ring stays inside its own diamond, T once each.
-        assert_eq!(rings[0], vec![id_xyz[0], id_xyz[3], id_xyz[2], id_xyz[1]]);
-        assert_eq!(rings[1], vec![id_xyz[0], id_xyz[4], id_xyz[5], id_xyz[6]]);
-    }
-
-    // ── issue #147 phase 1: the stitcher orientation contract ──────────────
-
-    /// One cell's own boundary loop, exactly as `survivor_edges` emits it.
-    fn cell_loop(order: u8, nest: u64, step: u32) -> Vec<Vec3> {
-        if step == 1 {
-            let xyz = boundaries_scalar(order, nest);
-            (0..4).map(|c| [xyz[0][c], xyz[1][c], xyz[2][c]]).collect()
-        } else {
-            boundaries_step_scalar(order, nest, step)
-        }
-    }
-
-    #[test]
-    fn cell_boundary_emission_orientation_is_uniform() {
-        // Phase 1 of issue #147: the classifier's orientation contract rests
-        // on every cell boundary being emitted with a fixed handedness.  The
-        // HEALPix boundary functions put the cell interior on the LEFT at
-        // step == 1 (CCW, positive spherical signed area) and on the RIGHT at
-        // step > 1 (CW, negative) — uniformly over every base cell and order,
-        // with the loop's fan area matching the exact cell area.
-        for order in 0u8..=5 {
-            let n: u64 = 1 << (2 * order);
-            let exact = std::f64::consts::PI / (3.0 * 4f64.powi(order as i32));
-            for step in [1u32, 2, 3, 4, 8] {
-                for base in 0u64..12 {
-                    for nest in [base * n, base * n + n / 2, base * n + n - 1] {
-                        let a = spherical_signed_area(&cell_loop(order, nest, step));
-                        assert_eq!(
-                            a > 0.0,
-                            step == 1,
-                            "order {order} step {step} nest {nest}: area {a}"
-                        );
-                        assert!(
-                            (a.abs() - exact).abs() < 0.35 * exact,
-                            "order {order} step {step} nest {nest}: |{a}| vs {exact}"
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    /// Covers used by the orientation audit: `(name, nested cells, order)`.
-    /// Includes exact-hemisphere and over-hemisphere covers (the audit drives
-    /// `boundary_rings_xyz` directly, below any guard) and the PR #179 review
-    /// sweep's two exemplar covers.
-    fn orientation_audit_covers() -> Vec<(&'static str, Vec<u64>, u8)> {
-        let cells = |bases: &[u64], order: u8| -> Vec<u64> {
-            let n = 1u64 << (2 * order);
-            bases.iter().flat_map(|&b| b * n..(b + 1) * n).collect()
-        };
-        let mut world: Vec<u64> = (0..192).collect();
-        world.remove(100);
-        vec![
-            ("base 0-3", cells(&[0, 1, 2, 3], 1), 1),
-            ("hemisphere 0-5", cells(&[0, 1, 2, 3, 4, 5], 1), 1),
-            ("over-hemisphere 0-6", cells(&[0, 1, 2, 3, 4, 5, 6], 1), 1),
-            ("exemplar 4/6/7/10", cells(&[4, 6, 7, 10], 1), 1),
-            ("exemplar 1/2/7", cells(&[1, 2, 7], 1), 1),
-            ("scattered", vec![16, 24, 25, 28, 40, 43], 1),
-            ("world minus one order-2 cell", world, 2),
-        ]
-    }
-
-    #[test]
-    fn chained_rings_carry_cover_on_left() {
-        // Phase 1 of issue #147 — the orientation contract, end to end: after
-        // one per-call calibration (reverse every ring iff the emission
-        // handedness is CW, read off one cell's own loop), every chained ring
-        // carries the covered region on its LEFT.  The property is local
-        // (each surviving directed edge bounds exactly one covered cell, on
-        // the emission side; chaining preserves edge direction), so it holds
-        // at any cover scale — verified here on exact-hemisphere,
-        // over-hemisphere and world-minus-cell covers by displacing each edge
-        // midpoint a quarter edge-length to the left (must land covered) and
-        // right (must land uncovered).
-        for (name, nested, order) in orientation_audit_covers() {
-            for step in [1u32, 3] {
-                let covered: std::collections::HashSet<u64> = nested
-                    .iter()
-                    .map(|&c| crate::morton::nested2mort(c, order))
-                    .collect();
-                let cover: Vec<u64> = covered.iter().copied().collect();
-                let mut rings = boundary_rings_xyz(&cover, step);
-                let ccw = spherical_signed_area(&cell_loop(order, nested[0], step)) > 0.0;
-                if !ccw {
-                    for r in rings.iter_mut() {
-                        r.reverse();
-                    }
-                }
-                assert!(!rings.is_empty(), "{name}: no rings");
-                for ring in &rings {
-                    let n = ring.len();
-                    for i in 0..n {
-                        let (a, b) = (ring[i], ring[(i + 1) % n]);
-                        let t = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
-                        let elen = (t[0] * t[0] + t[1] * t[1] + t[2] * t[2]).sqrt();
-                        let m = crate::sphere::normalize(&[a[0] + b[0], a[1] + b[1], a[2] + b[2]]);
-                        let left = crate::sphere::normalize(&cross(&m, &t));
-                        for (s, want) in [(1.0, true), (-1.0, false)] {
-                            let p = crate::sphere::normalize(&[
-                                m[0] + s * 0.25 * elen * left[0],
-                                m[1] + s * 0.25 * elen * left[1],
-                                m[2] + s * 0.25 * elen * left[2],
-                            ]);
-                            let (lon, lat) = xyz_to_lonlat(&p);
-                            let w = crate::geo2mort::geo2mort_scalar(lat, lon, order);
-                            assert_eq!(
-                                covered.contains(&w),
-                                want,
-                                "{name} step {step}: probe side {s} at lon {lon} lat {lat}"
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn pole_cap_stitches_to_one_ring_with_pole_vertex() {
-        // one segment running +180 -> -180 around the pole, stitched through -90.
-        let segs = vec![vec![
-            (180.0, -80.0),
-            (90.0, -80.0),
-            (0.0, -80.0),
-            (-90.0, -80.0),
-            (-180.0, -80.0),
-        ]];
-        let rings = stitch_segments(segs, -90.0).unwrap();
-        assert_eq!(rings.len(), 1);
-        assert!(rings[0].iter().any(|p| (p.1 + 90.0).abs() < 1e-9)); // pole vertex
-    }
-}
+mod tests;

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -797,6 +797,129 @@ mod tests {
         assert_eq!(rings[1], vec![id_xyz[0], id_xyz[4], id_xyz[5], id_xyz[6]]);
     }
 
+    // ── issue #147 phase 1: the stitcher orientation contract ──────────────
+
+    /// One cell's own boundary loop, exactly as `survivor_edges` emits it.
+    fn cell_loop(order: u8, nest: u64, step: u32) -> Vec<Vec3> {
+        if step == 1 {
+            let xyz = boundaries_scalar(order, nest);
+            (0..4).map(|c| [xyz[0][c], xyz[1][c], xyz[2][c]]).collect()
+        } else {
+            boundaries_step_scalar(order, nest, step)
+        }
+    }
+
+    #[test]
+    fn cell_boundary_emission_orientation_is_uniform() {
+        // Phase 1 of issue #147: the classifier's orientation contract rests
+        // on every cell boundary being emitted with a fixed handedness.  The
+        // HEALPix boundary functions put the cell interior on the LEFT at
+        // step == 1 (CCW, positive spherical signed area) and on the RIGHT at
+        // step > 1 (CW, negative) — uniformly over every base cell and order,
+        // with the loop's fan area matching the exact cell area.
+        for order in 0u8..=5 {
+            let n: u64 = 1 << (2 * order);
+            let exact = std::f64::consts::PI / (3.0 * 4f64.powi(order as i32));
+            for step in [1u32, 2, 3, 4, 8] {
+                for base in 0u64..12 {
+                    for nest in [base * n, base * n + n / 2, base * n + n - 1] {
+                        let a = spherical_signed_area(&cell_loop(order, nest, step));
+                        assert_eq!(
+                            a > 0.0,
+                            step == 1,
+                            "order {order} step {step} nest {nest}: area {a}"
+                        );
+                        assert!(
+                            (a.abs() - exact).abs() < 0.35 * exact,
+                            "order {order} step {step} nest {nest}: |{a}| vs {exact}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Covers used by the orientation audit: `(name, nested cells, order)`.
+    /// Includes exact-hemisphere and over-hemisphere covers (the audit drives
+    /// `boundary_rings_xyz` directly, below any guard) and the PR #179 review
+    /// sweep's two exemplar covers.
+    fn orientation_audit_covers() -> Vec<(&'static str, Vec<u64>, u8)> {
+        let cells = |bases: &[u64], order: u8| -> Vec<u64> {
+            let n = 1u64 << (2 * order);
+            bases.iter().flat_map(|&b| b * n..(b + 1) * n).collect()
+        };
+        let mut world: Vec<u64> = (0..192).collect();
+        world.remove(100);
+        vec![
+            ("base 0-3", cells(&[0, 1, 2, 3], 1), 1),
+            ("hemisphere 0-5", cells(&[0, 1, 2, 3, 4, 5], 1), 1),
+            ("over-hemisphere 0-6", cells(&[0, 1, 2, 3, 4, 5, 6], 1), 1),
+            ("exemplar 4/6/7/10", cells(&[4, 6, 7, 10], 1), 1),
+            ("exemplar 1/2/7", cells(&[1, 2, 7], 1), 1),
+            ("scattered", vec![16, 24, 25, 28, 40, 43], 1),
+            ("world minus one order-2 cell", world, 2),
+        ]
+    }
+
+    #[test]
+    fn chained_rings_carry_cover_on_left() {
+        // Phase 1 of issue #147 — the orientation contract, end to end: after
+        // one per-call calibration (reverse every ring iff the emission
+        // handedness is CW, read off one cell's own loop), every chained ring
+        // carries the covered region on its LEFT.  The property is local
+        // (each surviving directed edge bounds exactly one covered cell, on
+        // the emission side; chaining preserves edge direction), so it holds
+        // at any cover scale — verified here on exact-hemisphere,
+        // over-hemisphere and world-minus-cell covers by displacing each edge
+        // midpoint a quarter edge-length to the left (must land covered) and
+        // right (must land uncovered).
+        for (name, nested, order) in orientation_audit_covers() {
+            for step in [1u32, 3] {
+                let covered: std::collections::HashSet<u64> = nested
+                    .iter()
+                    .map(|&c| crate::morton::nested2mort(c, order))
+                    .collect();
+                let cover: Vec<u64> = covered.iter().copied().collect();
+                let mut rings = boundary_rings_xyz(&cover, step);
+                let ccw = spherical_signed_area(&cell_loop(order, nested[0], step)) > 0.0;
+                if !ccw {
+                    for r in rings.iter_mut() {
+                        r.reverse();
+                    }
+                }
+                assert!(!rings.is_empty(), "{name}: no rings");
+                for ring in &rings {
+                    let n = ring.len();
+                    for i in 0..n {
+                        let (a, b) = (ring[i], ring[(i + 1) % n]);
+                        let t = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+                        let elen = (t[0] * t[0] + t[1] * t[1] + t[2] * t[2]).sqrt();
+                        let m = crate::sphere::normalize(&[
+                            a[0] + b[0],
+                            a[1] + b[1],
+                            a[2] + b[2],
+                        ]);
+                        let left = crate::sphere::normalize(&cross(&m, &t));
+                        for (s, want) in [(1.0, true), (-1.0, false)] {
+                            let p = crate::sphere::normalize(&[
+                                m[0] + s * 0.25 * elen * left[0],
+                                m[1] + s * 0.25 * elen * left[1],
+                                m[2] + s * 0.25 * elen * left[2],
+                            ]);
+                            let (lon, lat) = xyz_to_lonlat(&p);
+                            let w = crate::geo2mort::geo2mort_scalar(lat, lon, order);
+                            assert_eq!(
+                                covered.contains(&w),
+                                want,
+                                "{name} step {step}: probe side {s} at lon {lon} lat {lat}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn pole_cap_stitches_to_one_ring_with_pole_vertex() {
         // one segment running +180 -> -180 around the pole, stitched through -90.

--- a/src_rust/src/dissolve.rs
+++ b/src_rust/src/dissolve.rs
@@ -370,7 +370,15 @@ fn cut_at_antimeridian(coords: &[(f64, f64)]) -> Result<Ring, Vec<Ring>> {
 
 /// Reconnect antimeridian-cut `segments` into closed lon/lat rings.  `pole` is
 /// the pole (+/-90) the filled region encloses (0.0 = none).
-fn stitch_segments(segments: Vec<Vec<(f64, f64)>>, pole: f64) -> Vec<Vec<(f64, f64)>> {
+///
+/// Errs (with a message for a Python `ValueError`, the curated convention
+/// from PR #111 — issue #181) instead of panicking on stitch states that
+/// cannot be closed: unbalanced segments with no enclosed pole, or a
+/// non-converging walk.
+fn stitch_segments(
+    segments: Vec<Vec<(f64, f64)>>,
+    pole: f64,
+) -> Result<Vec<Vec<(f64, f64)>>, String> {
     let segs = segments;
     let n = segs.len();
     let mut used = vec![false; n];
@@ -387,17 +395,24 @@ fn stitch_segments(segments: Vec<Vec<(f64, f64)>>, pole: f64) -> Vec<Vec<(f64, f
                 break;
             }
             guard += 1;
-            assert!(guard <= 8 * n + 16, "antimeridian stitch did not converge");
+            if guard > 8 * n + 16 {
+                return Err(
+                    "dissolved cover's antimeridian stitch did not converge (an \
+                     internal dissolve inconsistency); pass dissolve=False for \
+                     per-cell polygons"
+                        .to_string(),
+                );
+            }
             used[i] = true;
             ring.extend_from_slice(&segs[i]);
-            idx = next_segment(&segs, &used, &mut ring, pole, seed);
+            idx = next_segment(&segs, &used, &mut ring, pole, seed)?;
         }
         if let Some(&first) = ring.first() {
             ring.push(first);
         }
         rings.push(ring);
     }
-    rings
+    Ok(rings)
 }
 
 fn next_segment(
@@ -406,7 +421,7 @@ fn next_segment(
     ring: &mut Vec<(f64, f64)>,
     pole: f64,
     seed: usize,
-) -> Option<usize> {
+) -> Result<Option<usize>, String> {
     let &(side, end_lat) = ring.last().unwrap();
     // candidate starts on the same +/-180 side (the seed is allowed, to close).
     // The Python oracle keys min/max on the full (lat, index) tuple; here we
@@ -428,18 +443,23 @@ fn next_segment(
     };
     if let Some((la, i)) = pick {
         ring.push((side, la));
-        return if i == seed && used[seed] {
+        return Ok(if i == seed && used[seed] {
             None
         } else {
             Some(i)
-        };
+        });
     }
 
     // No same-side start in that direction: the region wraps `pole`.
-    assert!(
-        pole != 0.0,
-        "unbalanced antimeridian segments but no pole enclosed"
-    );
+    if pole == 0.0 {
+        return Err(
+            "dissolved cover's antimeridian segments are unbalanced but no \
+             pole is enclosed, so the stitch cannot close the outline; split \
+             the cover into smaller parts or pass dissolve=False for per-cell \
+             polygons (issue #181)"
+                .to_string(),
+        );
+    }
     let other = -side;
     ring.push((side, pole));
     ring.push((other, pole));
@@ -448,7 +468,7 @@ fn next_segment(
         .map(|i| (segs[i][0].1, i))
         .collect();
     if ocands.is_empty() {
-        return None;
+        return Ok(None);
     }
     let want_min = (other > 0.0) == (pole < 0.0);
     let (la, i) = if want_min {
@@ -463,11 +483,11 @@ fn next_segment(
             .unwrap()
     };
     ring.push((other, la));
-    if i == seed && used[seed] {
+    Ok(if i == seed && used[seed] {
         None
     } else {
         Some(i)
-    }
+    })
 }
 
 fn ring_signed_area_lonlat(ring: &[(f64, f64)]) -> f64 {
@@ -550,7 +570,7 @@ fn classify_and_split(
         } else {
             0.0
         };
-        for piece in stitch_segments(segments, pole) {
+        for piece in stitch_segments(segments, pole)? {
             if ring_signed_area_lonlat(&piece) >= 0.0 {
                 out.shells.push(piece);
             } else {
@@ -584,7 +604,7 @@ mod tests {
             assert!((s[s.len() - 1].0.abs() - 180.0).abs() < 1e-9);
         }
         // no pole enclosed -> each segment closes on its own side.
-        let rings = stitch_segments(segs, 0.0);
+        let rings = stitch_segments(segs, 0.0).unwrap();
         assert_eq!(rings.len(), 2);
         for r in &rings {
             let span = r.iter().map(|p| p.0).fold(f64::MIN, f64::max)
@@ -635,6 +655,34 @@ mod tests {
         band.dedup();
         let err = dissolve(&band, 1).err().expect("band must be rejected");
         assert!(err.contains("hemisphere"), "{err}");
+    }
+
+    #[test]
+    fn stitcher_error_is_curated_not_a_panic() {
+        // Issue #181: the stitching path's failure states must cross the FFI
+        // as the curated Err convention (PR #111), never as a raw panic.
+        // Base cells {1, 2, 7} at order 1 (π sr — one of the 79 covers the
+        // PR #179 review sweep measured on this path) deterministically
+        // reaches the unbalanced-segments state under the current global
+        // pole selection.  (Issue #147's classifier makes this cover dissolve
+        // instead — this fixture then moves to the working set — but the
+        // curated-Err contract on the remaining defensive stitch paths is
+        // pinned by `stitch_unbalanced_without_pole_errs` below either way.)
+        let cover: Vec<u64> = [1u64, 2, 7]
+            .iter()
+            .flat_map(|&b| (b * 4..(b + 1) * 4).map(|n| crate::morton::nested2mort(n, 1)))
+            .collect();
+        let err = dissolve(&cover, 1).err().expect("must reject, not panic");
+        assert!(err.contains("no pole is enclosed"), "{err}");
+    }
+
+    #[test]
+    fn stitch_unbalanced_without_pole_errs() {
+        // Direct unit pin of the curated message: one segment whose free ends
+        // cannot pair on their own side, with no enclosed pole.
+        let segs = vec![vec![(180.0, 10.0), (0.0, 10.0), (-180.0, 10.0)]];
+        let err = stitch_segments(segs, 0.0).expect_err("must err");
+        assert!(err.contains("no pole is enclosed"), "{err}");
     }
 
     #[test]
@@ -894,11 +942,7 @@ mod tests {
                         let (a, b) = (ring[i], ring[(i + 1) % n]);
                         let t = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
                         let elen = (t[0] * t[0] + t[1] * t[1] + t[2] * t[2]).sqrt();
-                        let m = crate::sphere::normalize(&[
-                            a[0] + b[0],
-                            a[1] + b[1],
-                            a[2] + b[2],
-                        ]);
+                        let m = crate::sphere::normalize(&[a[0] + b[0], a[1] + b[1], a[2] + b[2]]);
                         let left = crate::sphere::normalize(&cross(&m, &t));
                         for (s, want) in [(1.0, true), (-1.0, false)] {
                             let p = crate::sphere::normalize(&[
@@ -930,7 +974,7 @@ mod tests {
             (-90.0, -80.0),
             (-180.0, -80.0),
         ]];
-        let rings = stitch_segments(segs, -90.0);
+        let rings = stitch_segments(segs, -90.0).unwrap();
         assert_eq!(rings.len(), 1);
         assert!(rings[0].iter().any(|p| (p.1 + 90.0).abs() < 1e-9)); // pole vertex
     }

--- a/src_rust/src/dissolve/tests.rs
+++ b/src_rust/src/dissolve/tests.rs
@@ -1,0 +1,584 @@
+//! Tests for the dissolve pipeline (`src_rust/src/dissolve.rs`) --- split
+//! into a sibling file per the `sphere/tests.rs` layout so the module body
+//! stays reviewable (issue #147).
+
+use super::*;
+
+#[test]
+fn cut_no_crossing_returns_whole() {
+    let ring = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)];
+    let got = cut_at_antimeridian(&ring).unwrap();
+    assert_eq!(got.len(), ring.len() + 1); // closed
+    assert_eq!(got[0], got[got.len() - 1]);
+}
+
+#[test]
+fn cut_two_crossings_splits_each_side() {
+    // box straddling +/-180: two segments, one per hemisphere side.
+    let ring = [(170.0, 0.0), (-170.0, 0.0), (-170.0, 10.0), (170.0, 10.0)];
+    let segs = cut_at_antimeridian(&ring).unwrap_err();
+    assert_eq!(segs.len(), 2);
+    for s in &segs {
+        assert!((s[0].0.abs() - 180.0).abs() < 1e-9);
+        assert!((s[s.len() - 1].0.abs() - 180.0).abs() < 1e-9);
+    }
+    // no pole wrap needed -> each segment closes on its own side.
+    let rings = stitch_segments(segs).unwrap();
+    assert_eq!(rings.len(), 2);
+    for r in &rings {
+        let span = r.iter().map(|p| p.0).fold(f64::MIN, f64::max)
+            - r.iter().map(|p| p.0).fold(f64::MAX, f64::min);
+        assert!(span <= 180.0 + 1e-9);
+    }
+}
+
+// ── point-sampling oracle (issues #147/#181 fixtures) ──────────────────
+
+/// Even-odd planar point test (mirrors `mortie/dissolve.py::_point_in_ring`).
+fn planar_point_in_ring(x: f64, y: f64, ring: &[(f64, f64)]) -> bool {
+    let n = ring.len();
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = ring[i];
+        let (xj, yj) = ring[j];
+        if (yi > y) != (yj > y) {
+            let x_cross = xi + (y - yi) / (yj - yi) * (xj - xi);
+            if x < x_cross {
+                inside = !inside;
+            }
+        }
+        j = i;
+    }
+    inside
+}
+
+/// Even-odd planar containment over all emitted rings (shells + holes).
+fn emitted_contains(out: &ClassifiedRings, lon: f64, lat: f64) -> bool {
+    let mut inside = false;
+    for ring in out.shells.iter().chain(out.holes.iter()) {
+        if planar_point_in_ring(lon, lat, ring) {
+            inside = !inside;
+        }
+    }
+    inside
+}
+
+/// Point-sample an emitted outline against its source cover: at every
+/// cell centre of `sample_order`, planar containment in the emitted
+/// rings must equal exact cover membership.  Centres exactly on the
+/// ±180 seam are nudged 1e-4° west (membership is re-evaluated at the
+/// nudged point, so the comparison stays exact); all other centres are
+/// strictly interior to their covering cell, hence bounded away from
+/// the emitted outline.
+fn assert_point_sampled(cover: &[u64], out: &ClassifiedRings, sample_order: u8) {
+    let depths: Vec<u8> = cover.iter().map(|&w| mort2nested(w).1).collect();
+    let max_depth = *depths.iter().max().unwrap();
+    let flat: Vec<u64> = if depths.iter().any(|&d| d != max_depth) {
+        moc::to_order(cover, max_depth)
+    } else {
+        cover.to_vec()
+    };
+    let covered: std::collections::HashSet<u64> = flat.iter().copied().collect();
+    assert!(
+        sample_order >= max_depth,
+        "sample centres coarser than the cover sit on cell corners"
+    );
+    // The emit is a straight-chord (step-driven) discretization of the true
+    // cell-edge arcs, so pointwise agreement with the exact cover is only
+    // required for samples farther from the emitted boundary than the
+    // chord-vs-arc gap; the band shrinks with cell size.
+    let band = 4.0 / f64::from(1u32 << max_depth);
+    let ncells = 12u64 << (2 * sample_order);
+    let mut checked = 0u64;
+    for pix in 0..ncells {
+        let (mut lon, lat) = crate::geo2mort::pix2ang_scalar(sample_order, pix);
+        if lon > 180.0 {
+            lon -= 360.0;
+        }
+        if (lon.abs() - 180.0).abs() < 1e-9 {
+            lon = 180.0 - 1e-4;
+        }
+        let w = crate::geo2mort::geo2mort_scalar(lat, lon, max_depth);
+        if emitted_contains(out, lon, lat) != covered.contains(&w) {
+            let d = planar_distance_to_rings(out, lon, lat);
+            assert!(
+                d < band,
+                "sample pix {pix} at lon {lon} lat {lat}: mismatch {d} deg \
+                 from the emitted boundary (band {band})"
+            );
+        }
+        checked += 1;
+    }
+    assert_eq!(checked, ncells);
+}
+
+/// Min planar distance (degrees) from a point to any emitted ring segment.
+fn planar_distance_to_rings(out: &ClassifiedRings, x: f64, y: f64) -> f64 {
+    let mut best = f64::MAX;
+    for ring in out.shells.iter().chain(out.holes.iter()) {
+        for w in ring.windows(2) {
+            let ((x0, y0), (x1, y1)) = (w[0], w[1]);
+            let (dx, dy) = (x1 - x0, y1 - y0);
+            let len2 = dx * dx + dy * dy;
+            let t = if len2 > 0.0 {
+                (((x - x0) * dx + (y - y0) * dy) / len2).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            let (px, py) = (x0 + t * dx, y0 + t * dy);
+            let d = ((x - px) * (x - px) + (y - py) * (y - py)).sqrt();
+            best = best.min(d);
+        }
+    }
+    best
+}
+
+fn base_cells_cover(bases: &[u64], order: u8) -> Vec<u64> {
+    let n = 1u64 << (2 * order);
+    bases
+        .iter()
+        .flat_map(|&b| (b * n..(b + 1) * n).map(|c| crate::morton::nested2mort(c, order)))
+        .collect()
+}
+
+/// Exact covered area (steradians) of a cover: Σ π/(3·4^depth).
+fn cover_area(morton: &[u64]) -> f64 {
+    morton
+        .iter()
+        .map(|&w| std::f64::consts::PI / (3.0 * 4f64.powi(mort2nested(w).1 as i32)))
+        .sum()
+}
+
+// ── issue #147: hemisphere+ covers dissolve (fail-loud fixtures flip) ──
+
+#[test]
+fn hemisphere_cover_dissolves() {
+    // 24 order-1 cells (base cells 0-5) tile exactly half the sphere
+    // (area = 2π) — the flagship input the PR #111 guard rejected.  The
+    // winding-free classifier needs no winding sign, so it dissolves,
+    // point-sampled correct against the source cover (issue #147).
+    let cover = base_cells_cover(&[0, 1, 2, 3, 4, 5], 1);
+    assert!((cover_area(&cover) - std::f64::consts::TAU).abs() < 1e-12);
+    let got = dissolve(&cover, 1).unwrap();
+    assert!(!got.shells.is_empty());
+    assert_point_sampled(&cover, &got, 3);
+}
+
+#[test]
+fn equatorial_band_dissolves() {
+    // A thin equatorial band (~1.3 sr): both boundary rings enclose more
+    // than a hemisphere, which wrapped the old fan sum mod 4π (rejected
+    // by the PR #111 cross-check).  Planar classification does not care:
+    // the two circles stitch into one seam-closed shell (issue #147).
+    let mut band: Vec<u64> = Vec::new();
+    for ilon in 0..720 {
+        for ilat in -7..8 {
+            let lat = ilat as f64 * 0.5;
+            let lon = -180.0 + ilon as f64 * 0.5;
+            band.push(crate::geo2mort::geo2mort_scalar(lat, lon, 4));
+        }
+    }
+    band.sort_unstable();
+    band.dedup();
+    let got = dissolve(&band, 1).unwrap();
+    assert_eq!(got.shells.len(), 1);
+    assert!(got.holes.is_empty());
+    assert_point_sampled(&band, &got, 4);
+}
+
+#[test]
+fn sweep_exemplar_1_2_7_dissolves() {
+    // Base cells {1, 2, 7} at order 1 (π sr) — the PR #179 review
+    // sweep's second exemplar (12/12 stitcher panics post-#179, the
+    // issue #181 measurement).  Its region wraps a pole only in the
+    // net-winding accounting, not in fact; the local pole rule stitches
+    // it correctly (issue #147 plan delta, acceptance fixture).
+    let cover = base_cells_cover(&[1, 2, 7], 1);
+    let got = dissolve(&cover, 1).unwrap();
+    assert!(!got.shells.is_empty());
+    assert_point_sampled(&cover, &got, 3);
+}
+
+#[test]
+fn sweep_exemplar_4_6_7_10_dissolves() {
+    // Base cells {4, 6, 7, 10} at order 1 (4.19 sr, over-hemisphere) —
+    // the PR #179 review sweep's first exemplar (12/12 guard rejections
+    // post-#179).  Issue #147 plan delta, acceptance fixture.
+    let cover = base_cells_cover(&[4, 6, 7, 10], 1);
+    let got = dissolve(&cover, 1).unwrap();
+    assert!(!got.shells.is_empty());
+    assert_point_sampled(&cover, &got, 3);
+}
+
+#[test]
+fn over_hemisphere_cover_dissolves() {
+    // Base cells 0-6 (7.33 sr, well past a hemisphere): previously the
+    // area guard rejected anything past 0.98·2π; the planar classifier
+    // emits the honest outline of the larger region (issue #147).
+    let cover = base_cells_cover(&[0, 1, 2, 3, 4, 5, 6], 1);
+    let got = dissolve(&cover, 1).unwrap();
+    assert!(!got.shells.is_empty());
+    assert_point_sampled(&cover, &got, 3);
+}
+
+#[test]
+fn world_minus_hole_gets_frame_shell() {
+    // Every order-2 cell but one: the covered region encloses the whole
+    // seam and both poles, so its only spherical boundary ring is a
+    // planar hole (covered-on-left reads CW around the uncovered cell)
+    // and the shell is the explicit map frame (issue #147).
+    let mut nested: Vec<u64> = (0..192).collect();
+    nested.remove(100);
+    let cover: Vec<u64> = nested
+        .iter()
+        .map(|&c| crate::morton::nested2mort(c, 2))
+        .collect();
+    let got = dissolve(&cover, 1).unwrap();
+    assert_eq!(got.shells.len(), 1);
+    assert_eq!(got.shells[0], frame_ring());
+    assert_eq!(got.holes.len(), 1);
+    assert_point_sampled(&cover, &got, 3);
+}
+
+#[test]
+fn whole_sphere_cover_emits_frame() {
+    // All 48 order-1 cells: every edge cancels, no boundary ring
+    // survives — the planar image is the frame itself (issue #147).
+    let bases: Vec<u64> = (0..12).collect();
+    let cover = base_cells_cover(&bases, 1);
+    assert!((cover_area(&cover) - 2.0 * std::f64::consts::TAU).abs() < 1e-12);
+    let got = dissolve(&cover, 1).unwrap();
+    assert_eq!(got.shells, vec![frame_ring()]);
+    assert!(got.holes.is_empty());
+    assert_point_sampled(&cover, &got, 3);
+}
+
+#[test]
+fn north_pole_wrap_picks_nearest_start() {
+    // Latent stitcher bug fixture (found during issue #147): a north
+    // polar cap plus a disjoint seam-straddling box.  The old global
+    // net-winding rule set pole=+90, and after the cap's pole seam the
+    // `want_min` arm picked the *minimum*-latitude start on -180 (the
+    // box's), fusing cap and box into one self-intersecting ring —
+    // shapely reported the emit invalid.  The local rule resumes at the
+    // start nearest the crossed pole (the cap's own): two clean parts.
+    let mut cover: Vec<u64> = Vec::new();
+    for ilat in 0..10 {
+        let lat = 86.0 + 0.4 * ilat as f64;
+        for ilon in -180..180 {
+            cover.push(crate::geo2mort::geo2mort_scalar(lat, ilon as f64, 4));
+        }
+    }
+    for ilat in 0..21 {
+        let lat = 10.0 + 0.5 * ilat as f64;
+        for ilon in 0..33 {
+            let lon = 172.0 + 0.5 * ilon as f64;
+            let lon = if lon > 180.0 { lon - 360.0 } else { lon };
+            cover.push(crate::geo2mort::geo2mort_scalar(lat, lon, 4));
+        }
+    }
+    cover.sort_unstable();
+    cover.dedup();
+    let got = dissolve(&cover, 1).unwrap();
+    // cap (one seam-wrapped ring) + the box's east and west halves.
+    assert_eq!(got.shells.len(), 3, "cap and box must stay separate");
+    assert!(got.holes.is_empty());
+    assert_point_sampled(&cover, &got, 4);
+}
+
+#[test]
+fn stitch_missing_partner_errs_curated() {
+    // Issue #181: the stitching path's defensive failure states surface
+    // as the curated Err convention (PR #111), never as a raw panic.
+    // A lone segment starting and ending on +180 with no start above its
+    // end wraps the north pole and finds no partner on -180.
+    let segs = vec![vec![(180.0, 10.0), (0.0, 15.0), (180.0, 20.0)]];
+    let err = stitch_segments(segs).expect_err("must err");
+    assert!(err.contains("no partner segment"), "{err}");
+}
+
+#[test]
+fn sub_hemisphere_cover_still_dissolves() {
+    // Base cells 0-3 (2/3 of a hemisphere) stay outside the guard.
+    let cover: Vec<u64> = (0..16u64)
+        .map(|nest| crate::morton::nested2mort(nest, 1))
+        .collect();
+    let got = dissolve(&cover, 1).unwrap();
+    assert!(!got.shells.is_empty());
+}
+
+#[test]
+fn sub_hemisphere_cover_dissolves_deterministically() {
+    // issue #155: dissolve on this fixed cover (base cells 0-3 at order
+    // 1) flaked ~10-15% per call.  Phase-1 instrumentation finding: the
+    // cover's boundary graph is a single simple 16-cycle -- there is no
+    // branching vertex at all (neither a true corner-touch nor a
+    // snap-merge artifact; no near-coincident vertex pairs, no duplicate
+    // directed edges), so the ring *decomposition* is unique.  The
+    // nondeterminism was purely the HashMap-seeded starting rotation of
+    // that one ring: classify_and_split fans spherical_signed_area from
+    // ring[0], and 2 of the 16 possible anchors (the equatorial spike
+    // tips at lon +/-45, lat 0) wrap the fan to 0.790 sr vs the true
+    // 4.090 sr, tripping the hemisphere-ring guard -- predicting 2/16 =
+    // 12.5% (measured 48/400 pre-fix).  Each dissolve call builds fresh
+    // HashMaps, so the flake reproduces in-process: pre-fix, 50
+    // iterations fail with p ~= 1 - (7/8)^50 ~= 0.999.
+    let cover: Vec<u64> = (0..16u64)
+        .map(|nest| crate::morton::nested2mort(nest, 1))
+        .collect();
+    for i in 0..50 {
+        let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("iteration {i} failed: {e}"));
+        assert!(!got.shells.is_empty(), "iteration {i}: no shells");
+    }
+}
+
+#[test]
+fn dissolve_output_is_byte_identical_across_calls() {
+    // issue #155 phase 3: dissolve is a pure function of its input --
+    // two calls on identical input return byte-identical ClassifiedRings,
+    // on each fixture shape (plain cover, step > 1 densified edges, the
+    // pole/antimeridian stitch path, an equatorial cell).
+    let north: Vec<u64> = (0..16u64)
+        .map(|n| crate::morton::nested2mort(n, 1))
+        .collect();
+    let south: Vec<u64> = (32..48u64)
+        .map(|n| crate::morton::nested2mort(n, 1))
+        .collect();
+    let eq: Vec<u64> = (16..20u64)
+        .map(|n| crate::morton::nested2mort(n, 1))
+        .collect();
+    for (cover, step) in [(&north, 1u32), (&north, 4), (&south, 1), (&eq, 1), (&eq, 3)] {
+        let a = dissolve(cover, step).unwrap();
+        let b = dissolve(cover, step).unwrap();
+        assert_eq!(a.shells, b.shells);
+        assert_eq!(a.holes, b.holes);
+        assert!(!a.shells.is_empty());
+    }
+}
+
+fn lonlat_xyz(lon: f64, lat: f64) -> Vec3 {
+    let (rlon, rlat) = (lon.to_radians(), lat.to_radians());
+    [rlat.cos() * rlon.cos(), rlat.cos() * rlon.sin(), rlat.sin()]
+}
+
+// Two diamonds east and west of a shared corner-touch vertex T (id 0),
+// both wound anticlockwise (interior on the same side).
+fn corner_touch_fixture() -> (Vec<Vec3>, Vec<(u32, u32)>) {
+    let id_xyz = vec![
+        lonlat_xyz(0.0, 0.0),   // 0: T, the corner-touch vertex
+        lonlat_xyz(5.0, 5.0),   // 1: east diamond, north corner
+        lonlat_xyz(10.0, 0.0),  // 2: east diamond, east corner
+        lonlat_xyz(5.0, -5.0),  // 3: east diamond, south corner
+        lonlat_xyz(-5.0, 5.0),  // 4: west diamond, north corner
+        lonlat_xyz(-10.0, 0.0), // 5: west diamond, west corner
+        lonlat_xyz(-5.0, -5.0), // 6: west diamond, south corner
+    ];
+    let edges = vec![
+        (0, 3),
+        (3, 2),
+        (2, 1),
+        (1, 0), // east: T -> S -> E -> N -> T
+        (0, 4),
+        (4, 5),
+        (5, 6),
+        (6, 0), // west: T -> N -> W -> S -> T
+    ];
+    (id_xyz, edges)
+}
+
+// chain_rings on every LCG-shuffled permutation of `edges` (plus the
+// reverse-sorted order) must equal its output on the canonical order.
+fn assert_permutation_invariant(edges: &[(u32, u32)], id_xyz: &[Vec3]) {
+    let baseline = chain_rings(edges, id_xyz);
+    assert!(!baseline.is_empty());
+    // deterministic Fisher-Yates via an LCG (no rand dependency).
+    let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
+    let mut rng = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (state >> 33) as usize
+    };
+    let mut shuffled = edges.to_vec();
+    for _ in 0..200 {
+        for i in (1..shuffled.len()).rev() {
+            let j = rng() % (i + 1);
+            shuffled.swap(i, j);
+        }
+        assert_eq!(chain_rings(&shuffled, id_xyz), baseline);
+    }
+    shuffled.sort_unstable();
+    shuffled.reverse();
+    assert_eq!(chain_rings(&shuffled, id_xyz), baseline);
+}
+
+#[test]
+fn chain_rings_is_order_independent() {
+    // issue #155 phase 3: chain_rings output is a pure function of the
+    // edge *set* -- every permutation of the survivor slice yields the
+    // identical ring list (this is the invariant, not one lucky order).
+    // Three shapes: the real cover's survivors (a simple 16-cycle --
+    // pins seed/rotation order), the corner-touch fixture (a branching
+    // vertex -- pins the rotational pairing itself), and a net > 1
+    // duplicate-edge set (pins the canonical-index tie-break at
+    // identical azimuths).
+    let cover: Vec<u64> = (0..16u64)
+        .map(|n| crate::morton::nested2mort(n, 1))
+        .collect();
+    let (edges, id_xyz) = survivor_edges(&cover, 1);
+    assert_permutation_invariant(&edges, &id_xyz);
+
+    let (id_xyz, edges) = corner_touch_fixture();
+    assert_permutation_invariant(&edges, &id_xyz);
+
+    let mut dup = edges.clone();
+    dup.extend_from_slice(&edges[..4]); // east diamond twice (net = 2)
+    assert_permutation_invariant(&dup, &id_xyz);
+    let rings = chain_rings(&dup, &id_xyz);
+    assert_eq!(rings.len(), 3, "duplicated diamond must chain twice");
+    assert_eq!(rings[0], rings[1]); // the two east copies are identical
+}
+
+#[test]
+fn corner_touch_pairs_into_simple_rings() {
+    // issue #155 ruling: at a non-manifold corner-touch vertex the
+    // rotational pairing pinches the boundary into simple rings touching
+    // at a point (GeoJSON-valid) -- never one self-intersecting
+    // figure-eight.
+    let (id_xyz, edges) = corner_touch_fixture();
+    let rings = chain_rings(&edges, &id_xyz);
+    assert_eq!(
+        rings.len(),
+        2,
+        "pinch must yield two rings, not a figure-eight"
+    );
+    // exact pairing: each ring stays inside its own diamond, T once each.
+    assert_eq!(rings[0], vec![id_xyz[0], id_xyz[3], id_xyz[2], id_xyz[1]]);
+    assert_eq!(rings[1], vec![id_xyz[0], id_xyz[4], id_xyz[5], id_xyz[6]]);
+}
+
+// ── issue #147 phase 1: the stitcher orientation contract ──────────────
+
+#[test]
+fn cell_boundary_emission_orientation_is_uniform() {
+    // Phase 1 of issue #147: the classifier's orientation contract rests
+    // on every cell boundary being emitted with a fixed handedness.  The
+    // HEALPix boundary functions put the cell interior on the LEFT at
+    // step == 1 (CCW, positive spherical signed area) and on the RIGHT at
+    // step > 1 (CW, negative) — uniformly over every base cell and order,
+    // with the loop's fan area matching the exact cell area.
+    for order in 0u8..=5 {
+        let n: u64 = 1 << (2 * order);
+        let exact = std::f64::consts::PI / (3.0 * 4f64.powi(order as i32));
+        for step in [1u32, 2, 3, 4, 8] {
+            for base in 0u64..12 {
+                for nest in [base * n, base * n + n / 2, base * n + n - 1] {
+                    let a = spherical_signed_area(&cell_boundary_loop(order, nest, step));
+                    assert_eq!(
+                        a > 0.0,
+                        step == 1,
+                        "order {order} step {step} nest {nest}: area {a}"
+                    );
+                    assert!(
+                        (a.abs() - exact).abs() < 0.35 * exact,
+                        "order {order} step {step} nest {nest}: |{a}| vs {exact}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Covers used by the orientation audit: `(name, nested cells, order)`.
+/// Includes exact-hemisphere and over-hemisphere covers (the audit drives
+/// `boundary_rings_xyz` directly, below any guard) and the PR #179 review
+/// sweep's two exemplar covers.
+fn orientation_audit_covers() -> Vec<(&'static str, Vec<u64>, u8)> {
+    let cells = |bases: &[u64], order: u8| -> Vec<u64> {
+        let n = 1u64 << (2 * order);
+        bases.iter().flat_map(|&b| b * n..(b + 1) * n).collect()
+    };
+    let mut world: Vec<u64> = (0..192).collect();
+    world.remove(100);
+    vec![
+        ("base 0-3", cells(&[0, 1, 2, 3], 1), 1),
+        ("hemisphere 0-5", cells(&[0, 1, 2, 3, 4, 5], 1), 1),
+        ("over-hemisphere 0-6", cells(&[0, 1, 2, 3, 4, 5, 6], 1), 1),
+        ("exemplar 4/6/7/10", cells(&[4, 6, 7, 10], 1), 1),
+        ("exemplar 1/2/7", cells(&[1, 2, 7], 1), 1),
+        ("scattered", vec![16, 24, 25, 28, 40, 43], 1),
+        ("world minus one order-2 cell", world, 2),
+    ]
+}
+
+#[test]
+fn chained_rings_carry_cover_on_left() {
+    // Phase 1 of issue #147 — the orientation contract, end to end: after
+    // one per-call calibration (reverse every ring iff the emission
+    // handedness is CW, read off one cell's own loop), every chained ring
+    // carries the covered region on its LEFT.  The property is local
+    // (each surviving directed edge bounds exactly one covered cell, on
+    // the emission side; chaining preserves edge direction), so it holds
+    // at any cover scale — verified here on exact-hemisphere,
+    // over-hemisphere and world-minus-cell covers by displacing each edge
+    // midpoint a quarter edge-length to the left (must land covered) and
+    // right (must land uncovered).
+    for (name, nested, order) in orientation_audit_covers() {
+        for step in [1u32, 3] {
+            let covered: std::collections::HashSet<u64> = nested
+                .iter()
+                .map(|&c| crate::morton::nested2mort(c, order))
+                .collect();
+            let cover: Vec<u64> = covered.iter().copied().collect();
+            let mut rings = boundary_rings_xyz(&cover, step);
+            let ccw = spherical_signed_area(&cell_boundary_loop(order, nested[0], step)) > 0.0;
+            if !ccw {
+                for r in rings.iter_mut() {
+                    r.reverse();
+                }
+            }
+            assert!(!rings.is_empty(), "{name}: no rings");
+            for ring in &rings {
+                let n = ring.len();
+                for i in 0..n {
+                    let (a, b) = (ring[i], ring[(i + 1) % n]);
+                    let t = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+                    let elen = (t[0] * t[0] + t[1] * t[1] + t[2] * t[2]).sqrt();
+                    let m = crate::sphere::normalize(&[a[0] + b[0], a[1] + b[1], a[2] + b[2]]);
+                    let left = crate::sphere::normalize(&cross(&m, &t));
+                    for (s, want) in [(1.0, true), (-1.0, false)] {
+                        let p = crate::sphere::normalize(&[
+                            m[0] + s * 0.25 * elen * left[0],
+                            m[1] + s * 0.25 * elen * left[1],
+                            m[2] + s * 0.25 * elen * left[2],
+                        ]);
+                        let (lon, lat) = xyz_to_lonlat(&p);
+                        let w = crate::geo2mort::geo2mort_scalar(lat, lon, order);
+                        assert_eq!(
+                            covered.contains(&w),
+                            want,
+                            "{name} step {step}: probe side {s} at lon {lon} lat {lat}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn pole_cap_stitches_to_one_ring_with_pole_vertex() {
+    // one segment running +180 -> -180 around the pole; the local rule
+    // (end on -180 with no start below) wraps -90 with no pole parameter.
+    let segs = vec![vec![
+        (180.0, -80.0),
+        (90.0, -80.0),
+        (0.0, -80.0),
+        (-90.0, -80.0),
+        (-180.0, -80.0),
+    ]];
+    let rings = stitch_segments(segs).unwrap();
+    assert_eq!(rings.len(), 1);
+    assert!(rings[0].iter().any(|p| (p.1 + 90.0).abs() < 1e-9)); // pole vertex
+}

--- a/src_rust/src/dissolve/tests.rs
+++ b/src_rust/src/dissolve/tests.rs
@@ -287,6 +287,158 @@ fn north_pole_wrap_picks_nearest_start() {
     assert_point_sampled(&cover, &got, 4);
 }
 
+// ── issue #147 phase 4: the regenerated PR #179 review-sweep corpus ────────
+
+#[test]
+fn sweep_corpus_order1_combos_dissolve_point_sampled() {
+    // The PR #179 review sweep's coarse family, regenerated: every
+    // 1-to-5-base-cell mask at order 1 (1585 covers).  Under the old
+    // classifier 249 of them deterministically failed the PR #111 guards
+    // and 79 reached the stitcher assert; the winding-free classifier must
+    // dissolve every one, each emitted region point-sampled against the
+    // source cover (issue #147 plan delta).  The first 60 masks also run at
+    // step 3, mirroring the sweep's step slice.
+    let mut count = 0u32;
+    for mask in 1u16..(1 << 12) {
+        if mask.count_ones() > 5 {
+            continue;
+        }
+        let bases: Vec<u64> = (0..12).filter(|&b| mask >> b & 1 == 1).collect();
+        let cover = base_cells_cover(&bases, 1);
+        let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("mask {mask:#014b} failed: {e}"));
+        assert_point_sampled(&cover, &got, 3);
+        if count < 60 {
+            let got3 = dissolve(&cover, 3)
+                .unwrap_or_else(|e| panic!("mask {mask:#014b} step 3 failed: {e}"));
+            assert_point_sampled(&cover, &got3, 3);
+        }
+        count += 1;
+    }
+    assert_eq!(count, 1585);
+}
+
+#[test]
+fn sweep_corpus_fine_order_families_dissolve() {
+    // The sweep's realistic families, regenerated: contiguous nested runs
+    // at orders 2-5 (300 per order) plus 300 scattered order-3 sets,
+    // deterministically seeded.  Every cover dissolves; its own cell
+    // centres must all fall inside the emit, and a global order-1 lattice
+    // point-samples membership (the chord-band exemption applies near the
+    // boundary).
+    let mut state: u64 = 0x2545_f491_4f6c_dd1d;
+    let mut rng = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        state >> 33
+    };
+    let mut covers: Vec<(u8, Vec<u64>)> = Vec::new();
+    for order in 2u8..=5 {
+        let ncell = 12u64 << (2 * order);
+        for _ in 0..300 {
+            let len = 4 + rng() % 37;
+            let start = rng() % (ncell - len);
+            let cover: Vec<u64> = (start..start + len)
+                .map(|c| crate::morton::nested2mort(c, order))
+                .collect();
+            covers.push((order, cover));
+        }
+    }
+    for _ in 0..300 {
+        let cover: Vec<u64> = (0..8)
+            .map(|_| crate::morton::nested2mort(rng() % 768, 3))
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        covers.push((3, cover));
+    }
+    for (order, cover) in covers {
+        let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("order {order} cover failed: {e}"));
+        let covered: std::collections::HashSet<u64> = cover.iter().copied().collect();
+        let band = 4.0 / f64::from(1u32 << order);
+        // every cover cell's own centre is inside the emit.
+        for &w in &cover {
+            let (nest, _) = mort2nested(w);
+            let (mut lon, lat) = crate::geo2mort::pix2ang_scalar(order, nest);
+            if lon > 180.0 {
+                lon -= 360.0;
+            }
+            if (lon.abs() - 180.0).abs() < 1e-9 {
+                lon = 180.0 - 1e-4;
+            }
+            if !emitted_contains(&got, lon, lat) {
+                assert!(
+                    planar_distance_to_rings(&got, lon, lat) < band,
+                    "own centre of {w} at lon {lon} lat {lat} outside emit"
+                );
+            }
+        }
+        // a global order-1 lattice must classify by exact membership.
+        for pix in 0..48u64 {
+            let (mut lon, lat) = crate::geo2mort::pix2ang_scalar(1, pix);
+            if lon > 180.0 {
+                lon -= 360.0;
+            }
+            let w = crate::geo2mort::geo2mort_scalar(lat, lon, order);
+            if emitted_contains(&got, lon, lat) != covered.contains(&w) {
+                assert!(
+                    planar_distance_to_rings(&got, lon, lat) < band,
+                    "order {order}: lattice pix {pix} misclassified"
+                );
+            }
+        }
+    }
+}
+
+/// A jagged polar cap of the `n` northernmost order-4 cells.
+fn polar_cap_cells(n: usize) -> Vec<u64> {
+    let mut by_lat: Vec<(f64, u64)> = (0..3072u64)
+        .map(|nest| {
+            let (_, lat) = crate::geo2mort::pix2ang_scalar(4, nest);
+            (lat, nest)
+        })
+        .collect();
+    by_lat.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap().then(a.1.cmp(&b.1)));
+    by_lat[..n]
+        .iter()
+        .map(|&(_, nest)| crate::morton::nested2mort(nest, 4))
+        .collect()
+}
+
+#[test]
+fn polar_caps_straddling_hemisphere_dissolve() {
+    // Polar caps just under / at / just over a hemisphere (issue #147):
+    // 1475 / 1536 / 1597 of 3072 order-4 cells = 96% / 100% / 104% of 2π
+    // sr.  The 96% cap dissolved correctly before PR #111's 2% margin
+    // rejected it — regression-pinned as working again — and the exact- and
+    // over-hemisphere caps flip from raising to correct outlines.
+    for n in [1475usize, 1536, 1597] {
+        let cover = polar_cap_cells(n);
+        let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("cap of {n} cells failed: {e}"));
+        assert!(!got.shells.is_empty(), "cap of {n} cells: no shells");
+        assert_point_sampled(&cover, &got, 4);
+    }
+}
+
+#[test]
+fn both_polar_caps_multipart_dissolves() {
+    // A multipart hemisphere-straddling cover: both polar caps (|centre
+    // lat| > 60 at order 3).  The two boundary circles' net longitude
+    // windings cancel — the case the old global pole selection could not
+    // stitch (each cap must wrap its own pole).
+    let cover: Vec<u64> = (0..768u64)
+        .filter(|&nest| {
+            let (_, lat) = crate::geo2mort::pix2ang_scalar(3, nest);
+            lat.abs() > 60.0
+        })
+        .map(|nest| crate::morton::nested2mort(nest, 3))
+        .collect();
+    let got = dissolve(&cover, 1).unwrap();
+    assert_eq!(got.shells.len(), 2, "two caps, two shells");
+    assert!(got.holes.is_empty());
+    assert_point_sampled(&cover, &got, 3);
+}
+
 #[test]
 fn stitch_missing_partner_errs_curated() {
     // Issue #181: the stitching path's defensive failure states surface

--- a/src_rust/src/dissolve/tests.rs
+++ b/src_rust/src/dissolve/tests.rs
@@ -291,18 +291,18 @@ fn north_pole_wrap_picks_nearest_start() {
 
 #[test]
 fn sweep_corpus_order1_combos_dissolve_point_sampled() {
-    // The PR #179 review sweep's coarse family, regenerated: every
-    // 1-to-5-base-cell mask at order 1 (1585 covers).  Under the old
-    // classifier 249 of them deterministically failed the PR #111 guards
-    // and 79 reached the stitcher assert; the winding-free classifier must
+    // The PR #179 review sweep's coarse family, regenerated and extended:
+    // every non-empty base-cell mask at order 1 — all 4095, a superset of
+    // the sweep's 1-to-5-cell family (1585) whose 6-to-12-cell masks are
+    // the hemisphere+ regime this issue exists for.  Under the old
+    // classifier 194 of the sweep masks deterministically failed the PR
+    // #111 guards and 79 reached the stitcher assert (and every mask past
+    // 5 cells was area-guard-rejected); the winding-free classifier must
     // dissolve every one, each emitted region point-sampled against the
-    // source cover (issue #147 plan delta).  The first 60 masks also run at
-    // step 3, mirroring the sweep's step slice.
+    // source cover (issue #147 plan delta).  The first 60 masks also run
+    // at step 3, mirroring the sweep's step slice.
     let mut count = 0u32;
     for mask in 1u16..(1 << 12) {
-        if mask.count_ones() > 5 {
-            continue;
-        }
         let bases: Vec<u64> = (0..12).filter(|&b| mask >> b & 1 == 1).collect();
         let cover = base_cells_cover(&bases, 1);
         let got = dissolve(&cover, 1).unwrap_or_else(|e| panic!("mask {mask:#014b} failed: {e}"));
@@ -314,7 +314,7 @@ fn sweep_corpus_order1_combos_dissolve_point_sampled() {
         }
         count += 1;
     }
-    assert_eq!(count, 1585);
+    assert_eq!(count, 4095);
 }
 
 #[test]
@@ -418,6 +418,21 @@ fn polar_caps_straddling_hemisphere_dissolve() {
         assert!(!got.shells.is_empty(), "cap of {n} cells: no shells");
         assert_point_sampled(&cover, &got, 4);
     }
+}
+
+#[test]
+fn mixed_order_hemisphere_moc_dissolves() {
+    // A mixed-order hemisphere+ MOC (review fold, issue #147): base cells
+    // 0-5 at order 1 plus base cell 6 as its sixteen order-2 children
+    // (7.33 sr).  Exercises the path where the per-call orientation
+    // calibration reads morton[0]'s own order while the boundary is built
+    // at the densified finest order — emission handedness is
+    // order-uniform, so the calibration must still hold.
+    let mut cover = base_cells_cover(&[0, 1, 2, 3, 4, 5], 1);
+    cover.extend((6 * 16..7 * 16).map(|c| crate::morton::nested2mort(c, 2)));
+    let got = dissolve(&cover, 1).unwrap();
+    assert!(!got.shells.is_empty());
+    assert_point_sampled(&cover, &got, 3);
 }
 
 #[test]


### PR DESCRIPTION
Closes #147. Closes #181 (the stitcher-error commit, per the [plan-delta comment](https://github.com/espg/mortie/issues/147#issuecomment-5230469706)). Refs #108, #111, #138, #146, #155 / PR #179.

Replaces `dissolve`'s mod-4π anchor-fan classifier with a winding-free classifier: hemisphere+ covers now dissolve to point-sampled-correct outlines instead of raising. Built on the #138/#146 instruments (`ring_set_validity`, `point_in_ring_robust`) and PR #179's deterministic chaining.

## Phases

- [x] **Phase 1 — orientation audit** (79ce0bf). Verdict below.
- [x] **#181 — stitcher `assert!` → curated `ValueError`** (491f424): both stitcher assertions became curated `Err`s (the old assert already surfaced as a `ValueError` via `rust_dissolve`'s catch_unwind shim, but with raw assert text plus a panic trace on stderr); the Python oracle's `RuntimeError`s became matching `ValueError`s. Phase 2's local pole rule then made the unbalanced-no-pole state structurally unreachable — the fixture cover (base cells {1,2,7}) now *dissolves* — so #181's surviving contract is: every remaining defensive stitch state (non-convergence, missing partner after a pole seam) is a curated `ValueError`, pinned by `stitch_missing_partner_errs_curated` on both engines.
- [x] **Phase 2 — the winding-free classifier, Rust** (96eeba7 + 3cfb4e6): see Approach.
- [x] **Phase 3 — Python oracle mirror** (eef306e): `_dissolved_rings_py` implements the same classifier (calibration via `_emission_is_ccw`, gate via `mortie.ring_is_simple`, planar classification, frame rule, local pole stitching), same fixtures, differential-tested at corpus scale.
- [x] **Phase 4 — fixtures, goldens, sweep, round-trip** (fe15b43 + 3cfb4e6): all PR #111 fail-loud fixtures flip to working; polar caps at 96%/100%/104% of 2π (the 96% cap regression-pinned as working again); equatorial band; world-minus-hole (frame shell); whole-sphere; multipart both-polar-caps; the two sweep exemplars as named fixtures; the **regenerated sweep corpus** (below); spherely goldens; round-trip attempt (below).
- [x] **Phase 5 — divergence report** (below). Benches: informational only — **no dissolve benches exist** in `src_rust/benches/` or `benchmarks/`, so CodSpeed has nothing to say about this PR beyond its non-gating status (espg ruling 2026-08-09).

## Phase-1 verdict: cover-on-the-left holds, up to one per-call calibration

Pinned by `cell_boundary_emission_orientation_is_uniform` / `chained_rings_carry_cover_on_left` (Rust) and their Python mirrors in `mortie/tests/test_dissolve_hemisphere.py`:

- The HEALPix boundary functions emit every cell loop with a fixed handedness — interior on the **left** at `step == 1` (CCW, positive spherical fan area) and on the **right** at `step > 1` — uniformly over all 12 base cells, orders 0–5, steps {1,2,3,4,8} (the previously-informal comment in `classify_and_split` — "boundary point order differs between step==1 and step>1" — measured and pinned).
- Each surviving directed edge bounds exactly one covered cell on the emission side; chaining preserves edge direction; so **one per-call reversal** (iff one cell's own loop reads CW) puts the covered region on every ring's left — a *local* fact, valid at any cover scale. Verified end-to-end by displaced-midpoint probes (left of every ring edge covered, right uncovered) on exact-hemisphere, over-hemisphere, world-minus-cell and the sweep exemplar covers, both step regimes, both engines.

Phase 2 consumes the **contract, not the per-ring probe fallback**; the probe survives as `debug_assert_cover_on_left`, the debug-build residue of the retired PR #111 guards (see below).

## Approach

With covered-on-left established per ring:

1. **Validity gate** — `ring_set_validity`'s `crossing` half: a self-crossing boundary ring keeps the curated fail-loud `ValueError`. **Deviation from the issue's letter:** `identity_conflict` is *not* gated — a repeated snapped coordinate at non-adjacent positions is the *working representation* of a corner-touch pinch resolved into touching simple rings (the #155 ruling), and gating it would regress the pinned `test_dissolve_corner_touch_yields_simple_rings`. Flagged under Questions for review.
2. **Classification is planar, not spherical nesting parity.** The issue sketched O(R²) sphere-side nesting parity via `point_in_ring_robust`; that sketch is ill-defined on the sphere — for an annulus, the shell's representative point lies in the *left region* of the covered-on-left hole ring, so left-side parity counts misclassify the shell (there is no absolute "inside" on a sphere without a reference point). The plane has one: after the antimeridian cut/stitch, a planar ring with the covered region on its left is an exterior iff its shoelace is positive. Equivalent to planar nesting parity, O(R·V), and decided exactly where the output lives (GeoJSON planar rings). Flagged under Questions for review.
3. **Frame rule** — Σ shoelace over the emitted rings is the covered region's planar area when its boundary is complete, and that minus the whole map when the covered region encloses the frame (world-minus-hole, whole-sphere): separated by sign; negative Σ prepends the explicit `[-180,180]×[-90,90]` shell.
4. **Local pole stitching** — the global net-winding `pole` parameter is gone: covered-on-left means the covered seam interval always runs upward from a cut end on +180 and downward on −180, so an unmatched end wraps the pole on its side, unconditionally; one ring may wrap both poles. This is what unlocks multipart hemisphere-straddling covers (both-polar-caps; sweep exemplar {1,2,7}) — and it fixes a **latent live bug**: the old `want_min` arm picked the *minimum*-latitude start after a north-pole wrap, fusing a north cap with any other seam-crossing part into one invalid ring (reproduced on main with a cap+box cover, `north_pole_wrap_picks_nearest_start` pins the fix).
5. **Retired guards** — `HEMISPHERE_MARGIN` and the Σ-vs-exact-area wrap cross-check are deleted; their debug-assertion residue is (a) `debug_assert_cover_on_left` (the orientation fact the guards actually protected, checked by exact membership probes) and (b) the planar-area budget assert in `classify_and_split` (emitted Σ + frame ∈ (0, whole map]). A Σ-fan-area debug check was tried and abandoned: the fan's wraps are anchor-dependent and **not** clean 4π multiples (PR #179 measured 4.0899 vs 0.7901 sr fans for one ring), so no area identity survives at hemisphere+ scale.
6. **Pole-vertex planar expansion** (`ring_to_planar`) — fixes a **pre-existing silent defect**: a boundary vertex at a pole was emitted as the single planar point `atan2(0,0) = (0, ±90)`, slicing planar area off any cover whose boundary passes *through* a pole — on main, base cells {0,1} at order 1 mis-classify 49/144 near-pole probe points today. A pole vertex now expands to a lat-±90 cap over the wedge of longitudes the passage encloses, chosen by the **empty-bracket rule** (the interval between the arriving and departing meridians containing no other pole-incident meridian; covered side on degree-2 ties), subdivided so no planar step reaches 180°, with exact ±180 seam pairs where the cap crosses the seam.
7. **Seam-edge normalization** (`normalized_lonlat`) — boundary edges lying exactly on the ±180 meridian (base-cell meridians) previously took arbitrary `atan2` signs per vertex, fabricating spurious ±360° cuts; the sign now follows traversal direction (northward ⟹ covered west ⟹ map east, +180).
8. **Pinch splitting** (`split_at_revisits` + `split_planar_at_revisits`) — a chained walk revisiting a vertex (the covered region pinched at a point, e.g. two uncovered cells touching diagonally — the dual of #155's corner-touch) splits into simple rings touching at that point, id-level and again planar-level, so the emit is OGC-simple where the old single walk was shapely-invalid.

No new dependencies; `sphere.rs` untouched (`ring_set_validity` was already `pub`). **Module layout:** `dissolve.rs` was heading past the ~1000-line cap with its tests (1276 lines), so the test module moved to `src_rust/src/dissolve/tests.rs` following the repo's own `sphere.rs` / `sphere/tests.rs` layout — body now 935 lines, tests 736. Flagged under Questions for review.

## The regenerated sweep corpus (phase 4 acceptance)

`sweep_corpus_order1_combos_dissolve_point_sampled` regenerates the [PR #179 review sweep](https://github.com/espg/mortie/pull/179#discussion_r3743052040)'s coarse family and — per the adversarial review's blocking finding — extends it to **all 4095 non-empty order-1 base-cell masks** (the sweep's 1585 one-to-five-cell masks plus the 6-to-12-cell hemisphere+ regime this issue exists for), first 60 also at step 3; every one dissolves with each emitted region point-sampled against exact cover membership at all 768 order-3 cell centres (chord-discretization band exempted near edges). This is a superset of the 249 previously-guard-refused covers *and* the 79 stitcher-panic covers: under the old classifier the sweep family contains 194 deterministic wrap-guard rejections + 79 stitcher failures at step 1 (measured below), and everything past 5 cells was area-guard-rejected wholesale; **all now dissolve, none regress**. `sweep_corpus_fine_order_families_dissolve` regenerates the order-2–5 runs (300/order) + 300 scattered order-3 sets; `mixed_order_hemisphere_moc_dissolves` covers a mixed-order hemisphere+ MOC (review fold). The two exemplars ({4,6,7,10} and {1,2,7} at order 1) are named pinned fixtures on both engines. Whole-corpus runtime ~4.4 s in a debug `cargo test`.

## Phase-5 divergence report

Old = `d4e62d0` (origin/main) built in an isolated venv; new = this head. Corpus = the regenerated sweep (1585 masks + 60 step-3 + 1500 fine-order covers) + the dissolve test-corpus covers (box/holed/antimeridian/caps/annulus/band/moc/hemisphere family) = **3158 runs**. Verdicts compared per cover; `ok` outputs compared byte-wise, then geometrically (shapely symmetric difference, `make_valid`-guarded).

| old → new | runs | note |
|---|---|---|
| reject (Σ-wrap guard) → outline | 195 | 194 order-1 masks + the equatorial band |
| stitcher failure (`unbalanced…no pole`) → outline | 80 | 79 order-1 masks + both-polar-caps |
| reject (area guard) → outline | 3 | over-hemisphere cap, world-minus-one, whole-sphere |
| ok → identical outline | 936 | byte-identical |
| ok → equivalent outline, representation only | 229 | symdiff < 1e-9 (canonical starts, split representation) |
| ok → different outline | 1594 | **all differences are corrections** — see below |
| ok → reject (regressions) | **0** | |
| still failing under new | **0** | |

The 1594 geometric differences decompose as: **802 covers whose old emit shapely was invalid** (plus 121 more whose old emit could not even be nested into polygons — `_nest_and_build` raised); and covers with pointwise-wrong old emits from the pre-existing pole-vertex/seam-edge defects — including **silent complement inversions the old guards never caught**: e.g. base cells {1,2,3,6,7} (5.24 sr, sub-hemisphere, mask 206) passed every old guard and emitted its exact complement (all 12 base-cell probes inverted); now correct and pinned (`test_sweep_silent_inversion_mask_206_now_correct`). Every new outline in the corpus is point-sampled correct. Two caveats from the adversarial review: the "old" verdicts here are single samples of an engine that is still per-call nondeterministic on some coarse masks even post-#179 (e.g. mask 613 gave 7 valid + 1 reject over 8 in-process calls on `d4e62d0`; this build is 8/8 deterministic), so old-side counts are representative rather than exact; and new-emit *shapely validity* holds on 3149/3158 of this corpus but degrades on the extended full-mask family — see Questions for review (3).

## spherely goldens (phase 4)

`test_dissolve_outline_areas_match_spherely` (importorskip, live s2 like the existing cap test): Σ shell − Σ hole areas of the emit, frame counting 4π, vs the cover's exact area — pinned per fixture to 1e-6 against 2026-08-09 goldens, e.g. hemisphere 6.283185307 (frac 1.000000), exemplar {1,2,7} 3.141592654 (frac 1.000000), world-minus-one 12.500225 (frac 0.999944), and the order-1 chord-deficit cases at frac 0.976–1.032 — an inverted classification would sit near (4π−A)/A, far outside the 5% band asserted. Scope note from the review: this s2 route does not generalise to arbitrary corpus covers (s2 refuses or mis-measures ~3% of full-mask emits whose planar seam/pole doubling has no clean spherical reading), so the goldens stay a named-fixture oracle, not a corpus-wide one.

## Round-trip (open question 2) — attempted, honest result

`cover → to_geometry → from_geometry(..., order, normalize=False)`:

- **Exact set equality cannot hold**: coverage is an *overlap* cover, so boundary-touching neighbour cells always join the round trip (measured: `missing 0, extra ≈ boundary ring` on every hole-free case).
- The **containment half holds for every hole-free emit with a real boundary, hemisphere+ included**, and is pinned (`test_roundtrip_coverage_contains_cover_normalize_false`). One exception found by the review: the whole-sphere cover's frame-only emit (a spherically degenerate seam-and-poles ring) loses most cells through `from_geometry` — the frame ring is a planar convention with no faithful spherical reading, so the whole-sphere case is excluded from the pinned invariant (review measured 3571/3572 other hole-free emits round-tripping).
- **Emits with holes break under `normalize=False`**: the parity fill reads a CW-wound (RFC 7946) hole ring as selecting its complement, re-filling the hole (world-minus-one comes back with the hole cell; a holed box floods its exterior). Under `normalize=True` holed sub-hemisphere covers round-trip to supersets, but hemisphere+ shells get re-normalized to the wrong side. So no single flag gives a universal invariant; the blocker is the hole-winding convention mismatch between the RFC 7946 emit and the `normalize=False` parity fill — left as a finding, not pinned.

## How tested

Green gate at head: `maturin develop --release`; `cargo test --lib` ×3 (360 passed each — dissolve corpus included, chaining determinism re-exercised); `cargo fmt --check`; `cargo clippy --lib --tests` (0 warnings in dissolve; the 6 pre-existing sites elsewhere untouched); `flake8 mortie --select=E9,F63,F7,F82`; `pytest` (1434 passed, 16 skipped); `numpydoc lint mortie/*.py` clean.

## Questions for review

1. **Identity-conflict gate not applied** (deviation from the issue's phase-2 item 1): gating `ring_set_validity.identity_conflict` would reject the corner-touch covers that dissolve correctly today (touching simple rings *are* the pinch representation per #155). Only the `crossing` half gates. Flagging in case the letter was wanted.
2. **Planar classification instead of spherical O(R²) nesting parity** (deviation from the issue's phase-2 item 3): the spherical sketch has the annulus counterexample above; the planar shoelace form is the equivalent well-defined statement in the output's own space. Happy to add a debug-assertion cross-check against planar point-in-ring nesting if wanted.
3. **Residual shapely-invalidity: parity-correct, self-touching emits on covers whose boundary *touches* the ±180 seam at a point.** The adversarial review sized and diagnosed this properly (my initial "9 of 3158" was an artifact of the original 1–5-cell corpus cap, since removed): over all 4095 order-1 masks, **338 emits at step 1 (715 at step 3) are shapely-invalid**, with smaller rates at finer orders (5.5–8.5% of order-2–4 half-space covers). Mechanism ([review comment](https://github.com/espg/mortie/pull/182#discussion_r3743436698)): `normalized_lonlat` pins an isolated seam-touch vertex onto one side, and a stitcher meridian connector then runs straight *through* that vertex — a self-touch, never a parity error (review: 0 parity failures on every invalid mask probed; `Σ shoelace == shapely.area` to 1e-6 on all 4095 masks; `make_valid` recovers them). Every one of these covers previously **raised or emitted invalid/inverted geometry**, so nothing regresses — but downstream `union`-style consumers can reject self-touching input. Options, one-pass: (a) accept + follow-up issue: the fix is localized (split stitch connectors at seam-lying ring vertices so the pieces touch at a point instead of overlapping through it), but it is another stitcher surgery on top of an already-large PR; (b) require it in this PR. My lean is (a), with the follow-up carrying the review's measured corpus as its acceptance set.
4. **Test-module split**: `dissolve.rs` would have crossed the ~1000-line cap with its tests; moved them to `dissolve/tests.rs` per the existing `sphere/tests.rs` layout (§4 discussion-first caveat — raising here rather than pre-landing, since it is layout-only and mirrors in-repo precedent).
5. The **chord-discretization band** in the point samplers (mismatches allowed only within `4°/2^order` of the emitted boundary) is the honest contract for a chord emit; tightening it means densifying `step` in the fixtures.
6. **Pre-existing, out of scope, surfaced by the review** ([comment](https://github.com/espg/mortie/pull/182#discussion_r3743437768)): corner-touch pinches resolve into shell+hole (interior-disconnected, invalid) at every `step > 1`, on released 0.9.6 exactly as on this branch, both engines — the step>1 azimuthal orderings at the pinch vertex differ from step 1. Candidate follow-up issue (not opened unilaterally); no `step > 1` pinch test exists today.
