### PR TITLE
Example notebook for the toc module (issue #180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ the wider HEALPix ecosystem (`cdshealpix` / `healpy` `(order, nested-pixel)`
 pairs) is covered in
 [docs/healpix_interchange.md](docs/healpix_interchange.md).
 
+### Example notebooks
+
+Runnable walkthroughs live in [examples/](examples/); each opens on Binder from
+the badge in its first cell. Two of them need no downloads at all —
+[morton_set_algebra.ipynb](examples/morton_set_algebra.ipynb) for the MOC
+boolean verbs, and
+[toc_temporal_coverage.ipynb](examples/toc_temporal_coverage.ipynb) for the
+**toc word** (temporal order coverage: encoding, the conservative merge, the
+comparator-free sort, window predicates, and the UTC/GPS boundary).
+
 ## Performance
 
 Mortie's morton core is a Rust extension and the sole runtime path — there is no

--- a/docs/api/toc.md
+++ b/docs/api/toc.md
@@ -11,6 +11,13 @@ the ragged many-cover plurals land in [mortie.batch](batch.md) when the
 interval-set algebra (issue #177) activates. The names stay flat on the
 package (`mortie.time2toc`, ...).
 
+Worked example:
+[examples/toc_temporal_coverage.ipynb](https://github.com/espg/mortie/blob/main/examples/toc_temporal_coverage.ipynb)
+walks the type end-to-end on synthetic data — encoding, the conservative
+merge, sorting without a comparator, the window predicates at a quantum
+boundary, and the UTC/GPS round-trip
+([run it on Binder](https://mybinder.org/v2/gh/espg/mortie/HEAD?labpath=examples%2Ftoc_temporal_coverage.ipynb)).
+
 ::: mortie.toc
     options:
       members:

--- a/docs/api/toc.md
+++ b/docs/api/toc.md
@@ -12,7 +12,7 @@ interval-set algebra (issue #177) activates. The names stay flat on the
 package (`mortie.time2toc`, ...).
 
 Worked example:
-[examples/toc_temporal_coverage.ipynb](https://github.com/espg/mortie/blob/main/examples/toc_temporal_coverage.ipynb)
+[examples/toc_temporal_coverage.ipynb](https://github.com/espg/mortie/blob/HEAD/examples/toc_temporal_coverage.ipynb)
 walks the type end-to-end on synthetic data — encoding, the conservative
 merge, sorting without a comparator, the window predicates at a quantum
 boundary, and the UTC/GPS round-trip

--- a/examples/toc_temporal_coverage.ipynb
+++ b/examples/toc_temporal_coverage.ipynb
@@ -1,0 +1,899 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "758979c2",
+   "metadata": {},
+   "source": [
+    "# toc words: temporal order coverage\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/espg/mortie/HEAD?labpath=examples%2Ftoc_temporal_coverage.ipynb)\n",
+    "\n",
+    "`mortie` packs a HEALPix cell into one unsigned 64-bit *morton index* that\n",
+    "self-encodes its order and ancestry. The **toc word** — *temporal order\n",
+    "coverage* — is the same trick for time: one `uint64` holding **either** an\n",
+    "exact nanosecond timestamp **or** a quantized, conservative time range, a\n",
+    "tagged union that sorts as a plain unsigned integer and is closed under a\n",
+    "merge that is exactly associative, commutative and idempotent.\n",
+    "\n",
+    "```\n",
+    "[start: 32 bits, 2^31 ns units][flag: 1 bit][low: 31 bits]\n",
+    "\n",
+    "  timestamp (flag = 1): the word is t_ns with the flag bit spliced in at 31\n",
+    "  range     (flag = 0): low is the end code, 31 bits at 2^32 ns;\n",
+    "                        envelope [start * 2^31, end * 2^32) is half-open\n",
+    "```\n",
+    "\n",
+    "That is the whole type. Everything below follows from it: encoding\n",
+    "(`time2toc` / `span2toc`), the dual behaviour under merge (`toc_merge` /\n",
+    "`toc_reduce`), sorting with no comparator, window predicates\n",
+    "(`toc_overlaps` / `toc_contains`), and the UTC/GPS boundary\n",
+    "(`from_datetime64` / `from_gps_ns`).\n",
+    "\n",
+    "Layout, epoch, merge results and sort order are **normative** — words persist\n",
+    "on disk — and are pinned by golden fixtures; the decision ledger is\n",
+    "[#175](https://github.com/espg/mortie/issues/175) and the design record is\n",
+    "[englacial/zagg#410](https://github.com/englacial/zagg/issues/410). This is\n",
+    "deliberately **not** an IVOA T-MOC (different epoch, timescale and cell\n",
+    "model). The interval-set algebra over many words is deferred to\n",
+    "[#177](https://github.com/espg/mortie/issues/177).\n",
+    "\n",
+    "All data here is synthetic — nothing is downloaded — so the notebook is\n",
+    "[runnable on Binder](https://mybinder.org/v2/gh/espg/mortie/HEAD?labpath=examples%2Ftoc_temporal_coverage.ipynb) as-is (see `binder/` for the\n",
+    "repo2docker config). Only `numpy`, `matplotlib` and `mortie` are imported.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0c40eb7e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:46.848471Z",
+     "iopub.status.busy": "2026-08-10T10:49:46.848263Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.653608Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.652650Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.9.7'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import functools\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import mortie\n",
+    "from mortie import toc\n",
+    "\n",
+    "mortie.__version__\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50b2f710",
+   "metadata": {},
+   "source": [
+    "## The internal timescale\n",
+    "\n",
+    "Internal times are `uint64` **nanoseconds since 1850-01-01T00:00:00** on a\n",
+    "continuous, leap-free, GPS-aligned scale. Leap seconds exist in exactly one\n",
+    "place — the UTC boundary (`from_datetime64` / `to_datetime64`); GPS interop\n",
+    "(`from_gps_ns` / `to_gps_ns`) is a pure constant offset.\n",
+    "\n",
+    "Three constants set the type's resolution and reach:\n",
+    "\n",
+    "| constant | value | meaning |\n",
+    "|---|---|---|\n",
+    "| `Q_START_NS` | 2^31 ns | a range's start code **floors** to this grid |\n",
+    "| `Q_END_NS`   | 2^32 ns | a range's end code **ceils** to this grid |\n",
+    "| `TOC_MAX_NS` | 2^63 − 2^32 ns | exclusive ceiling on internal times |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "56ad4e76",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.657512Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.657145Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.664910Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.663142Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q_START_NS =         2,147,483,648 ns  (2.147 s)\n",
+      "Q_END_NS   =         4,294,967,296 ns  (4.295 s)\n",
+      "TOC_MAX_NS = 9,223,372,032,559,808,512 ns  (ceiling 2142-04-11T23:46:54.559808511)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'Q_START_NS = {toc.Q_START_NS:>21,} ns  ({toc.Q_START_NS / 1e9:.3f} s)')\n",
+    "print(f'Q_END_NS   = {toc.Q_END_NS:>21,} ns  ({toc.Q_END_NS / 1e9:.3f} s)')\n",
+    "print(f'TOC_MAX_NS = {toc.TOC_MAX_NS:>21,} ns  (ceiling '\n",
+    "      f'{mortie.to_datetime64(toc.TOC_MAX_NS - 1)})')\n",
+    "\n",
+    "# The epoch identity: 1850-01-01T00:00:00 UTC is internal ns 0, exactly.\n",
+    "assert mortie.from_datetime64('1850-01-01T00:00:00') == 0\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "996a0ac1",
+   "metadata": {},
+   "source": [
+    "## 1. Encoding instants — `time2toc`\n",
+    "\n",
+    "A timestamp word is the instant itself with a `1` flag bit spliced in at\n",
+    "position 31, so unsigned word order over timestamps *is* nanosecond order.\n",
+    "`toc_is_range` reads the flag back.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "adde0f06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.667718Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.667388Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.677262Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.675894Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2018-01-01T00:00:00.000000000 5,301,590,418,000,000,000 ns   0x932610CAE9813400\n",
+      "2018-01-01T00:00:01.000000000 5,301,590,419,000,000,000 ns   0x932610CBA51BFE00\n",
+      "2018-06-15T12:34:56.789000000 5,315,891,714,789,000,000 ns   0x938BAEB38C70C340\n",
+      "2020-02-29T23:59:59.000000000 5,369,846,417,000,000,000 ns   0x950B0DBB97B06A00\n",
+      "\n",
+      "is_range: [False False False False]\n"
+     ]
+    }
+   ],
+   "source": [
+    "utc = np.array(['2018-01-01T00:00:00', '2018-01-01T00:00:01',\n",
+    "                '2018-06-15T12:34:56.789', '2020-02-29T23:59:59'],\n",
+    "               dtype='datetime64[ns]')\n",
+    "\n",
+    "t_ns = mortie.from_datetime64(utc)        # UTC -> internal ns (leap table)\n",
+    "words = mortie.time2toc(t_ns)             # internal ns -> toc words\n",
+    "\n",
+    "for u, t, w in zip(utc, t_ns, words):\n",
+    "    print(f'{str(u):<27} {int(t):>21,} ns   0x{int(w):016X}')\n",
+    "\n",
+    "print()\n",
+    "print('is_range:', mortie.toc_is_range(words))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72a9e8dc",
+   "metadata": {},
+   "source": [
+    "The first row is one of the type's **golden fixtures** (pinned in the test\n",
+    "suite and in [PR #178](https://github.com/espg/mortie/pull/178)):\n",
+    "2018-01-01T00:00:00 UTC is internal ns 5,301,590,418,000,000,000 — 61,361 days\n",
+    "of 86,400 s plus the 18 s GPS−UTC offset in force since 2017 — encoding to\n",
+    "`0x932610CAE9813400`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "77a28264",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.679416Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.679178Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.684957Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.683650Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "golden fixture holds\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert int(mortie.from_datetime64('2018-01-01T00:00:00')) == 5_301_590_418_000_000_000\n",
+    "assert int(mortie.time2toc(5_301_590_418_000_000_000)) == 0x932610CAE9813400\n",
+    "print('golden fixture holds')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1074f49",
+   "metadata": {},
+   "source": [
+    "### The GPS path\n",
+    "\n",
+    "Mission time usually arrives as GPS seconds, not UTC. ICESat-2 ATL03, for\n",
+    "instance, stores a per-photon `delta_time` in seconds against the granule's\n",
+    "`atlas_sdp_gps_epoch` (itself GPS seconds since 1980-01-06). Both scales are\n",
+    "leap-free and tick together, so the composition is a constant offset and no\n",
+    "leap table is consulted:\n",
+    "\n",
+    "```\n",
+    "gps_ns = epoch_ns + round(delta_time * 1e9)\n",
+    "t_ns   = mortie.from_gps_ns(gps_ns)\n",
+    "```\n",
+    "\n",
+    "Add the epoch in **integer** nanoseconds, not in float seconds: `float64` has\n",
+    "53 bits of mantissa, and GPS-epoch-scale ns need ~61, so\n",
+    "`(epoch + delta) * 1e9` quietly loses hundreds of nanoseconds. The type is\n",
+    "exact to 1 ns — don't spend that on the ingest arithmetic.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c167cb81",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.687115Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.686865Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.701936Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.700615Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delta_time     0.00 s   0x932610CAE9813400   2018-01-01T00:00:00.000000000\n",
+      "delta_time     0.50 s   0x932610CB874E9900   2018-01-01T00:00:00.500000000\n",
+      "delta_time     1.25 s   0x932610CBB402B080   2018-01-01T00:00:01.250000000\n",
+      "delta_time   900.00 s   0x9326126DF5AF5C00   2018-01-01T00:15:00.000000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ICESat-2 flavored: the ATLAS SDP epoch is GPS second 1_198_800_018\n",
+    "# (= 2018-01-01T00:00:00 UTC), with delta_time seconds off it.\n",
+    "atlas_sdp_gps_epoch = 1_198_800_018\n",
+    "delta_time = np.array([0.0, 0.5, 1.25, 900.0])          # seconds\n",
+    "\n",
+    "gps_ns = (atlas_sdp_gps_epoch * 10**9\n",
+    "          + np.round(delta_time * 1e9).astype(np.int64)).astype(np.uint64)\n",
+    "photon_ns = mortie.from_gps_ns(gps_ns)\n",
+    "photon_words = mortie.time2toc(photon_ns)\n",
+    "\n",
+    "for d, w, back in zip(delta_time, photon_words,\n",
+    "                      mortie.to_datetime64(photon_ns)):\n",
+    "    print(f'delta_time {d:>8.2f} s   0x{int(w):016X}   {back}')\n",
+    "\n",
+    "# The GPS leg agrees with the UTC leg at the shared instant.\n",
+    "assert int(photon_ns[0]) == int(mortie.from_datetime64('2018-01-01T00:00:00'))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "851cad93",
+   "metadata": {},
+   "source": [
+    "## 2. The dual type — exact leaves, conservative ranges\n",
+    "\n",
+    "`span2toc` encodes a real closed interval `[start, end]` as a **range** word.\n",
+    "Rounding is outward, with a strictly-greater end ceiling\n",
+    "(`e = (end >> 32) + 1`, uniformly — including when `end` sits exactly on the\n",
+    "2^32 grid), so the decoded envelope always *properly contains* the real\n",
+    "interval. `toc2time` hands back that envelope, with `end_ns` **exclusive**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c7b9b851",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.705473Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.705155Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.713955Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.712725Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "word          0x938BAAE249C5D5B8   is_range=True\n",
+      "real          [5,315,889,618,000,000,000 .. 5,315,889,918,000,000,000]\n",
+      "envelope      [5,315,889,616,488,759,296 .. 5,315,889,921,431,437,312)\n",
+      "slack         start 1.511 s  (< 2.147 s)   end 3.431 s  (<= 4.295 s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "seg_start = int(mortie.from_datetime64('2018-06-15T12:00:00'))\n",
+    "seg_end = int(mortie.from_datetime64('2018-06-15T12:05:00'))\n",
+    "\n",
+    "seg = mortie.span2toc(seg_start, seg_end)\n",
+    "env_start, env_end = mortie.toc2time(seg)\n",
+    "\n",
+    "print(f'word          0x{seg:016X}   is_range={mortie.toc_is_range(seg)}')\n",
+    "print(f'real          [{seg_start:,} .. {seg_end:,}]')\n",
+    "print(f'envelope      [{env_start:,} .. {env_end:,})')\n",
+    "print(f'slack         start {(seg_start - env_start) / 1e9:.3f} s  '\n",
+    "      f'(< {toc.Q_START_NS / 1e9:.3f} s)   '\n",
+    "      f'end {(env_end - seg_end) / 1e9:.3f} s  '\n",
+    "      f'(<= {toc.Q_END_NS / 1e9:.3f} s)')\n",
+    "\n",
+    "assert env_start <= seg_start and env_end > seg_end\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08e8ca97",
+   "metadata": {},
+   "source": [
+    "The bound is absolute, not relative: **at most one 2^31 ns quantum of slack at\n",
+    "the start and one 2^32 ns quantum at the end**, whatever the span's length.\n",
+    "Against a five-minute segment that is a fraction of a percent; against the\n",
+    "day-scale spans that merges produce (below) it is noise.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "047d6b78",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.716436Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.716183Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.933288Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.932026Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKYAAAEOCAYAAACzaR/CAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWtVJREFUeJzt3Xl4Tdf+x/HPySADgiSCSETMap6nUKKmBlWqaqiWKtUBpS2tXy+3RbXa2+mqat1qq1Wqg1JVVfM8q5obxCwhSEIEkfX7I9e+TmM4IbFJ3q/n8Tw5a6+91netc+SsfM/e6ziMMUYAAAAAAADAbeZmdwAAAAAAAADInUhMAQAAAAAAwBYkpgAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2ILEFAAAAAAAAGxBYgoAAAAAAAC2IDEFAAAAAAAAW5CYAgAAAAAAgC1ITAE53Ouvv66wsDC5ubmpdu3akqSCBQvqqaeesjmym1e0aFH16dPH7jAAAAByvdWrV8vhcGjmzJl2h5Jlzpw5I4fDoVGjRuWIfoA7HYkpIAebOXOm/vGPf2jSpElKTU3V+vXr7Q7prnO3J/HuFswzAAB3rs2bN8vhcGjatGl2hwIgB/KwOwAA2ef3339XUFCQWrRo4VR++vRpewLKIseOHbM7BAAAAABAFuCKKSAHi4uLk4+Pj91hAAAAAABwVSSmgBwoJiZGDodDM2bM0P79++VwODL8u/K2qapVq1r7T/1dw4YNValSJaeyzz//XHXq1JGvr6/y58+vli1bunyboLe3twYNGqTFixerVq1a8vX1VZ06dbRx40ZJ0sKFC1WnTh35+PioYsWKmj9/foY2rrbH1OV2V69erfr168vb21ulSpXSp59+6lTvxIkTcjgcevvttzO0W716dbVu3VpS+lVlDodDCQkJmjhxojVvTZs2zZK5+O6771S/fn0VLFhQAQEBioyM1Lx58zLUc6X95ORkDRw4UEWKFFG+fPnUunVrxcTEqHbt2rrvvvuuOk+3Mv+uxuXKc+LqPAMAkFUqV6581bWRw+HQv//9b6teXFyc+vbtq+DgYOXJk0fh4eF66aWXlJyc7NSeK/Wu3IdpwoQJCg8PV758+dShQwfFx8dLksaPH69SpUrJ29tbkZGR2rdvn0vjyWz/kydPVpkyZeTt7a3atWtrxYoV121/5syZqlGjhiSpa9eu1lyNHDkyQ11X2j537pxeffVVlStXTl5eXgoKCtLjjz/u0hXxrpyb2bHu379fHTt2VP78+RUQEKD+/fvr3LlzN4wls+PJTD/79u3Tgw8+6FT3+PHjV92P6lbmE7hjGAA5VqdOnUxYWFiG8gIFCph+/fpZj9977z0jyWzevNmp3o4dO4wk884771hlL7zwgvHy8jLvv/++iY2NNYcPHzZPP/208fb2Nhs3brxhTF5eXqZNmzama9euZu/evSY2Nta0bdvWBAUFmWXLlpnOnTub6OhoExcXZzp06GDy589vTp065dRGkSJFzBNPPJGh3aioKNOlSxeza9cuEx8fbwYPHmwkmVWrVln1jh8/biSZcePGZYitWrVqplWrVtedqyvd7FwsXbrUOBwOM3bsWHPixAmTkJBgli5datq0aWNSU1Mz3X7btm1NoUKFzI8//mgSEhLMqlWrTFRUlKlUqZJp3rx5ls+/q3G5+pzcaJ4BAMhOqamppnXr1sbNzc0sWLDAGGNMQkKCKVOmjClVqpRZunSpSUhIMLNmzTIBAQGmcePG1vu1q/VWrVplJJmOHTua1157zRw/ftxs3brVlCpVykRFRZnx48ebESNGmLi4OLN9+3ZTpkwZExERccPYM9t/ly5dzP/93/+Zo0ePmv3795t7773XBAQEmKSkpOv2s2nTJiPJfPPNNxmOZabt8+fPm0aNGpnixYubWbNmmYSEBLNt2zYTERFhypYtaxITE68Zg6vnZiaeU6dOmbCwMFOpUiWzdu1ac/r0afP111+b7t27G0nm9ddfv+68uBpTZvo5efKkCQ0NNVWqVDHr1683p0+fNtOmTTOPPvpohrq3Mp/AnYTEFJCDuZqYio+PN15eXua5555zqvfCCy8YT09PExcXZ4wxZuvWrcbhcJgRI0Y41UtLSzNVq1Y1UVFRN4zJy8vLBAUFmbNnz1pl27dvN5JMWFiYOXPmjFW+a9cuI8lMnDjRqY1rJaYKFy7sdP758+dNQECA6dWrl1WWVYmpW5mLUaNGGTc3N3Px4sVr1nG1/WXLlhlJZvz48U711qxZYyRdNTF1K/OfmXG7+pwYQ2IKAGCffv36ZfggbsyYMUaSWbFihVPdKVOmOCVoXK13OVnStm1bp3offfSRkWQ6derkVD5x4kQjyezateu6sWe2//vvv9+p3oYNG4wk88UXX1y3H1cSU660PX78eCPJLFq0yKnu4cOHjZeX11XXZ5k9NzPxjB492kgyW7Zscao7atQolxJTrsaUmX5ef/1143A4zNatW53qjh07NkPdW5lP4E7CrXwA5O/vrw4dOujrr7/W+fPnJUmpqamaMmWK2rdvr8KFC0uSfv75Zxlj1LlzZ6fzHQ6HIiMjtWTJEklShw4dnC6Lr1+/vlP9e++9V76+vtbjcuXKyc3NTTVr1lTevHmt8rJly8rDw0N79+51aRxNmzZ1Oj9PnjwqV66cy+dnhqtzcTXVqlVTWlqaunbtqqVLl+rChQs33f6iRYskSe3atXOqV7duXQUFBV21/1uZ/8yO+3Y+JwAAZNZbb72liRMn6umnn9bgwYOt8gULFqho0aJq2LChU/1OnTpZxzNT77I2bdo4Pa5QoYIkqUmTJk7lFStWlKQbvl9mtv+oqCinx5UrV3apH1e40vbs2bMVGBiY4Zb94OBgVaxY8brrp8ye60o8CxYsUHh4uKpUqeJUt0OHDteM42Ziykw/ixYtUnh4eIatNNq3b3/T/QN3Or6VD4AkqU+fPpo+fbpmzpypLl266Oeff1ZsbKyeeOIJq87le9WrVasmSTLpV11aP0u6apLl74oVK+b02N3dXT4+PhnKHQ6H8ubN6/K3CP79fEny8/Nz+R77y2NwhatzkSdPngzntm3bVp988onef/993XvvvfL29lbjxo01ePBga48rV9u/vC/F1ZJQ10pM3cr8Z3bct/qcAACQXWbMmKFhw4YpKipKH3zwgdOx+Ph4FS1aNMM5Pj4+KlCggE6cOJGpepf9/X0xf/781y2/0RroVvvPkyePvLy8suQbm11p+9ixYzpx4oQ8PNL/DL28jri8hrjel/Zk9lxX4omPj1eRIkUy9HW1sluJKTP9xMfHu7yuu5X5BO4kXDEFQJLUvHlzhYeH67PPPpMkffbZZwoJCVHLli2tOoGBgZKkPXv2KDU1VZcuXVJaWprS0tKsN8E8efJo5syZTm+Mq1evdurL4XBcNYZrlbvKlfP9/PzkcDiUlJSU4djhw4dd7svVubiWJ598Ulu3blVsbKymTJmic+fO6f7779eyZcsy1X5AQICk9I1P/+5qZdKtzX9mx32rzykAANlh1apV6tmzp6pXr67p06fL3d3d6bi/v79iY2MznJeSkqLExETr/dDVepdl9Rooq/rPCq6uI0qWLKnU1FSndcTlNcTKlSuz7FxX4gkICLjq/F2t7FZiykw/AQEBLq/rbmU+gTsJiSkAktLfvHv16qXff/9da9as0dy5c/X44487LdTatm0rSZo+fbpdYd6yPHnyKCQkRFu3bnUqX716tXX10ZXy5s1r3d54payai6CgID300EOaMmWKjDFWYsrV9ps1ayZJmjNnjlP5unXrrpmYuhXZ9Rq41jwDAJDV9uzZY21VMGfOHKdbzi9r3ry5jh49qjVr1jiV//DDDzLGqHnz5pmql11uV/+X5+hW36vbtWunmJgYrV279raeey2RkZGKiYnJsC786aefsjSmzPTTrFkz7du3T9u3b3cq//nnn2+6f+BOR2IKgKVXr16SpM6dO+vSpUvW48uqVaumF198Uf/4xz80btw4HThwQOfOndO2bdv09ttv69lnn7Uj7Ex78sknNXv2bM2YMUNnzpzRsmXLNG7cOGs/hytVrlxZa9as0dGjR53Kb2UuXn31VY0YMUJbtmxRcnKy4uLi9NFHH8nhcOjee+/NVPsRERGKiorS8OHDNWvWLCUlJWnNmjV6/fXXM+xNkBWy6zVwrXkGACArXbp0Sffff78uXLigOXPmXPWWc0l65plnVKpUKfXo0UMrVqxQUlKS5syZo0GDBqlhw4Z66KGHMlUvu9yu/kuUKCE/Pz/Nnz9fZ86cuel2+vXrp4iICD300EOaMWOGjh8/roSEBK1du1YDBw7UpEmTsuXca3n66acVEhKibt26acOGDUpMTNS0adO0Y8eOLB1PZvp55plnrLobN25UYmKiZsyYkSGplV1zAtiBxBQAS0hIiFq1aqWDBw+qWbNmKlWqVIY6b731lr744gv9/PPPqly5sgIDA/XII48oPj5eL7/8sg1RZ97QoUPVr18/9e/fX0WLFtU777yj8ePHX/XWu3feeUcFCxZU6dKl5XA4nDaXvNm5GDhwoPLkyaPHHntMhQsXVuXKlbV582bNmzdPjRo1ynT73377rbp3764+ffqoaNGiGjFihD744AM5HA55eXllzaRdITteA9ebZwAAssrFixe1e/duJSYmqmrVqk5f1uJwOPTvf/9bklSgQAGtWLFC9957rx566CH5+/vr6aefVs+ePTVv3jxrTx9X62WX29W/l5eXJk2apPXr16tQoUJyOBwaOXLkTbXz+++/q3///nr99ddVokQJhYeHa+DAgSpXrpy6deuWLedeS6FChbR06VKVLl1a9957r0qWLKmFCxfqX//6V5aOJzP9FCpUSEuWLFHJkiXVpEkTlSxZUgsWLNDo0aOtPrNzTgA7OExmdvsFANw1ChUqpI4dO+o///mP3aEAAADgFvzxxx+qXr26vvzySz366KN2hwNkKa6YAoAcaOHChTp9+rR1ayAAAADuXt9//70cDoeaNGlidyhAlsvea0sBANlu8uTJSk5OVtu2bVWoUCGtWLFCTz31lCpVqqQuXbrYHR4AAAAyYejQoWrQoIEiIiKUmpqqH374QW+//bZ69+6tsLAwu8MDshy38gHAXe7UqVMaOXKkfvnlFx04cECBgYG6//77NWbMGBUuXNju8AAAAJAJ27dv14gRI7Ry5UqdOHFCJUuW1KOPPqphw4Zl+75lgB1ITAEAAAAAAMAW7DEFAAAAAAAAW5CYAgAAAAAAgC24QTUbpKWl6ciRI8qfP78cDofd4QAAgEwyxigpKUnBwcFyc+NzvOzEugkAgLvfraydSExlgyNHjig0NNTuMAAAwC06ePCgQkJC7A4jR2PdBABAznEzaycSU9kgf/78ktKfED8/P5ujAQAAmZWYmKjQ0FDrPR3Zh3UTkPMlJyerV69emjx5snx9fe0OB0A2uJW1E4mpbHD5MnQ/Pz8WWAAA3MW4tSz7sW4Ccj4PDw95enrKz8+PxBSQw93M2olNEwAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2ILEFAAAAAAAAGxBYgoAAAAAAAC2IDEFAAAAAAAAW3jYHUBOdnLKV7ro42N3GAAA5EgBvXvZHQKyEOsmIOc6d/GipPT/5+c8PW2OBjfC+ytuN66YAgAAAAAAgC1ITAEAAAAAAMAWJKYAAAAAAABgCxJTAAAAAAAAsAWJKQAAAAAAANiCxBQAAAAAAABsQWIKAAAAAAAAtiAxBQAAAAAAAFuQmAIAAAAAAIAtSEwBAAAAAADAFiSmAAAAAAAAYAsSUwAAAAAAALAFiSkAAAAAAADYgsQUAAAAAAAAbEFiCgAAAAAAALYgMQUAAAAAAABbkJgCAAAAAACALUhMAQAAAAAAwBYkpgAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2OKuTUy98cYb+vTTT+0OAwAA4I43e/ZsDRw40O4wAAAAMvCwO4CbtWbNGoWEhNgdBgAAwB1vz549WrBggd1hAAAAZHDXXjEFAAAAAACAu1umr5javn27PvvsMx06dEilSpVS3759VbJkSev4iBEjVKZMGfn6+mr+/Pm6dOmSHnnkETVv3lySNHPmTM2dO1cTJ050avfjjz/WoUOHNGrUKJf6uZply5Zp6tSpOnnypKpWraqnn35ahQoVyhCbh4eHFi1apEuXLunxxx9X48aNMzVGAAAAV8THx+vjjz/W1q1bFRQUpE6dOqlJkybW8RkzZmj9+vXq3LmzvvnmGx0/flxNmjTRE088IYfDoejoaL3wwgv69NNPVbhwYeu85cuX64MPPtDXX38tT0/PG/ZzNfv27dOECRMUExOjkJAQ9evXT+XLl88Q2wMPPKAZM2YoNjZWrVu3Vs+ePTM1RgAAgOvJ1BVT8+fPV0REhPLkyaP27dvr3LlzqlatmrZt22bVWbFihQYOHKivvvpKjRo1UuHChdWyZUutWLFCklShQgV98sknTucYYzRmzBj5+/u73M/fzZgxQ82bN1eBAgXUunVrzZkzR/Xr19e5c+ecYhswYIA++eQTNWzYUH5+foqMjHS6tP1m+gYAAPi7w4cPq0aNGtq1a5eioqJUvHhxdezYUZMnT7bq7Nq1SxMmTFC/fv1UsWJF1alTR0OHDtUbb7whSSpVqpTWrVunb7/91qntjz/+WCkpKfL09HSpn7/bs2ePatSooZiYGLVt21YnTpxQzZo1tWXLlgyx9ezZU+XLl1fNmjX13HPP6Z///GemxggAAHA9Ll8xZYxRv379NHbsWPXt21eS1K1bN509e1avvfaapk+fbtUtXbq0fvjhBzkcDknSxo0b9c0336hRo0aqUKGCatWqpa+//lpjxoyRJC1dulSHDx9W165dM9XPZWlpaRoyZIhefvlla7HUpUsXlSxZUuPHj9cLL7xg1fX19dW8efOUJ08eSVJKSopeeeUVrVmz5qb6lqTz58/r/Pnz1uPExERXpxUAAORQw4cPV0REhL788kurLCQkRM8//7x69epllaWmpmru3LkKCgqSJJ09e1ZfffWVXnnlFbm5ualr1676+uuv9cwzz0iSkpOTNXPmTH322WeZ6udK//jHP1S9enUr4dWzZ0+dPHlSr7zyin7++WerXlJSklasWKEqVapIkkJDQ9W7d289++yzCggIuKm+WTcBAIAruZyY2r17t/bt26fvvvtOv/32m4wxMsZoz549unjxolPdiIgIKyklpSeqjhw5Yj3u3r273n//fY0ePVoOh0Nff/21mjdvrmLFimnXrl0u93PZwYMHdfDgQT344INWma+vr9q0aaOVK1c61W3VqpWVlJKkBx54QJ988okuXLigffv2ZbpvKf0bAq/89BAAAGDevHkqWrSoHnroIWtNkZCQoLi4OMXFxVmJqPLly1s/S1dfN73zzjvau3evSpUqpZkzZ8rd3V3t27fPVD9XWrlyZYZv6evUqZOGDBniVBYeHm4lpaT0dVNycrI2b96s5s2b31TfrJsAAMCVXE5MnT59WpLUsWNHFS1a1OmYr6+v02MvLy+nxw6HQ2lpadbjrl276sUXX9SKFStUt25dfffdd3rvvfcy3c9l8fHxkqSCBQs6lRcqVEgxMTFOZQUKFHB6XLBgQaWlpen06dM31bckvfzyyxo8eLD1ODExUaGhodesDwAAcr7Tp0+rU6dOuu+++5zKn3vuOeXLl896fKN1U40aNXTPPfdo6tSp+r//+z99/fXX6tSpk7y9vTPVz5Xi4+Ovum5KSEjQpUuX5O7uLinjusnb21teXl7W2utm+mbdBAAAruRyYiosLEySFBQUpA4dOtxSp0WLFlVkZKS++uorHT9+XOfPn1fHjh1vup/w8HBJ6fslXLlJeXR0dIZNy/fu3ev0eM+ePfL19VVQUJC1CMzsGL28vDIsKgEAQO4WFhYmNze3W143SelXTU2ZMkX9+vXTb7/9pnnz5t1SP+Hh4dqzZ49TWXR0tEJCQqyklCTt37/fKVF1+PBhnT9/3lpf3UzfrJsAAMCVXN78vGjRooqKitI//vEPxcbGWuX79+/XrFmzMt1xjx49NGPGDE2ePFkPPPCA9anazfRTqFAhtW7dWm+99ZYuXLggSVq7dq1+/fVXde/e3anu3LlztXnzZknpezS89957euSRR7JljAAAIPfq06ePJk2apHXr1lllZ86cuamNwbt3765du3bpxRdfVJEiRdS0adNb6qdbt2767LPPdPToUUnSiRMn9NFHH2VYN506dcrpm5THjBmjsmXLqlatWlk+RgAAkDtl6lv5Pv/8cwUHB6tcuXKKjIxUjRo11KpVK/n4+GS6444dOyolJUWzZ89Wjx49brmfjz76SPv371e5cuXUtGlTNWvWTM8//7xatmzpVK9+/fpq166dmjVrpnLlyuns2bMaNWpUtowRAADkXoMHD1bfvn3VpEkT1a9fX40bN1aFChWsrQMyIywsTI0aNdIXX3yhbt26yc3tf0u4m+ln0KBBqlWrlipVqqTmzZurYsWKKlWqlF555RWneuHh4frkk09Uv359ValSRVOnTtWnn35qXUGVlWMEAAC5k8MYYzJ70l9//aXo6GgFBwerUqVK8vD43x2BK1euVMGCBXXPPfdYZVu2bNG5c+dUr149p3aWLl2qkydPqm3btk5tuNLPmjVr5OPjo6pVq1plqampWr9+vU6dOqXKlStn2K/gvvvuU+3atTV8+HD9+eefSk1NVYMGDeTp6Zmpvm8kMTFRBQoU0L5/j1d+EloAAGSLgN5X/9a3rHD5vTwhIUF+fn631FZcXJw2b96sfPnyqWrVqk57L+3evVvHjh1TkyZNrLIjR45o06ZNioqKcmpn+/bt2r17t+rXr59hL8wb9bNnzx7t379fkZGRGdqMiYlRSEiI05pKkkaNGqWff/5Zy5Yt07Zt2xQXF6e6detm2JvqRn3fCOsmIOc7d/Ginp7zsz6Kaiufq/zthTtLdr6/Iue6lbXTTSWm7laXE1Njx47N1n5YYAEAkP3ulsTU3epyYmr16tXZ2g/rJiDnIzF1dyExhZtxK2unTN3KBwAAAAAAAGQV1+9PywFee+21q15+DgAAAGcPP/yw0y2GAAAA2SFXJaYaNmxodwgAAAB3hXLlyqlcuXJ2hwEAAHI4buUDAAAAAACALUhMAQAAAAAAwBYkpgAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2ILEFAAAAAAAAGxBYgoAAAAAAAC2IDEFAAAAAAAAW5CYAgAAAAAAgC1ITAEAAAAAAMAWJKYAAAAAAABgCxJTAAAAAAAAsAWJKQAAAAAAANiCxBQAAAAAAABsQWIKAAAAAAAAtiAxBQAAAAAAAFuQmAIAAAAAAIAtSEwBAAAAAADAFh52B5CT+T/aQ35+fnaHAQAAcMdj3QTkXMnJydKcn+X/aA/5+vraHQ6AOwxXTAEAAAAAAMAWJKYAAAAAAABgCxJTAAAAAAAAsAWJKQAAAAAAANiCxBQAAAAAAABsQWIKAAAAAAAAtiAxBQAAAAAAAFuQmAIAAAAAAIAtSEwBAAAAAADAFiSmAAAAAAAAYAsSUwAAAAAAALAFiSkAAAAAAADYgsQUAAAAAAAAbEFiCgAAAAAAALYgMQUAAAAAAABbkJgCAAAAAACALUhMAQAAAAAAwBYkpgAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2ILEFAAAAAAAAGxBYgoAAAAAAAC2IDEFAAAAAAAAW5CYAgAAAAAAgC1ITAEAAAAAAMAWJKYAAAAAAABgCxJTAAAAAAAAsAWJKQAAAAAAANiCxBQAAAAAAABsQWIKAAAAAAAAtiAxBQAAAAAAAFuQmAIAAAAAAIAtSEwBAAAAAADAFiSmAAAAAAAAYAsSUwAAAAAAALAFiSkAAAAAAADYgsQUAAAAAAAAbEFiCgAAAAAAALYgMQUAAAAAAABbkJgCAAAAAACALUhMAQAAAAAAwBYkpgAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2ILEFAAAAAAAAGxBYgoAAAAAAAC2IDEFAAAAAAAAW5CYAgAAAAAAgC1ITAEAAAAAAMAWJKYAAAAAAABgCxJTAAAAAAAAsAWJKQAAAAAAANiCxBQAAAAAAABsQWIKAAAAAAAAtiAxBQAAAAAAAFt42B1ATldy2By7QwAA4K4XMzbK7hCQzSqPmCc3L1+7wwCQDdwuXVBlu4MAcMfiiikAAAAAAADYgsQUAAAAAAAAbEFiCgAAAAAAALYgMQUAAAAAAABbkJgCAAAAAACALUhMAQAAAAAAwBYkpgAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2ILEFAAAAAAAAGxBYgoAAAAAAAC2IDEFAAAAAAAAW5CYAgAAAAAAgC1ITAEAAAAAAMAWJKYAAAAAAABgCxJTAAAAAAAAsAWJKQAAAAAAANiCxBQAAAAAAABsQWIKAAAAAAAAtvCwOwAAALKKt7tDhXzc5OawOxJktZSUlGxp193dXR4eHnI4eNEAAADYgcQUACBHKOvvqf61Cyq/t7skkgw5zb59+7KtbV9fXxUrVkx58uTJtj4AAABwdSSmXPDDDz8of/78atGihd2hAACuwtvdof61CyqsSCF5+PpJXP2S44QX9cvyNo0xunDhgo4fP659+/apbNmycnNjl4NbtX79ev3xxx964okn7A4FAADcBUhMueDLL79USEgIiSkAuEMV8nFTfm93efj6yeHpZXc4yAbe3t7Z0q6Pj488PT21f/9+XbhwIdv6yU2WL1+uSZMmkZgCAAAu4WNBAMBdL31PKQdXSuGmcJUUAACAfXLEFVMbN27Uhg0b1LlzZ82ePVtHjx7VwIED5eXlpXPnzmnOnDk6dOiQSpUqpdatWzvtITFv3jxt2rRJkhQQEKB69eqpatWqdg0FAIBbtnTBPFWqWkMBhYNuy3nZYcXiBSpTvoKKFCtudyg5zokTJzRp0iQ9/fTTWrRokaKjo9W+fXuVLVtWxhgtXLhQW7duVVBQkJo3b66goP+9Hnbs2KGffvpJkpQ3b17dc889ioyMZPN4AABw03LER4QrV67UsGHDVK9ePc2fP18nT56UMUZ//fWXKlasqI8++kh79+7V2LFjVb16dR0/ftw699y5czp9+rROnz6tlStXqnHjxnrjjTdsHA0AALfmi48/1P59e27bednhq0kTFL1zh91h5EjHjh3Tyy+/rKZNm2rixImKjY3VxYsXde7cObVo0ULPPfec/vrrL82YMUP33HOPli1bZp178eJFa920c+dO9enTR1FRUTLG2DgiAABwN8sRV0xJ0smTJzV16lS1atXKKnvsscfUtWtXp0RT27ZtNXLkSI0fP16S1KFDB3Xo0ME63r9/fzVu3Fh9+vRR4cKFXer7/PnzOn/+vPU4MTHxFkcDALhVbjOmZku7aZ27ZUu7wO3WqlUrpzXSK6+8ovPnz+vPP/+Uu7u7JGncuHF66qmntG3bNklS1apVna4sT0xMVPny5TVr1iw98MADLvXLugkAAFwpxySm/P39nZJShw4d0qpVq1SvXj29/fbbMsbIGCOHw6FVq1Y5nbt161atXbtWJ06cUFpami5duqQdO3a4nJh644039M9//jNLxwMAuPsdO3JIf27aIB9fX9VrdK88/3sr+dIF81SxcjUdOhCjE3Gxqt+4qfL7FbDOiz16WH9u2qDEhNMqWbqsatZtIEmK2fOXdm77U8Ehoapas45TXzu3/alD+/epeu16Lsdxo/NudTyH9sfo4P59atCkmdXG6mWLFRxSQiXCS90wtivt2rVLmzdvVlhYmOrXr2+Vz5kzRzVq1FB0dLROnjyp5s2bK3/+/NbxgwcPas2aNcqbN6+aN2/udDt/btetm3OSdfr06apUqZLeffdda910+PBhbd++XQkJCSpQIP01Ghsbq99//11Hjx5Vamqq8ufPrz/++MPlxBTrJgAAcKUccSufpAxJpMOHD0tK/1TuxIkTio+P18mTJ1WpUiV16dLFqvfKK68oIiJC8+fPV2xsrE6fPi03NzedPHnS5b5ffvllJSQkWP8OHjyYNYMCANy15s/5Sf26ddTCeXP01aSP1TWqmZLPnpGUfsvc808+qskfva9vp3ymRx9oqYsXL0qSfp31gx5qEaFfZn6nLRvX69D+GEnSd19/rsc7ttHCX3/Wy8/11auDn7H6mvb5p3qqe0f99vNMPfPYwzpy6IBLcVzvvKwYTx4vL708oK8uXrggKf02sJcH9JWXt9cN27zSd19/roiICP3444/q3r27evXqZR0bN26c2rVrp7feekvvvvuuateuraSkpPTzvvtOLVq00MyZM/Xee++pdu3aOnMmY/u51d/XTkeOHFFaWprTusnHx0dDhw5VWlqaJGn27NkqXbq0vv76ax04cECnT59WWloa6yYAAHDTcswVU38XGBgoSXrooYcUGRl51Tpnz57Vm2++qd9//13NmqV/mpuUlKQ333wzU315eXnJy4uvJwcApDPG6I1XX1Kv/gOVN18+SdK3Uz7Tkvm/qk2HhyRJzdu0Va/+AyVJD7dqrJ1bt6hy9Zp64/9e1AeTv1GNOv+7KigtLU3vjv6HPvtujsrfU0VnkhLVrklt7dr+p8pWqKR/vz1aU2b+pvAy5XTqZLyiGtW4YRyt2ne85nlZNZ4qNWrpnirVtHj+XLWIekBLfv9VFSpVVZFixV1q88qxL1+2TNWqVVNiYqLKli2rP/74Q9WqVZMktWnTRqNGjZIkde7cWZ999pkGDBigZ599VkOHDrWuoJowYYJmz56trl273tLzm1MFBgaqZs2aeu21165Z5/XXX9eQIUOcrnj6/fffM9UP6yYAAHClHJuYKl26tKpUqaJx48bp3nvvtfZKuHjxonbu3KkqVaro7NmzSktLsy5Nl6RJkybZFTIAIIeIPx6nxITT2rN7p1VWoVJVFQoItB5XqlbT+jmoWLASE07rRFz6JtRXJqUk6URcrBwOh8rfU0WSlC+/nypVra6YPdEq5B+oPHm8FF6mnCSpkH+A9fP14jgRF3vN87JqPJLUvnM3zfruG7WIekCzvp2q9p27utzmlWO/nITy8/NT7dq1tWvXLqssIiLCqt+kSRPt2LFDsbGxOnXqlLU3kiTVqFHD5dv0c6MHH3xQn376qQYOHKiAgACrfOPGjapZM/35PXPmjNO6acOGDdq0aZPTcwAAAJAZOTYxJUlfffWVWrdurbp166pVq1Y6deqUFi9erMGDB6tKlSoKCgrS/fffr86dO6tbt27au3evFi9eLE9PT7tDBwDcxQr6B8jhcKj304OsvZT+zuFwOBcYo0IBgbp48YKOHj6oYsVDrUOF/AOUkpKiE3GxCgwqorS0NO3ft1eFg4qokH+AziYl6fSpkypYyF8XL6Sff6M4Ll64cM3zsmo8khTZKkpj/zFUu3ds1ZZN6zVuwmSX27xy7MeOHVPRokWVlpamv/76S8WKFbPqREdHWz/v3r1bxYoVU2BgoBwOh4YNG6YyZcpcs338z6hRo7R+/XpVrVpVnTt3lqenp1asWKFy5crp888/lyT16tVLI0eO1KFDh3Tp0iV9/fXXKlKkiL2BAwCAu1qOSEzVqlVLffv2zVBetWpV7d69Wz/++KOio6NVvXp1vfTSSwoPD7fqzJw5U9OmTVN0dLQaN26sDz/8UO+//77Klfvfp8adOnVy+nQQAIDr8fDwUJ9nh+ipHh3VqdtjKuSffvVJs1ZR1s/XOu/xpwaoX7eO6tS1p/IXKGBtfv5Q98f17ONd1LZjF61fvUL58/upep36cnNzU/vOXfXsY13Uun1HrV6+2NrT6UZxXOu8rBqPJOXx8tJ9bdrpxf691eL+9vLy9s5Um5558uih7o8rKipKjz76qJYsWaICBQqoUaNGVp33339fp0+fVlJSkqZOnapNmzbJw8NDw4cPV8uWLdW3b1/rFv8OHTpYP+dWhQsX1tChQ5Xvv7dQXubn56fly5fr119/1fr165UvXz699957qlu3rlXnxRdfVPXq1bVq1SrlzZtXK1as0OrVq52usKpTx3ljfgAAgOtxGPPfjzSRZRITE1WgQAElJCSo6phldocDADle8fzuGtksSEHBIXJ4pH/rmtuMqdnSV1rnbjeu9F+rli7S6uWLlXDqlCSp78AXFBxSQp9//IGatmijkqXLSpKmTv5EdRs2VpnyFSVJi3/7RetWrdDZM0mqWbeB2nfuKmOM5vz4rbZv2axixUPVqftj8vXNK0m6dOmSfvjmSx3Yt1eNm7fU9i2bFNmqrXUl0rXiuNF5WTWev3Zu19f/+Vjdn3hKZSvc41KbX02aoPqNm6pM+YoyxujPJXO0fv16hYWFqW/fvsqbN33sTZs21eDBg7Vz507Fx8frscce0z33/K+P+fPn6/fff1d8fLwk6dVXX1VYWJhTDCkpKdq3b5/Cw8Pl/d/E2ZXv5X5+fi4/58i8y3MdOuhbuXn52h0OgGzgdumCKu+arGnTpsnXl//nQE50K2snElPZgMQUANxeV0tMIWepGlLwquVNmzbVyJEj1bRp05tum8SUvUhMATkfiSkg57uVtZNbNsUEAACQ7aKiopz2mwIAAMDdJUfsMQUAAHKnF1980e4QAAAAcAu4YgoAAAAAAAC2IDEFAAAAAAAAW5CYAgAAAAAAgC1ITAEAAAAAAMAWJKYAALjD7dm9U8YYu8O4KXdz7AAAAMh+JKYAALjDPXJ/U104f/6qx1xN/ETv2pHVYbnkerEDAAAAHnYHAABAdmj/7xXZ0u6sZxtlS7s3a/igpzRl5m/yzJPnuvUebtVYa6OPycODt34AAADcObhiCgCAbHDowH4lJ5/V+ZQUHTl0wCpPTU3VoQP7lXLunFP9mD1/6a+d23Xk0AGlpaW53M/o9z6Wh6enJOmvndslSadPndTpUyetOkcPH5Qk7dm9Q3/t3G61f61YLreTePq04k8cV+zRw0o8fTpDvBcvXLil2AEAAAA+NgUAIBuMGPKMgooFa/2qFarbqLFGv/ex5vz4rd55/VXlzZdfp0/G6+kXXlbXx/tKkl4f9rxOnYzXuXPJcnO4afyX36pk6bI37OeR+5tq+dYYeXl766EWjfTgI49qzYolOhUfr2dfHK4effpr8kfv69KlS3r5ufS+pv68UAt+nX3NWB5q0UjtO3fThjUr1KPP03I4pO1b/tDr/xovKT3R9cTD7fTr6j9vKXYAAACAxBQAANnEw8NT89b8KTc3Nx07ckgT3hmrf33ypfLmy6+EU6c0uO+jatuxi/L7FdB/ZvysxNOndeJ4rH75cYa+/GS8/vHme5nus07DCI0c94H2Re/W4x3bqEef/npl9Nv67uvP9e28ZfLw8LhhLJJUq15DKxGVcOqUPv7Xm0pOPitf37yaNWOaWrfvJM//XqmVVbEDAAAg9yExBQBANmnd7kG5uaXfNf/npg06fSperw0dZB0PDCqi+BPH5eObVy893Vtrli9WYFBRXbhwXiVKlr6pPlu16yhJCi9TTikpKbp44UKG/aeuF8vlxFSbBzpZxwoUKqTaDSK04JfZavfQI/r5+2n61ydfSkq/HTCrYgcAAEDuQ2IKAIBsksfb2/rZx9dXIWHhmvbL4gz1Vi9brGNHDmvxH3vk6empX2f9oB+++fKm+rxyc3OHw2Ht+eRwOFyK5TKvK2KXpPadu2rKpx8pOCRU+fL7qWzFSpKk9auWZ1nsAAAAyH3Y/BwAgNugVv1GOpOYqHEjX9Gfmzbor53btfevXZIk37x5dSLumDatW63li+br43ffzPL+/QODtHj+XP21c7tq1G1wzViupVHT+xQT/Zc++eBttX+4q1V+O2IHAABAzsUVUwAAZIPg0DD5+Phaj318fPWfGT/r0w/e1th/DNW55LPy9vHV1J8XqGrNOnrk8Sf1wdjXVDS4uHr2e1Z/blxvnVu6XAXrlsC/u/JY6XIVnI6VKlveOvbiiNGa8ul4JSUkaOrPC68Zy9XakdKvxHrk8T6aN/tH3f9AZ6v8VmIHAAAAHMYYY3cQOU1iYqIKFCighIQEVR2zzO5wACDHK57fXSObBSkoOEQOjzw3PgF3naohBbOt7ZSUFO3bt0/h4eHy/u8tjFe+l/v5+WVb3/jfXIcO+lZuXr43PgHAXcft0gVV3jVZ06ZNk68v/8+BnOhW1k58hAkAAAAAAABbkJgCAAAAAACALUhMAQAAAAAAwBZsfp7NYsZG2R0CAOR41h5BRf2sPYIA3F22/rMV+3kBOVRycrIeeWSy3WEAuENxxRQAIMfg+zxwM9LS0uwOAQAAINfiiikAwF3P09NTDodDx48fV+HCheVwOOwOCXcBY4wuXLig48ePy83NTXny8I2OAAAAtxuJKQDAXc/d3V0hISE6dOiQYmJi7A4HdxlfX1+VKFFCbm5cSA4AAHC7kZgCAOQI+fLlU9myZXXx4kW7Q8FdxN3dXR4eHlxlBwAAYBMSUwCAHMPd3V3u7u52hwEAAADARVyzDgAAAAAAAFtwxVQ2uPytUImJiTZHAgAAbsbl93C+6TH7sW4Ccr7k5GRdvHhRiYmJSk1NtTscANngVtZOJKayQVJSkiQpNDTU5kgAAMCtSEpKUoECBewOI0eLj4+XxLoJyA2KFStmdwgAsll8fHym104kprJBcHCwDh48KGOMSpQooYMHD8rPz8/usO4aiYmJCg0NZd4yiXm7OczbzWHebg7zdnPsmDdjjJKSkhQcHHxb+svN/P39JUkHDhzIVUnA3Pz7ILeOPbeOW8q9Y8+t45Zy79hz67glKSEhQSVKlLDe1zODxFQ2cHNzU0hIiHUpm5+fX657UWYF5u3mMG83h3m7OczbzWHebs7tnrfclCSxk5tb+panBQoUyJX/L3Lz74PcOvbcOm4p9449t45byr1jz63jlv73vp6pc7IhDgAAAAAAAOCGSEwBAAAAAADAFiSmspGXl5dGjBghLy8vu0O5qzBvN4d5uznM281h3m4O83ZzmLecLbc+v7l13FLuHXtuHbeUe8eeW8ct5d6x59ZxS7c2dofhe5ABAAAAAABgA66YAgAAAAAAgC1ITAEAAAAAAMAWJKYAAAAAAABgCw+7A8ip0tLStH37dl26dEmVK1eWu7u73SHdUY4dO6bo6OgM5RERERnKTpw4oX379qlEiRIqUqTI7QjvjrNt2zYlJiaqQYMGVz1ujNH27duVmpp6zdebK3VymuvN27p163T+/HmnstDQUIWFhTmV5bZ5S05O1u7du1W4cGEVL178qnV4vWV0o3lbv369UlJSnMpCQkJUsmRJp7Ir561SpUry8MjZb9MXL17Url275OXlpfDw8KuO15U5yW3zlhucOXNGe/fulYeHh0qVKiVvb2+7Q7ptLl26pB07dsjHx0elS5e2O5zb7o8//lBSUpIaNWokh8NhdzjZ7vLvQV9fX4WFheXI98ukpCTt2rVLhQsXzrDOyslSUlK0a9cu+fv7KyQkJFe8nq+UlpamVatWKV++fKpWrZrd4dw2iYmJio6OVqlSpVSwYEG7w7ltDhw4oLi4OAUHBys4ODjzDRhkuW3btpkyZcqYokWLmuLFi5sSJUqYdevW2R3WHWXChAnG29vbNGrUyOlfamqqU72hQ4caLy8vc8899xgvLy/z9NNPm7S0NJuivv2mTJliatWqZQoVKmTy5s171To7duww5cqVM0WKFDEhISEmJCTErFmzJtN1chJX5q148eKmbNmyTq+/CRMmONXJTfN29OhR89hjj5kCBQqY6tWrm0KFCplGjRqZffv2OdXj9ebs2LFjplevXta8+fv7mwYNGpg9e/Y41QsLCzNlypRxer39+9//dqqza9cuU6FCBRMUFGRCQ0NN8eLFzcqVK2/ncG6rkSNHmqCgIFOtWjUTEhJiihcvbmbPnu1Ux5U5yW3zlhuMGjXK5M2b11SpUsWUKVPG+Pv7mylTptgd1m0xc+ZMU6xYMRMeHm6qVKliIiMjTVxcnN1h3TaLFi0ynp6eRpI5d+6c3eFkq5SUFDNs2DATEBBgKlWqZIKDg02ZMmXM0qVL7Q4tS3388cfG19fXVKhQwfj6+pq2bduas2fP2h1Wtjp58qR56qmnTMGCBU3VqlVNYGCgqVmzptm2bZvdod1Wo0ePNm5ubqZWrVp2h3JbpKammkGDBhkfHx9To0YNU6JECTNixAi7w8p2+/fvN7Vr1zb+/v6mVq1aJn/+/KZp06bmxIkTmWqHxFQWu3TpkqlUqZJ56KGHrATKY489ZsLCwsz58+dtju7OMWHCBFO6dOnr1pk2bZrx8vIya9euNcYY8+eff5q8efOaiRMn3o4Q7wjDhw83a9asMRMmTLhqgiUtLc1UrVrVdOjQwVy6dMkYY8wTTzxhQkNDTUpKist1cpobzZsx6YmpyZMnX7ON3DZvq1evNl988YW5ePGiMcaYpKQk06RJE9O4cWOrDq+3jNatW2cmT55szduZM2dMZGSkadCggVO9sLAw8+mnn163rRo1aph27dpZCfp+/fqZ4ODgHPnHWWpqqnnzzTfNmTNnjDHpr5uXXnrJ+Pr6Or1OXJmT3DRvucHGjRuNJPPjjz9aZaNGjTIeHh4mMTHRvsBugxUrVhh3d3endc7SpUvNli1bbIzq9jl+/LgJCwszgwcPzhWJqePHj5s33njDel1funTJ9O/f3wQEBJjk5GSbo8samzZtMg6Hw3z77bfGGGNiY2NNiRIlzPPPP29zZNlr27ZtZsKECdbffikpKaZ9+/amYsWKNkd2+6xcudKULFnSdOvWLdckpgYNGmSKFStmdu7caYxJ/z/99w+9c6KHH37YVK9e3fq9FR8fb0qUKGEGDhyYqXZITGWxlStXGklm8+bNVll0dLSRZObOnWtjZHeWCRMmmPDwcLNlyxazbdu2qybtWrZsaTp06OBU1qNHD1OvXr3bFeYd41oJlrVr1xpJZv369VZZTEyMkWRdeeBKnZzqRompcePGmXXr1pljx45lOJ6b5+2ySZMmGQ8PDyvBxOvNNZ9//rlxc3OzklXGpCemxo4de83X2+U/xlevXm2VHTx40DgcDqc/0HOyX375xUiy5seVOWHecp558+Y5vQ6MSb+KRpLZv3+/jZFlvxYtWpjIyEi7w7BNVFSUGTVqlPnmm29yRWLqajZv3mwkmQ0bNtgdSpYYMGCAqVChglPZqFGjTKFChay1RW4xc+ZMI8nEx8fbHUq2O3XqlAkPDzcLFy40zzzzTK5ITB07dsx4enqaTz75xO5QbrtmzZqZxx9/3KmsVatWplu3bplqh83Ps9imTZvk4eGhqlWrWmWlS5eWv7+/Nm3aZGNkd56YmBh17txZ999/vwIDAzV+/Hin45s2bVKtWrWcyurWravNmzfLGHM7Q71jbdq0SW5ubqpRo4ZVFhYWpqCgIOv15kqd3Oq1115Tnz59VKpUKTVt2lT79u2zjjFv6ftwhYeHy80t/a2C15tr1q1bp7CwsAz7HI0ePVp9+vRR6dKl1aRJE+3du9c6dnluatasaZWFhISoWLFiOXre9u3bp2XLlmnatGl68cUXNWDAAGsvQVfmJLfOW04WGRmpVq1aqXfv3po7d65+/PFHDRkyRM8995xKlChhd3jZJjU1VUuXLlW7du105swZbdiwQUeOHLE7rNvm3XffVUJCgoYNG2Z3KLZat26d3N3dM+w/eLe61lr+1KlT2r9/v01R2WPdunXy9/dXoUKF7A4l2/Xp00cPPfSQmjVrZncot83SpUt18eJFtWvXTgcPHtTmzZuVlJRkd1i3xfDhwzV37lx9+OGHWrBggcaMGaMtW7boxRdfzFQ77A6axU6ePCl/f/8Mm9sFBATo5MmTNkV156lYsaK2b9+uChUqSJKmTJminj17qlSpUmrTpo2k9LkMCAhwOi8gIEDnz59XcnKy8ubNe9vjvtOcPHlSBQsWtBIHl135enOlTm702muvqWfPnvLw8NCJEyf0wAMPqEuXLlq9erXc3Nxy/bwtWLBAkyZN0uTJk60yXm83tnjxYk2cOFGffPKJU/mIESPUo0cPeXp6Kj4+Xg8++KA6d+6stWvXyt3dXSdPnpSfn588PT2dzsvp8zZ79mxNmzZNMTExCgwMVPfu3a1jrsxJbp23u0laWppWrlx53TqFChVSpUqVJEkeHh569tln1b9/f7344otKSUmRr6+vevbseTvCzVLR0dE6duzYdevUqlVLPj4+io+P1/nz57Vt2zaVK1dORYsWVXR0tOrWratvvvlGhQsXvk1R37pz585pw4YN161TtGhRlSlTRpK0YcMGvfHGG1ZS5m62bds2nTp16rp1GjZsmOE9Ukr/wPbll1/WM888I39//+wK8bY6efKk0wdVkqy1/cmTJxUeHm5HWLfd+vXr9c4772jMmDE5fgP0CRMmaO/evZo6dardodxWR44ckZeXl15//XX99NNP8vf3V3R0tF566SWNHDnS7vCyVd26ddW2bVuNGDFCJUuW1N69e/Xkk0/qnnvuyVQ7JKaymKenZ4ZvXpLS36Tz5MljQ0R3pnvvvdfp8aOPPqqJEydq2rRpVmLqanN57tw5SWIu/8uV1xuvyavr3bu39XNgYKBGjx6tZs2aac+ePSpbtmyunrd169apY8eOeuGFF/Too49a5bzerm/Dhg3q0KGDBg4cqF69ejkdu/JxQECAxowZo8aNG2v37t2qWLFirp23AQMGaMCAATLG6LXXXlNkZKR2796t4OBgXm85xPnz5294FUz9+vX19ttvS5KWL1+uBx54QLNnz9b9998vKf1qmqZNm2rnzp0KCQnJ9pizyvfff6/Zs2dft87UqVNVokQJK7n622+/adOmTSpSpIhOnjypRo0aafDgwZoyZcrtCDlLHD9+/IbPebt27TR06FBJ6WvARx55RAcPHtTBgwe1a9cuSdLKlStVtmxZhYaGZnvMWWXy5MlavXr1devMnz9fPj4+TmVHjx5Vy5YtVadOHY0bNy47Q7ytWMtLO3bsUFRUlHr06KFBgwbZHU62Onz4sIYMGaL3339fa9eulZT+2j5z5oyWL1+uKlWqqECBAjZHmT08PT11/vx5nTt3Tvv375e7u7sWLFhg/b+OioqyO8Rs061bN506dUoHDhxQvnz5FB8fr8aNGyspKUkff/yxy+2QmMpiYWFhSkxMVFJSkvLnzy9JunDhgo4fP56jL0HPCkWKFNHhw4etx2FhYU6PpfRfeEWLFs3w6XhuFRYWpuTkZJ0+fdr6OtLU1FTFxcVZrzdX6kDW7UOHDx9W2bJlc+28rV+/Xi1bttSTTz6psWPHOh3j9XZtGzduVIsWLdSrVy/rD+zrufL1VrFiRYWFhenChQs6ceKEAgMDJaV/ZXxsbGyOnrfLHA6HXnjhBY0cOVJLly7VI4884tKc5PZ5uxv4+Pho+fLlLtefM2eOSpYsaSWlJOnpp5/WkCFDtHDhwrvqyqmhQ4dayZcbKVSokPz8/NShQwfr94O/v78efvhhffHFF9kZZpYrUaJEpp7zkJAQbdy4URs3bpQknThxQpL06quvql+/fnfVc+7K7/+/O3bsmCIjI1WqVCn9+OOPOSphc621vKS7KuF4s3bu3KnIyEhFRUXpk08+yfFXS507d041a9Z0+p21d+9eJSUladiwYfrwww8zXEGXU1y+/fbJJ5+0rvxs3ry5ypQpo2XLluXYxNSlS5c0d+5cTZgwQfny5ZOU/gFs165dNWHChEwlpthjKos1a9ZMHh4eTp+QzZs3TxcuXNB9991nY2R3lrNnzzo9PnPmjFatWqXKlStbZS1atNCcOXOUlpZmlc2aNUstWrS4bXHe6Zo2bSpPT0/NmjXLKps/f76Sk5Ot15srdXKbv7/+pPRPqd3d3VWxYkVJuXPeNmzYoBYtWqh3795XXVzzeru6zZs3q0WLFnr00Uf17rvvZjh+rdebm5ub9Xpr0qSJ8uTJ4zRvCxcuVFJSUo78nXe1OYmOjpb0v9s8XJmT3DZvuUHhwoUVHx/vdJXF4cOHZYy5q25nyyyHw6GWLVtm+CP+0KFDOXrcUvrvw+XLl1v/Lt/2smDBgrsqKXUzYmNjFRkZqRIlSmjmzJny8vKyO6Qs1aJFCy1evNhpr52ffvpJderUsT68yql27dqlZs2aqXXr1po0aVKOT0pJUpkyZZz+Ly9fvlwdO3ZU+fLltXz58hyblJKkxo0by9fX1+l3+Pnz53XixIkc/Tvc3d1d/v7+OnTokFP5wYMHMz1urpjKYkWKFNHzzz+vAQMG6Pz58/L09NRLL72kJ598UqVLl7Y7vDtGhw4d1LBhQ9WtW1dJSUl67733rE/ML3vppZf0zTffqEePHuratatmzpyp3bt36+uvv7Yx8ttr586dOnHihPbs2aO0tDTrE8jq1asrX758CgwM1AsvvKBBgwYpNTVVXl5eGjp0qHr37q3y5ctLkkt1cpobzdvy5cv11ltvqXv37ipevLhWrlypt956Sy+99JL1SXVum7edO3eqZcuWqlGjhh588EGnT7vr1asnT09PXm9XsXv3bt13332qXLmyOnfu7DRvdevWVZ48ebRq1SqNHj1ajz76qIoXL67Vq1frzTff1JAhQ1S8eHFJ6VdGDB06VEOGDFFaWpp8fX01dOhQ9ezZM9P36N8Nli9frrffflvdunVTaGiooqOj9dZbb6lJkyaKjIyU5Nqc5LZ5yw26du2qN954Qw8++KCeeeYZpaSkaMyYMapUqVKO30j3n//8pxo0aKBXX31VjRs31rp16/Tll1/qm2++sTs0ZIPExEQ1b95cKSkpevHFF7V+/XrrWKVKlXLEJtm9evXShx9+qAceeEADBw7U+vXrNX36dM2dO9fu0LLVwYMHFRkZqZCQEPXq1ctpn72aNWvK19fXxuiQHfLnz68RI0Zo0KBBOnv2rAoXLqyJEyfKy8srxyfYBwwYoLFjx8rPz09Vq1bV6tWrNXnyZE2YMCFT7TgMX2+W5dLS0jRp0iT99NNPSktL0/3336/+/ftn+Iam3OzMmTOaMGGCli1bJk9PT9WsWVPPPfec/Pz8nOpd/mNlz549CgsL05AhQ6wNUnODV199VYsWLcpQ/p///Mf6I98Yo//85z+aOXOmUlNT1bp1az377LNOrzdX6uQkrszb6tWr9dlnn2n//v0KDQ1V165d1bx5c6f6uWne5s6dq9GjR1/12KxZs6yNWHm9Ofvtt9/02muvXfXYjz/+aH1atHbtWv3nP/9RTEyMQkND1aVLlwxX9Bhj9Pnnn+v7779XamqqWrVqpWeffTbH3rq8Zs0aTZ48WXv27FHRokV13333qXv37hleSzeak9w2b7nBoUOH9P7772vbtm3y9PRU7dq19dxzz+X4Kywkafv27frXv/5l/a544oknFBERYXdYt9WCBQs0YsQILVy4MEfd1vZ3+/btc9rH8UpvvfWWGjZseJsjyh7Hjx/X2LFjtXnzZhUuXFj9+/fPsNdsTrNy5Uq99NJLVz02ZcqUXLPpu5S+R+C2bds0adIku0O5LaZPn65p06YpJSVFVatW1eDBg60PvXOy77//Xj/++KNiY2NVvHhxde3aVa1atcpUGySmAAAAAAAAYAv2mAIAAAAAAIAtSEwBAAAAAADAFiSmAAAAAAAAYAsSUwAAAAAAALAFiSkAAAAAAADYgsQUAAAAAAAAbEFiCgAAAAAAALYgMQXgrvPLL79oz549N33+0aNH9fPPP2vatGlZGNWd688//9TChQvtDgMAANgoJSVF06ZNU1JS0k23sWPHDv3www+5Zl2xYMECbd261Za+lyxZoi1bttjSN3C7kZgCcNcZPHiw5s+ff1Pnrly5UuXLl9eECRM0c+bMrA3sDjV9+nS99tprN3Xuli1btHjx4iyLJavbAwAArjl9+rS6du2qw4cP39T57777riIiIjR16lQtX748i6O7M40YMULfffedLX2/8cYbmjp1qi19A7ebh90BAMDtNGXKFLVp00bTp0+3O5S7wtSpU7V+/Xo1bdr0jmwPAADcHp988olGjRql/v372x0KgByGxBSQi23YsEGHDx9W+fLlVb58eadjFy5c0KpVq5SUlKR77rlHpUqVynD+xYsXtWbNGp0+fVp16tRRkSJFnI4nJiZq5cqVunDhgurVq5fh+A8//KC6devKw8NDmzdvlp+fn+rXry83N+eLOY8dO6Y1a9aoePHiqlatWqbHctns2bO1adMm5c+fX9OmTVNYWJgaNGhgxZGWlqaNGzeqZMmSql69uiRp3759+uOPP1SgQAE1bNhQXl5eVntxcXFauHChHn74Ye3YsUN79uxRhQoVVK5cORljtG7dOh07dkw1a9ZUSEjI1Z+Ev7WzYcMG7d+/X02bNlVgYKCk9Mvmd+3apeDgYNWoUUOenp7WuX/99Zc2bNggScqfP78qV66ssLCwa/Z1LYcPH7bGWatWLXl7e2vXrl3asWOHYmNjrdseIyIidO7cuRv2uWnTJp05c0a1atXSypUrdebMGVWsWPGq7V1vbgAAuNOcP39eq1ev1tmzZ1WjRg0VK1bM6fipU6e0evVqeXh4qEaNGtb7+ZUSEhKsOvXr11fevHmdjh88eFAbNmxQvnz51LBhQ/n6+lrHTp8+rV9//VUdO3ZUTEyMdu/erVKlSumee+7J0M/27dsVHR2tcuXKqWDBgpkeiySdPXtWs2fP1uHDh7Vz505NmzZNderUUUBAgBXH9u3btWfPHjVo0EDBwcGSZK1pQkNDVadOHac2t27dqtjYWEVERGjz5s2Ki4tT/fr1VbhwYaWkpGjFihVKTU1VgwYN5Ofnd83n4sp2Vq5cqRMnTqhz586SpEuXLmnt2rWKi4tT2bJlM8zPihUrdPDgQTkcDhUuXFjVq1eXv7//Nfu6lhv1M2/ePJUsWVKFCxfWpk2brOf8yjWllP68Llu2TAEBAapRo0am4wDuZiSmgFwoJSVFrVq1UkxMjGrUqKHo6GhVrFhRM2bMkCRt3LhRHTp0UOHChRUcHKxVq1apS5cuGj9+vNXG+vXr1alTJ3l6eqp8+fJ67rnnNGbMGHXt2lWS9Ntvv+nhhx9W2bJllTdvXq1du1bvv/++nnzySauN3r17q0GDBvrrr79UsWJFrV+/XhUqVNDvv/8ud3d3SdKsWbP0yCOPqHr16nJzc9O5c+d0+vRpl8dypd9++02HDx+Wl5eXZs6cqYYNG6pBgwbq3bu36tWrp127dqlmzZrq1KmTqlevrmHDhunDDz9Uo0aNdODAASUnJ2vu3LmqVKmSpPTFXteuXfXxxx/r3Llz8vPz08KFC/XGG29o7ty5On/+vLy9vbV69WrNmjVL991331Wfj8vtfPXVVzp8+LDKlSunKlWqKF++fOrRo4dWrFih2rVra9++fXI4HJo9e7ZKliwpKT1xdvmWxISEBC1btkwDBw7U6NGjXX49fPDBBxo+fLgaNWqk8+fPKy4uTtOnT1dMTIz++usvnTx50uojPDxcCQkJN+zziy++0G+//SZjjEJCQhQeHi4PD4+rtkdiCgBwt4iOjlbTpk1VuHBhhYaGauvWrXruuef0/PPPS0p//xs4cKBq1aold3d3a/3z2GOPWW1MnjxZAwYMUIUKFVSwYEEdOnRI3377rapUqSJJGjNmjEaNGqWGDRsqNjZWx48f1+zZs63kTkxMjLp27ar27dsrJiZGISEhWrRokV544QWnW/eHDx+uf/3rX2rcuLEOHDiQ4UPGG43lsuTkZM2cOVPnz5/XunXrFBsbq8DAQCUlJalr166KiorS/v37rQ8yCxYsqPbt22vLli2qXbu2Nm7cqAoVKmj27NnKnz+/JOm7777TF198IQ8PD5UqVUpxcXHas2ePPvzwQ40ePVrh4eE6cuSIEhIStGbNmqsmzC63M2XKFOXNm1eFCxdW0aJF1blzZ8XExKhdu3a6dOmSypQpow0bNqhevXqaPn269QHfunXrtHr1aknSoUOH9Oeff+qLL75Qhw4dXH49uNLP0KFD5e/vr/3796tixYratm2bfH19tXr1ams+1qxZozZt2ig0NFQBAQE6fPiwHA6H9UEpkOMZALnOzJkzTWBgoDl79qxV9v333xtjjElJSTGhoaHmww8/tI4dO3bMFClSxMyYMcMYY8y5c+dMcHCweeKJJ0xqaqoxxpjk5GQzb948Y4wxZ8+eNcWLFzfDhg2z2pg0aZLx9vY2MTExVlmBAgVMgwYNTHJysjHGmKNHjxofHx8za9Ysq52iRYua119/3TrnjTfeMJLMhAkTbjiWq+nUqZPp16+fU1mBAgVMtWrVTFJSklW2ePFi4+bmZlauXGmMMSY1NdV06NDBNGzY0KqzaNEiI8kpvqFDhxpJZty4cVbZM888Yxo3bnzNmC63M2TIEKfyl156yURERFjzk5aWZnr16mWioqKu2dbOnTuNj4+P2bRpk1U2fPhwc++9917znEKFCplvv/3WehwTE2PWr19vjad58+bXPPdafQ4cONA4HA6zdOlSp7qutAcAwJ1q0KBBpk2bNtbjixcvWuuWLVu2mLx585p169ZZxxctWmR8fHzMwYMHjTHGbNy40bi7u5vPP//cqnPgwAGzYcMGY4wxmzZtMm5ububXX381xqS/9/fs2dNUrlzZWnNt2rTJSDKDBg2y2pg5c6bx8PAwJ0+eNMYYs2HDBqf34dTUVBMVFWUkmR07dtxwLFcTEBBgvvnmG+vx5Tj69Olj0tLSrPKRI0eaEiVKmNjYWGOMMcePHzclS5Y0L7/8slVnxIgRxuFwmCVLlljjbNCggXF3dzerV682xhhz6dIlU7VqVfPqq69eM6YRI0YYSWb27NlO5fXq1TMvvPCC9fjMmTOmUqVKTuuzv/viiy9MUFCQuXDhglXWqFEjM2LEiGue40o/1apVM+Hh4dZzc/bsWRMcHGw++OADa+zVqlUzTzzxhHXON998YySZoUOHXrNvICdh83MgF/Lx8dG5c+e0e/duq6xjx46S0r995PDhwwoMDNR3332nGTNmaMmSJSpVqpQWLVokSZo/f76OHDmiN99807qyycfHRy1btpQkLVu2TEeOHNGwYcOs9nv37i1/f3/99NNPTrE8/vjj8vHxkSQVLVpU5cuX165duyRJS5cu1fHjxzV48GCr/qBBg5QnTx6XxpIZvXv3Vr58+azH06ZNU9OmTdWgQQNJkru7u4YNG6aVK1fqwIEDTuf269fP+vly/b+XXRnftQwYMMDp8eTJk1WlShXNmTNHM2bM0IwZM1S0aFEtXrxYxhir3tmzZ7Vs2TLNmDFDmzZtUlBQkNatW+fy2L29vbVt2zZdunRJkhQWFqZatWpd9xxX+qxevboaN27schwAANzpfHx8FBsbq7i4OEmSh4eH2rVrJyl9H8sSJUooJiZGM2bM0Lfffqu4uDjlyZNHq1atkiR99dVXqlixotMVVKGhoapZs6ak9C8sqV69ulq1aiVJcjgceuWVV7R161Zt27bNKZYr93pq2rSpUlNTrW8t/vbbb1WvXj3rfdjd3V1DhgxxeSyZ8dxzz8nhcFiPp02bpj59+igoKEiSFBgYqKeeeirDtyFXrFhRTZo0scZZr149VatWTfXq1ZMkubm5qW7dujdcQ4WHh6tt27bW4+3bt2vNmjUqWbKktZadM2eOypQpY61lLzt27Jh+//13TZ8+XampqYqLi1NMTIxL485MP4888ogKFSokSfL19VXdunWt9e6uXbv0xx9/6MUXX3SqfzNbMwB3K27lA3KhFi1a6Omnn9a9996rYsWKqXnz5urXr5+qVq2qmJgY5cmTJ8M31pUoUUJly5aVJB04cED+/v4KCAi4avv79+9XQECAChQoYJU5HA6Fh4dr//79TnX/fi+/l5eXUlJSrH4KFy7stK+Ct7e30+Xc1xtLZvz9EvH9+/dnuOS9dOnS1rESJUpY5ZcXGpfjd3d3ty7N/vuYXI0hOTlZx48f1/bt23Xy5Emnem3bttWFCxfk5eWlefPmqVu3bgoNDVXJkiXl7e2tM2fOWItMV3z55Zd69tln9cEHH6hJkybq3LmzunXr5rTIvJKrfV7rsnsAAO5WQ4YM0c6dOxUWFqZq1aqpVatWevbZZ1W4cGHFxMTo7NmzGb7FrXXr1taa6MCBAypXrtw127/a+uPy4/379zutb65cQ13er+jKNdTl2/4vCw8Pd3ksmeHqGurAgQMyxljriyvXT5fHcLWy48ePZ6r/y4mlJUuWOO1b6u3tbW3HIKXfMjl69GjVrFlTRYoUsepe3ivqRlztR7rxeldShufr74+BnIzEFJALORwOvfXWWxo9erTWr1+vr776SrVr19aWLVvk5+enCxcu6LPPPnNKCF2pYMGCSkxMVGpqqjw8Mv4aCQwMVEJCgtLS0pzeqE+ePHnVDUCvJSAgQKdPn3ZaxEjpm4q6MpYKFSq43NffkzCBgYEZEkKXH2dmDJlxZQze3t7KkyePunXrpr59+17znOeff16DBg3Sq6++apWVKVPG6YqqG7nvvvu0c+dO7du3T7/++quef/557dq1y2mfipvp81qJLQAA7lYBAQH64YcflJiYqOXLl+tf//qXpkyZot27d8vPz0/FixfPcGXQlQoWLKi//vrrmscDAwMzXBl1ed2T2TXU3/u5cv10o7FcbX13La6uoQICArJlbfD3Ni9vlj5q1KhrJgFjY2M1fPhwLV261Lqq7NChQ5oxY4bLayhX+nHF5Q96T506paJFi1rlf3++gJyMW/mAXOjYsWNKS0uTp6enGjRooPHjx8vHx0cbN25UZGSk3N3dNWnSJKdzUlNTFRsbK0lq1qyZHA6Hpk6d6lTn8idadevWtTbpvmzr1q3auXOnIiIiXI6zbt26unTpkubNm2eVLViwQImJiS6N5VZERERowYIFSkhIsMou30p3+cqp7OTm5qYWLVro008/tW6xu+zw4cPWz8eOHXP6FsJNmzZp7969Lvdz8eJF60qn8PBw9e/fX127drU2A82XL1+Gq71upc+rtQcAwN3i8nuwn5+f7r//fo0bN0779u1TXFycWrdurTVr1mjTpk1O55w6dUrnzp2TJLVs2VIrV65UdHS0ddwYoxMnTkiS9e1yx44ds47PmDFDBQsWVOXKlV2OMyIiQsuXL1d8fLxV9sMPP7g8llsRERGRoa/vvvsuU2vAW1G7dm0FBATo448/dio3xujIkSOSZK1pr1zP/P1Kt6zoxxUVK1aUv7+/090Ku3fv1tatWzMVD3A344opIBdaunSp3njjDXXq1EmhoaH6/ffflSdPHjVt2lTBwcF69913NWjQIG3fvl116tTRwYMH9f3332vcuHFq3bq1goODNXbsWPXt21ebN29WxYoVtXz5chUrVkxjx45VSEiIhg4dqp49e2ro0KHy9fXVO++8o86dO2dqz6HQ0FANGDBA3bt319ChQ+Xm5qb333/f6SuVrzeWW9G7d29NnDhRTZs2Vd++fbVv3z699957+vzzz532uMpO7733nu69915FRESoW7duSktL05IlS5QvXz59+eWXkqQOHTpo2LBhio+PV1JSkt59912nvbJu5OLFi2rYsKHatGmj6tWr6/jx4/riiy80btw4SemLrjFjxuiDDz5QUFCQIiIibqnPq7XHt/IBAO4WY8eO1Z49e9SyZUvlzZtXkydPVsOGDRUcHKxOnTqpc+fOioyM1IABA1SiRAlt27ZNs2bN0sqVK+Xj46NOnTpp6tSpaty4sZ577jkVKFBA33//vYYMGaKoqCh17txZH330kSIjI/XMM8/o2LFjGjdunN59912nbQJupHPnznrnnXcUGRmpp556Snv37tWUKVNcHsuteP3111WnTh116tRJrVu31vz587VmzRqtWbPmltp1lbe3tyZNmqRHHnlER48eVWRkpI4fP66ffvpJffr00ZNPPqmKFSuqXLlyeuSRR9SjRw9t27Ytw/xkRT+u8PX11T//+U89//zzOnr0qAIDA/XBBx84bYkB5HQkpoBc6OGHH9Y999yj6dOna8mSJSpfvrzGjh1rLUSeeeYZNWjQQNOnT9eyZctUunRp/fDDD0732w8ePFj16tXTjBkztHbtWrVo0ULdu3e3jr/22muqVauWfvnlF128eFGvv/66evTo4RTH5WTSlVq0aOF0X/5bb72lypUra8mSJQoODtbcuXM1efJklSlTxqWx/F1ERESGhd3V4vDw8NDSpUs1adIkrV69WgUKFNCiRYvUqFEjq05QUJC6dOnidLtisWLF1KVLF6e2QkND1alTp6vGc612pPTb47Zu3arPP/9cGzduVMGCBfX444+rffv2Vp2PP/5YEydO1Nq1a1WgQAH98MMP+uWXX5zmsGrVqtdMpvn6+mrz5s36/PPPtWrVKvn5+enHH39Us2bNJKXvizFp0iQtWbJEK1euVHh4uEt91qxZ86rPwdXaIzEFALhbfPjhh/r111/166+/Kjk5WT179tSjjz4qKf2Wsm+++UazZ8/Wb7/9psOHD6tKlSpav369ChYsKCn9iujvv/9e3377rRYuXCgfHx+NHDnSaRPwX3/9VZ999pnWrl2rvHnzas6cOWrevLkVQ6FChdSlSxdrXykpfXPzLl26WPtDubm5acGCBfrwww+1bt06lS1bVitWrNDw4cOtW9CuN5ar6dixo9OG3FeLQ0rfT2rz5s369NNPtWzZMpUtW1Zvvvmm0x5XV7v6q1q1ahnWaLVq1cqwN9aVrnUVWYcOHbRlyxZ99dVXWr58uUqUKKEJEyZYm8x7enpq6dKlGj9+vBYvXqywsDCtWrVKw4cPd9pj67777rvulWo36kdKX/v8fXuJhg0bytvb23r87LPPKiQkRLNnz1ZycrI+//xzLVu2jA3QkWs4TGY2IgEAAAAAAACyCHtMAQAAAAAAwBYkpgAAAAAAAGALElMAAAAAAACwBYkpAAAAAAAA2ILEFAAAAAAAAGxBYgoAAAAAAAC2IDEFAAAAAAAAW5CYAgAAAAAAgC1ITAEAAAAAAMAWJKYAAAAAAABgCxJTAAAAAAAAsAWJKQAAAAAAANji/wGNswg54kS9TwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x280 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, (full, zoom) = plt.subplots(1, 2, figsize=(12, 2.8))\n",
+    "\n",
+    "\n",
+    "def draw_pair(ax, real, envelope, ref, title, xlabel):\n",
+    "    (r0, r1), (e0, e1) = real, envelope\n",
+    "    ax.barh(1, (e1 - e0) / 1e9, left=(e0 - ref) / 1e9, height=0.5,\n",
+    "            color='#d62728', alpha=0.45, label='encoded envelope')\n",
+    "    ax.barh(0, (r1 - r0) / 1e9, left=(r0 - ref) / 1e9, height=0.5,\n",
+    "            color='#1f77b4', label='real interval')\n",
+    "    ax.set_yticks([0, 1]); ax.set_yticklabels(['real', 'envelope'])\n",
+    "    ax.set_title(title); ax.set_xlabel(xlabel)\n",
+    "\n",
+    "\n",
+    "draw_pair(full, (seg_start, seg_end), (env_start, env_end), seg_start,\n",
+    "          'five-minute segment', 'seconds from real start')\n",
+    "draw_pair(zoom, (seg_start, seg_end), (env_start, env_end), seg_end,\n",
+    "          'zoom on the end edge', 'seconds from real end')\n",
+    "zoom.set_xlim(-8, 8); zoom.axvline(0, color='0.3', lw=0.8)\n",
+    "full.legend(loc='lower right', fontsize=8)\n",
+    "fig.tight_layout(); plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01fc367d",
+   "metadata": {},
+   "source": [
+    "### Merge: where the dual type earns its keep\n",
+    "\n",
+    "Exact timestamps are the leaves. `toc_merge` (pairwise) and `toc_reduce`\n",
+    "(whole array) join words into the conservative range that covers them — the\n",
+    "semilattice join. Merging is how a granule of a million photon times collapses\n",
+    "to **one** word that a coarse index can hold.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4150d8d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.935477Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.935291Z",
+     "iopub.status.idle": "2026-08-10T10:49:47.952279Z",
+     "shell.execute_reply": "2026-08-10T10:49:47.951051Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "200,000 timestamp words  ->  one word 0x938B5C4E49C5C1CD (is_range=True)\n",
+      "true span     21,599.915 s\n",
+      "envelope      21,603.685 s\n",
+      "slack         start 0.307 s, end 3.463 s  -> 0.01745% wide\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng = np.random.default_rng(0)\n",
+    "\n",
+    "# A synthetic granule: 200k instants scattered over ~6 hours of one day.\n",
+    "day0 = int(mortie.from_datetime64('2018-06-15T00:00:00'))\n",
+    "granule_ns = day0 + np.sort(rng.integers(0, 6 * 3600 * 10**9, size=200_000))\n",
+    "granule = mortie.time2toc(granule_ns.astype(np.uint64))\n",
+    "\n",
+    "summary = mortie.toc_reduce(granule)\n",
+    "lo, hi = mortie.toc2time(summary)\n",
+    "true_lo, true_hi = int(granule_ns.min()), int(granule_ns.max())\n",
+    "span_s = (true_hi - true_lo) / 1e9\n",
+    "\n",
+    "print(f'{granule.size:,} timestamp words  ->  one word 0x{summary:016X} '\n",
+    "      f'(is_range={mortie.toc_is_range(summary)})')\n",
+    "print(f'true span     {span_s:,.3f} s')\n",
+    "print(f'envelope      {(hi - lo) / 1e9:,.3f} s')\n",
+    "print(f'slack         start {(true_lo - lo) / 1e9:.3f} s, '\n",
+    "      f'end {(hi - true_hi) / 1e9:.3f} s  '\n",
+    "      f'-> {100 * ((hi - lo) - (true_hi - true_lo)) / (true_hi - true_lo):.5f}% wide')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a81d461",
+   "metadata": {},
+   "source": [
+    "Two laws make that reduction safe to run anywhere — in parallel, out of order,\n",
+    "or over already-merged partials:\n",
+    "\n",
+    "- **Idempotence.** `toc_merge(w, w) == w` for *any* word: bitwise-equal inputs\n",
+    "  return unchanged, so two equal timestamps never decay into a range.\n",
+    "- **Associativity + commutativity.** Every fold tree over the same words\n",
+    "  yields the identical `uint64`, so a merged summary of merged summaries is\n",
+    "  the same word as one flat reduce.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1ca6be3d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:47.954332Z",
+     "iopub.status.busy": "2026-08-10T10:49:47.954101Z",
+     "iopub.status.idle": "2026-08-10T10:49:48.005967Z",
+     "shell.execute_reply": "2026-08-10T10:49:48.005171Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "idempotent, associative, commutative -- all fold trees agree\n"
+     ]
+    }
+   ],
+   "source": [
+    "w0 = int(granule[0])\n",
+    "assert mortie.toc_merge(w0, w0) == w0                     # idempotent\n",
+    "assert mortie.toc_merge(summary, summary) == summary\n",
+    "\n",
+    "# fold-tree independence: shuffled left fold == flat reduce == reduce of\n",
+    "# per-chunk partial merges\n",
+    "shuffled = rng.permutation(granule)\n",
+    "left_fold = functools.reduce(mortie.toc_merge, (int(w) for w in shuffled[:5000]))\n",
+    "assert left_fold == mortie.toc_reduce(shuffled[:5000])\n",
+    "\n",
+    "chunks = np.array([mortie.toc_reduce(c) for c in np.array_split(granule, 7)],\n",
+    "                  dtype=np.uint64)\n",
+    "assert mortie.toc_reduce(chunks) == summary\n",
+    "print('idempotent, associative, commutative -- all fold trees agree')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e96e9316",
+   "metadata": {},
+   "source": [
+    "## 3. Sorting — one `np.sort`, no comparator\n",
+    "\n",
+    "Timestamps and ranges live in the same array and sort together with plain\n",
+    "unsigned `np.sort`: word order is order by conservative encoded start. Within\n",
+    "a tied start quantum, ranges sort before timestamps, then timestamps by exact\n",
+    "ns and ranges shorter-first. Nothing has to know which variant a word is.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "69cf6d4d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:48.008024Z",
+     "iopub.status.busy": "2026-08-10T10:49:48.007568Z",
+     "iopub.status.idle": "2026-08-10T10:49:48.015555Z",
+     "shell.execute_reply": "2026-08-10T10:49:48.014779Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              word  kind      start (UTC)                 end\n",
+      "0x938B9791B0BFDC00  timestamp 2018-06-15T09:03:00.000000000 -\n",
+      "0x938B97C949C5CC1D  range     2018-06-15T09:04:59.441204224 2018-06-15T09:09:02.106856448\n",
+      "0x938B988CEB41F400  timestamp 2018-06-15T09:12:00.000000000 -\n",
+      "0x938B9A8349C5CD88  range     2018-06-15T09:29:58.384790528 2018-06-15T09:35:01.179984896\n",
+      "0x938B9B9B930F9400  timestamp 2018-06-15T09:40:00.000000000 -\n"
+     ]
+    }
+   ],
+   "source": [
+    "base = int(mortie.from_datetime64('2018-06-15T09:00:00'))\n",
+    "minute = 60 * 10**9\n",
+    "\n",
+    "mixed = np.concatenate([\n",
+    "    mortie.time2toc(np.array([base + 3 * minute, base + 40 * minute,\n",
+    "                              base + 12 * minute], dtype=np.uint64)),\n",
+    "    mortie.span2toc(np.array([base + 5 * minute, base + 30 * minute],\n",
+    "                             dtype=np.uint64),\n",
+    "                    np.array([base + 9 * minute, base + 35 * minute],\n",
+    "                             dtype=np.uint64)),\n",
+    "])\n",
+    "\n",
+    "ordered = np.sort(mixed)                    # that is the entire sort\n",
+    "starts, ends = mortie.toc2time(ordered)\n",
+    "is_range = mortie.toc_is_range(ordered)\n",
+    "\n",
+    "print(f'{\"word\":>18}  {\"kind\":<9} {\"start (UTC)\":<27} end')\n",
+    "for w, s, e, r in zip(ordered, starts, ends, is_range):\n",
+    "    kind = 'range' if r else 'timestamp'\n",
+    "    end = str(mortie.to_datetime64(int(e))) if r else '-'\n",
+    "    print(f'0x{int(w):016X}  {kind:<9} '\n",
+    "          f'{str(mortie.to_datetime64(int(s))):<27} {end}')\n",
+    "\n",
+    "assert np.all(starts[:-1] <= starts[1:])    # chronological interleave\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93957040",
+   "metadata": {},
+   "source": [
+    "## 4. Window queries — `toc_overlaps` and `toc_contains`\n",
+    "\n",
+    "Both predicates run on each word's **conservative encoded bounds** against a\n",
+    "half-open window `[q_start_ns, q_end_ns)`. That fixes their error direction,\n",
+    "and the direction is the useful one:\n",
+    "\n",
+    "- `toc_overlaps` **never under-reports** — every word whose real time content\n",
+    "  meets the window tests `True` — but may over-report by up to one quantum.\n",
+    "  It is a safe *candidate filter*: refine survivors against exact times.\n",
+    "- `toc_contains` **never over-reports** — envelope-inside-window implies\n",
+    "  interval-inside-window — but may under-report by up to one quantum. It is a\n",
+    "  safe *certainty filter*.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8585b3b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:48.017241Z",
+     "iopub.status.busy": "2026-08-10T10:49:48.017073Z",
+     "iopub.status.idle": "2026-08-10T10:49:48.022127Z",
+     "shell.execute_reply": "2026-08-10T10:49:48.021445Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "window [2018-06-15T09:04:00.000000000 .. 2018-06-15T09:31:00.000000000)\n",
+      "\n",
+      "0x938B9791B0BFDC00  timestamp overlaps=False contains=False\n",
+      "0x938B97C949C5CC1D  range     overlaps=True  contains=True\n",
+      "0x938B988CEB41F400  timestamp overlaps=True  contains=True\n",
+      "0x938B9A8349C5CD88  range     overlaps=True  contains=False\n",
+      "0x938B9B9B930F9400  timestamp overlaps=False contains=False\n"
+     ]
+    }
+   ],
+   "source": [
+    "q_start = base + 4 * minute\n",
+    "q_end = base + 31 * minute\n",
+    "\n",
+    "hits = mortie.toc_overlaps(ordered, q_start, q_end)\n",
+    "inside = mortie.toc_contains(ordered, q_start, q_end)\n",
+    "\n",
+    "print(f'window [{mortie.to_datetime64(q_start)} .. '\n",
+    "      f'{mortie.to_datetime64(q_end)})\\n')\n",
+    "for w, r, h, c in zip(ordered, is_range, hits, inside):\n",
+    "    print(f'0x{int(w):016X}  {\"range\" if r else \"timestamp\":<9} '\n",
+    "          f'overlaps={bool(h)!s:<5} contains={bool(c)!s}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1da4b66f",
+   "metadata": {},
+   "source": [
+    "### Seeing the quantum at a window edge\n",
+    "\n",
+    "Both edge behaviours are constructible on purpose. Snap the window to the\n",
+    "quantum grid — `q_start` onto the 2^31 grid, `q_end` one nanosecond past a\n",
+    "2^32 grid line — and:\n",
+    "\n",
+    "1. a range whose real interval ends *just inside* the window still has its\n",
+    "   envelope end ceil past `q_end`, so `contains` is `False` (under-report);\n",
+    "2. a range whose real interval ends *just before* the window has its envelope\n",
+    "   end ceil past `q_start`, so `overlaps` is `True` (over-report).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "db914f13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:48.023725Z",
+     "iopub.status.busy": "2026-08-10T10:49:48.023483Z",
+     "iopub.status.idle": "2026-08-10T10:49:48.033309Z",
+     "shell.execute_reply": "2026-08-10T10:49:48.032261Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "window   [5,315,878,816,793,493,504 .. 5,315,882,413,828,603,905)\n",
+      "\n",
+      "inside-but-not-contained   envelope [5,315,878,874,775,552,000 .. 5,315,882,418,123,571,200)  overlaps=True  contains=False\n",
+      "before-but-overlapping     envelope [5,315,878,806,056,075,264 .. 5,315,878,818,940,977,152)  overlaps=True  contains=False\n",
+      "\n",
+      "both errors are bounded by one quantum: 4.295 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "qs = (base // toc.Q_START_NS) * toc.Q_START_NS               # 2^31-aligned\n",
+    "grid = ((qs + 3600 * 10**9) // toc.Q_END_NS) * toc.Q_END_NS  # a 2^32 grid line\n",
+    "qe = grid + 1                                                # 1 ns past it\n",
+    "\n",
+    "# (1) real interval inside the window, envelope end spills past qe\n",
+    "a = mortie.span2toc(qs + minute, grid)\n",
+    "# (2) real interval entirely before the window, envelope end spills past qs\n",
+    "b = mortie.span2toc(qs - 10 * 10**9, qs - 1)\n",
+    "\n",
+    "print(f'window   [{qs:,} .. {qe:,})\\n')\n",
+    "for name, w in [('inside-but-not-contained', a), ('before-but-overlapping', b)]:\n",
+    "    s, e = mortie.toc2time(w)\n",
+    "    print(f'{name:<26} envelope [{s:,} .. {e:,})  '\n",
+    "          f'overlaps={mortie.toc_overlaps(w, qs, qe)!s:<5} '\n",
+    "          f'contains={mortie.toc_contains(w, qs, qe)}')\n",
+    "\n",
+    "assert mortie.toc_overlaps(a, qs, qe) and not mortie.toc_contains(a, qs, qe)\n",
+    "assert mortie.toc_overlaps(b, qs, qe)\n",
+    "print(f'\\nboth errors are bounded by one quantum: '\n",
+    "      f'{toc.Q_END_NS / 1e9:.3f} s')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "439d943b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:48.035788Z",
+     "iopub.status.busy": "2026-08-10T10:49:48.035597Z",
+     "iopub.status.idle": "2026-08-10T10:49:48.181098Z",
+     "shell.execute_reply": "2026-08-10T10:49:48.179752Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEIAAAE2CAYAAABlSTcJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVtNJREFUeJzt3Xd0VNX6//HPpJIeEkIJCRB6SUCq0luoUhUEBKWrVBW5IiqggoBfQCx44XItIBYEQWkiXRGR3jshoYbQSYCElMn5/cEvcxkSIBMSApn3a61Zy7PPPvs8p+HMk733MRmGYQgAAAAAAMAOOOR2AAAAAAAAAA8LiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN0gEQIAAAAAAOwGiRAAAB7QW2+9JScnp9wOA3bAHu81ezzmx1lQUJB69eqV6fqenp4aPHhwzgUEABkgEQIAsGuvvfaa8uXLl9thAECeVaBAAfXr1y+3wwAACxIhAAA8oIkTJyolJSW3wwCAXHf69GnNmjUrt8MAgHsiEQIAAAAAAOwGiRAAeEgiIyPVvn17eXp6yt/fX4MGDdK5c+dkMpk0ceJES70NGzbIZDJp6dKlmj59ukqXLi1HR0dt27ZNkrR//3517txZAQEBcnV1VYUKFfTZZ5+l219m6r3yyivy9fXV9evX1adPH/n6+srX11cvvPCC4uLicvaEZGDfvn3q2rWrChcuLHd3d1WrVk2zZ8+WYRiWOmvXrlXjxo3l5eUld3d3Pfnkk1q4cKFVO5k9rg4dOujTTz9VYmKiTCaT5XP8+HFJ0ieffGJV7u3trYYNG2r58uVW+8toDgNbzm1kZKSef/55FS1aVO7u7goNDdW4ceMUHx+fpfNoyzm6evWqevXqJT8/P1WoUMGm47b1/pk/f77CwsKUL18+lS9fXnPnztW0adNkMpl0+vRpq7qZvc9z2v3O5ZQpU2QymbRv3750286cOVMmk0lbt261lNnyXGZ0bTJi6/W6cuWKunXrJh8fH/n5+al37966fPmyVd0HuSez8xnNyKeffiqTyaRdu3alWzd9+nSZTCZt2bLlvnHeKbP35/2uz5w5c1SrVi25u7vL09NTzZo1s4qnZs2aCgsLyzCGunXrqly5cjbHnlVp83Ns2bJFtWvXlpubm0JCQjRjxowM69/v2CTrOUKuX78uk8mkS5cu6auvvrLco/Xq1UvXdnbGkHZcf//9t+rUqSM3NzeNGzcuC2cIQJ5lAABy3MWLF42iRYsaVapUMXbs2GFcvXrV+OGHH4zu3bsbkowJEyZY6v7111+GJKNjx47GO++8Y0RHRxvr16839u3bZ2zevNlwd3c32rdvbxw4cMCIi4sz5s+fb3h7exsjRoywtJHZei+//LLh4+Nj9OrVy1i2bJkRFxdn/P7774aXl5fx8ssv3/e4fvzxR0NSpj5Lliy5Z1sbN2403NzcjObNmxs7duwwrl+/buzatcvo1auXcfjwYcMwDGPx4sWGg4OD0bNnT+P48eNGdHS08a9//cuQZMyYMSNLx/Xqq68arq6u9z1Ws9lsHD9+3Hj11VcNZ2dnY/v27ZZ1I0aMMBwdHa3q2xJDmTJljEaNGhmHDh0yEhISjIMHDxqjR482fvjhh/vGdSdbz1GXLl2MJUuWGJcvXza+/vprm47blmOcN2+eIcl47bXXjOjoaOPkyZPGK6+8YrRr186QZJw6dcpSN7P3b0ay857MzLk8f/684eLiYrz22mvptn/yySeNsLAwm4/rXtcmo3vtdpm5Xs8995yxbNkyIzY21li7dq0RFBRk1KhRw0hKSrLUzeo9mRPP6J3HfPXqVcPDw8Po379/uv2HhYUZoaGh94wxI7bcn/e6Pm+99Zbh4uJifPzxx0ZMTIwRHR1tDBkyxHB1dTW2bt1qGIZhfPPNN4Yk488//7SKYffu3YYkY+LEifeM9emnn87U/e3j43Pf4/bw8DBat25tdO7c2Th06JBx+fJly/Vav369Vd3MHJthGEbRokWNnj17Wm3r7+9v9O3b96HF4OHhYbRo0cJo166dceDAAePkyZPG4sWL73s+ANgPEiEA8BCMGTPGMJlMxsGDB63Kx40bd9dESLNmzdK1U7NmTaNMmTJGYmKiVfnkyZMNJycnIzo62qZ6L7/8siHJmDdvnlW9IUOGGC4uLkZycvI9jys7f3Q+8cQTRokSJYybN2/etU7ZsmWN8uXLG2az2aq8adOmhq+vrxEfH2/zcWU2EXK7EiVKGIMHD7Ys3y0RkpkYTp8+bUgyvvrqK5tiuBtbz9Hs2bMz3fadx23LeS5VqpRRs2ZNq3qpqalGxYoV0/3QzOz9m5HsvCczey47depkFChQwCre/fv3G5KMTz75xObjute1uV8i5HZ3u15z5syxqrd06VJDkvHtt98ahvFg92ROPKMZHXP//v0NDw8PIzY21lKW9m/n1KlTbY7blvvzbtfn4MGDhslkMt5555107VSrVs1o0aKFYRiGkZCQYPj5+Rldu3a1qvfyyy8bTk5OxtmzZ+8Za3YnQvz9/Y1r165ZypKTk42CBQsaL7zwgs3HZhhZS4RkdwweHh6Gp6encfXq1fueAwD2iaExAPAQrFu3TmXKlFH58uWtytu1a3fXbe5cd+7cOW3dulXt27eXi4uL1brw8HClpKRo48aNma53u9atW1sth4aGKikpKd1whTt17dpVxq2k+n0/bdq0uWs7Z8+e1a5du9SpUye5urpmWOf06dM6cuSIOnToIAcH6/99derUSVevXtWOHTuy5bjS3LhxQ++8847Kly+vfPnyWQ2diYiIyFQb94uhUKFCKly4sD788EPNmTNH58+fz1S7GcnKOcroHrT1uO93jKdOndKxY8fUtm1bq3omkyndfZGV+/d22XVP2nIu+/btq4sXL2rx4sWWOl999ZVcXFzUo0ePLB/Xvf59uJ2t1+vOdlu3bi0XFxetXbtWUtbvyYf5jA4aNEg3btzQ7NmzLWX//ve/rc55Ztlyf97uzvO4bNkyGYahzp07p2unSZMm+vPPPyVJ+fLlU58+fbRw4UKdO3dOkhQXF6fvv/9erVu3VuHChe8Z79KlSzN1f1+9ejVTx9+gQQN5enpalp2cnFSuXDlFRkbafGxZlRMxNGzYUD4+Pg8UF4C8i0QIADwEly5dUsGCBdOVZ1SWpmjRolbLMTExkqSPP/5YTk5OcnR0lKOjoxwcHPTEE09Y9pPZemm8vb3l4eFhtS9vb29JyvQX6QeV9kPrzmO+XVrMGf1ISCu7ePGipSw7jqt79+6aPn26PvroI0VHR8tsNsswDIWGhio5Ofm+22cmBicnJ61cuVIVK1bUSy+9pEKFCqlSpUoaN26cEhISMhVnGlvPkbu7u3x9fdPVteW4M3OMaXFl5hmw9f7NKbacy+bNmys4OFhfffWVJCk5OVlz5sxRhw4d5O/vL8n247rbtcmILdcrX758luuTxmQyKSAgwHI8Wb0nH+YzWqVKFdWpU0fTp0+XJF24cEELFixQ+/btVaBAgXtue7e4bfk3OqPrk3aNq1evbrnGDg4OcnBw0OTJk3Xz5k3LHCsDBgxQcnKy5Z6ZM2eOrl+/rr59+9oUe3YoUqRIujJvb2+ra2DLsT0qMdzr/ycAQCIEAB4Cf3//DP+qeq+/tDo7O1stp325Hz16tFJSUmQ2m2U2m5Wammr5C+BLL72U6XppTCZTlo9r7ty5VpM03uuzdOnSu7YTEBAgSTpz5sxd6/j5+UmS5S+ot0sru/0H0IMclyTFxsZq8eLFGjx4sNq3by8/Pz85ODjIMAydOHEiU21kNoawsDAtWbJEV69e1YYNG9SyZUuNHj1aQ4YMsSlmW8/RnfeYZPtxZ+YY05IBmXkGbL1/75Rd96Qt59LBwUG9e/fWypUrdfr0aS1ZskQXLlyw+lFr63FldG0yYuv1unnzZrrJSA3D0IULFyzXScraPfmwn9FBgwbp4MGD+uOPP/Tll18qKSkpS4kEW+7PNBldn7RjO3z4sOUap6amWl1jd3d3SVLJkiXVsmVL/ec//5HZbNb06dNVuHDhdD1kMtKmTZtM3d+ZTaRl5jrYcmxZkRMxZPYZAmCfSIQAwEPQuHFjRURE6PDhw1bl9/ohdqeiRYuqatWqWrhwoVJSUh643qMkMDBQVatW1YIFC5SUlJRhneDgYJUpU0aLFi2yeouMJC1YsEC+vr6qVq2azfv28PBQcnJyujZNJpMMw0g3VOeXX37RtWvXbN5PZri6uqpu3bqaMmWKGjRooPXr19u0fXaco5w47uDgYJUqVUrLli2zKjcMI13Zo3L/2nou+/TpI0maNWuWvvrqKxUrVkzh4eGW9Tl1XFm5XkuWLLFaXr58uZKSktS0adN0dW25J3PqGb2bTp06qWDBgpo2bZpmzpyp4OBgNWvWzOZ2bLk/7+Xpp5+WyWTSTz/9lKn6AwcO1MmTJ/Xmm29q//796tmzZ7q3Tz0qbD22O3l4eCgxMTFXYwCA25EIAYCHYMiQISpcuLC6deumXbt2KS4uTj/99JMOHjxoUzszZszQsWPH9Mwzz2jHjh2Kj4/XqVOntGjRIjVt2lSxsbE21XtQ2TUfgyR98cUXiomJUdu2bbVr1y7duHFDu3fvVp8+fXTkyBFJ0qRJk3To0CH169dPJ0+eVExMjN5++22tWrVK48ePl5ubm83HEBoaqtTUVC1btkxms9lSnvYK0unTp2vLli26fv26lixZoqlTpyo0NNTm/dzN1q1b1alTJ61evVrnz59XQkKCVqxYoZ07d6px48aWehERETKZTOrXr98923vQc5RTxz1hwgRt3rxZw4cPV0xMjM6cOaPBgwerdOnS6eo+yP2bnfekLeeyePHiatq0qaZPn64VK1aod+/e6ebJyInn0tbr5ePjoyVLlmj58uW6du2a/vzzT73yyiuqWrWqunTpIinz9+SDnrMH5eLion79+mnBggU6fvx4huc8s8+NLffn3YSGhuqtt97S+++/r48++kgnT55UQkKCDhw4oClTpmjgwIFW9Vu3bq2QkBB9/PHHkv6XTLuf7J4jJCeOLaPtt2zZoujo6FyLAQBuRyIEAB4Cf39/rV+/XkFBQapXr55CQkK0fv16jR07VpLuOkHonWrVqqUdO3Yof/78atu2rXx9fVW/fn3NmTNHo0aNskwMl9l6j5LatWtr8+bN8vLyUnh4uAICAtSnTx81bNhQZcqUkSS1b99ev//+uyIiIlSxYkWFhIRo9erVmjdvngYMGJCl/T733HPq16+fevfuLWdnZ8skk5L0ww8/qG7dumrVqpWKFi2qb775RnPnzs309cqM6tWrq3v37po8ebJCQ0MVEBCgN954Q2+99ZY+//xzS73r169LutV75l6y4xzlxHF37txZP/30k37//XcVL15cTZo0Uf369VW/fn1J1s/Ao3L/2nou+/Xrp+joaKWmpqp3797p1ufUcdl6vf7973/rm2++UdGiRdWhQwc1btxYK1eutEzimtl7MiM58Yzey8svvyxHR0eZTKYMz3lmnxtb7s97GT9+vL7//nstX75cYWFhKlCggLp06aLz58/r7bfftqrr4OCgV155RZJUv359lS1bNlP7yC22HNudJk+erICAAJUuXVomk0n16tV76DEAwO1Mxp19FwEAD8327dtVo0YN/fDDD+rWrVtuh4NH2KeffqpRo0YpMjLS5skgH2Wvv/66pk+fruvXrz+ywwLyildeeUVz5859aJMgPwyXLl1SYGCgGjRooFWrVqVb/6DPTU7fnzNmzNCAAQM0a9Ys9ezZM9vbBwBkjB4hAJCLFixYIAcHB8tfHYG7WbNmjd544408lQRJSUnR4sWLVadOHZIgyJJff/1VSUlJ6t+/f4brH+S5eRj3508//SRfX990r4QFAOQsvnUAwEPyr3/9S/Xq1VO9evWUnJysn3/+WVOnTlX//v0VFBSU2+HhEbd48eLcDuGBXLp0SW+88YaGDBmi8uXL6+TJkxo9erROnDhheYUoYIuzZ8/q448/Vrly5fTss89mWCezz83Dvj8Nw9Bvv/2mP//8U2PGjHmgN64AAGxHjxAAeEh69eqlb7/9VpUrV1bx4sU1bdo0jRo1Sl988UVuhwbkOH9/fzVt2lSDBg1SkSJF9OSTT+rixYtauXKlGjVqlNvh4TFTo0YNFS9eXO7u7po3b54cHR0fqL2HeX8eOnRIDg4O6tatm3r27KmRI0dma/sAgPtjjhAAAAAAAGA36BECAAAAAADsBokQAAAAAABgN5gsNRelpqYqOjpaXl5eMplMuR0OAAAAAACPJcMwdO3aNQUGBsrB4d59PkiE5KLo6GgFBwfndhgAAAAAAOQJp06duu8bGUmE5CIvLy9Jty6Ut7d3LkfziEiOk86ukhycJJNzbkcDAACAR5GRLKWmSEWaSc58jwYgxcXFKTg42PI7+15IhOSitOEw3t7eJELSJEu67i45ukmOrrkdDQAAAB5F5kTJnCB5e5MIAWAlM9NOMFkqAAAAAACwGyRCAAAAAACA3XjgREj37t315ptvZkcsAAAAAAAAOcqmREjXrl01cuRIq7IbN24oPj4+W4PKioxiAwAAAAAAmZeamqro6GhFREQoOjpaqampuR1StrNpstTr168rISHBquz777+/7zt6H4aMYgMAAAAAAJkTFRWljRs36saNG5YyDw8P1alTRyEhIbkYWfbKdAZj4MCBWrFihaZPny5fX1/5+vrq6NGjeumllzRmzBhLvQ4dOmjo0KHq27evypUrp5CQEI0bN04XLlxQr169FBQUpEqVKunbb79Nt4+vv/5aNWrUUOHChVWnTh39/PPPVus3bNigpk2bqmjRoqpZs6Zmzpx5z9iGDRtmWS5VqpS6d++uU6dOWbWZ1Xg7dOigN954Qy+//LLKli2rUqVKacKECZk9nQAAAAAAPDKioqK0atUqqySIdGsUyKpVqxQVFZVLkWW/TCdCJk+erKZNm6pPnz46fvy4jh8/rlKlSqUbGnP9+nV98cUXqlq1qtasWaNx48Zp1KhRqlatmmrXrq1Nmzbp9ddfV58+fRQREWHZbsqUKfrwww81fvx47dixQyNGjFD//v21ZMkSSVJCQoJat26tJk2aaOvWrfrvf/+rXbt2aceOHXeN7cMPP7Qs//bbbzIMQ+3bt7fq2pPVeK9fv66PP/5Y/v7+WrlypT7++GN99NFHmj59+gNdEAAAAAAAHqbU1FRt3LjxnnU2btyYZ4bJmAzDMDJbuU2bNipdurQ++eQTS1mHDh0UFBSkadOmSZLCw8Pl7u6uxYsXW+pUrFhRoaGhmjdvnqWsWLFi+uCDD9SrVy8lJSUpICBAP/74o1q3bm2pM3r0aG3ZskW///67jh07ptKlS+v06dMqWrRopmK7U3x8vLy8vLRnzx5VqlQpy/GmbXfx4kXt2rXLUmf8+PGaOXOmjh8/nuH+ExMTlZiYaFmOi4tTcHCwYmNj5e3N+88lSclxUvRyydFNcnTN7WgAAADwKDInSuYEKbCV5Mz3aOBBRUdHa+nSpfet16ZNGwUGBj6EiGwXFxcnHx+fTP2+zpHJPcqXL2+17Ofnl2HZpUuXJEkHDx5UXFycevTooQIFCsjf319+fn6aPHmyjh07JkkKCQlRvXr11LhxY40dO1YbNmyQ2Wy+ZxyRkZF68cUXVbZsWfn5+SkwMFCpqak6ceLEA8Wbpnbt2umWT5w4oevXr2cYz4QJE+Tj42P5BAcH3zN+AAAAAAByWmZfgPIovCglO+RIIiSjyVMzKkvrjJKcnCxJ+v333xUREaFjx44pMjJS0dHR2r59u2X7devWadKkSTp37pxefPFFlS9f3pIoyUirVq2Umpqq+fPn6/Dhw4qKipKzs7OSkpIeKN40jo6OVstOTrfmnk1JSckwnpEjRyo2NtbyuXO+EgAAAAAAHjZ3d/dsrfeos+mtMU5OTjkyJqhcuXJycXHR1q1bVatWrXvuv3379mrfvr3MZrNq1KihGTNmaNKkSeliO3PmjI4cOaJly5apdOnSkqS9e/daki7Z4fZhMZK0c+dOFSxYUL6+vhnWd3V1lasrwz0AAAAAAI+OwoULy8PDI91Eqbfz8PBQ4cKFH2JUOcemHiHBwcE6cODAfYek2MrLy0tDhw7VmDFjtHz5cqWkpCg2NlY//vijpkyZIknatm2bRowYYRnWcurUKV28eFFBQUEZxhYQECBPT0/Nnz9fhmHo1KlTevnll7M17r///lszZ85USkqKdu/erY8++kiDBw/O1n0AAAAAAJCTHBwcVKdOnXvWqVOnToYjJx5HNh3FoEGDFBMTI09PT8srarPLxIkTNWzYMPXr10/u7u4qWbKkfvvtNz377LOSpLCwMPn7+6thw4Zyc3NT1apV9cwzz2jQoEEZxnbixAnNmTNH06ZNU758+VS5cmU1a9YsW7vydO/eXT///LPy58+vmjVrqnXr1hoxYkS2tQ8AAAAAwMMQEhKiZs2aycPDw6rcw8NDzZo1U0hISC5Flv1semtMmqSkJMXHx8vb21sJCQlycHCQm5ubpFvvGHZ0dFS+fPks9a9fvy4nJyersmvXrsnFxSXDoSIJCQmW9jKSmJh41yEmt8eWlq26vb3Y2Fi5u7vL2dn5geINDw9XjRo1NHHiRJnNZhmGYZkjJLNsmdXWbvDWGAAAANwPb40BckxqaqpiYmIUHx8vd3d3FS5c+LHoCWLL72vbfrn/fy4uLnJxcZGkDLNFd/L09ExX5uXlddf275UEkXTPeTZujy2j9nx8fKzWZUe8d06aCgAAAADA48jBweGRfUVudnn00zoAAAAAAADZJEs9QiAtWrSIniAAAAAAADxmSIRkUUZDagAAAAAAwKONoTEAAAAAAMBukAgBAAAAAAB2g0QIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7AaJEAAAAAAAYDdIhAAAAAAAALtBIgQAAAAAANgNEiEAAAAAAMBukAgBAAAAAAB2g0QIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7AaJEAAAAAAAYDdIhAAAAAAAALtBIgQAAAAAANgNEiEAAAAAAMBukAgBAAAAAAB2g0QIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7AaJEAAAAAAAYDdIhAAAAAAAALtBIgQAAAAAANgNEiEAAAAAAMBukAgBAAAAAAB2g0QIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7IZTbgcAAAAAII/5z3O5HQEehvdiczsCIEvoEQIAAAAAAOwGiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN14LBMhLVq00CuvvKIePXrIz89P4eHhkqRBgwbJyclJTk5OKlSokNq3b69jx46l23bAgAHq3bu3goKCVKRIEQ0bNkxms9lSJyEhQf3791f+/PlVvHhxDRw4UJ06ddLLL79s1dZnn32m8uXLy9PTU5UrV9asWbNy/NgBAAAAAEDWPZaJELPZrP/85z+qXbu2IiMjtWLFCknS559/rps3b+rmzZvasWOHAgIC1KFDB6skh9ls1syZM1W3bl3t3btXCxYs0Jdffqk5c+ZY6owYMUJr1qzRypUrtWXLFjk7O2vBggVW7YwbN07Tp0/X119/rejoaE2dOlXDhw/X/PnzH96JAAAAAAAANjEZhmHkdhC2Cg8Pl4ODg1auXHnPejdv3pSnp6d27typsLAwy7ZeXl765ZdfLPWef/555cuXT19//bUSEhKUP39+zZ49W126dJEkpaSkKCQkRC1atNCXX36pmzdvKiAgQAsXLlSzZs0s7bz//vv6+++/7xpXYmKiEhMTLctxcXEKDg5WbGysvL29s3w+8pTkOCl6ueToJjm65nY0AAAAyIr/PJfbEeBheC82tyMALOLi4uTj45Op39ePZY8QSQoNDU1XdvDgQT3zzDMKDAyUi4uLPD09ZTabdfLkSat6ZcuWtVr28/PTlStXJEmRkZFKTExUzZo1LeudnJz0xBNPWJYPHTqk69evq02bNsqXL59cXV3l4uKiDz74QJGRkXeNecKECfLx8bF8goODs3LoAAAAAAAgix7bRIiLi4vVsmEYat26tfz9/fXXX38pNjZW8fHxcnZ2VnJyslVdk8mUrr07O8bcWef25bQhMtu2bdP169d148YNxcfHKzExUYcPH75rzCNHjlRsbKzlc+rUqcwdLAAAAAAAyBaPbSLkTtHR0Tp+/LhGjBihUqVKyc3NTfv370+XBLmfkJAQubi4aMeOHZay1NRU7d6927Jcvnx55cuXT2vWrLFMzpr2cXR0vGvbrq6u8vb2tvoAAAAAAICHJ88kQgoWLChfX1/Nnj1bN2/e1MGDB9WvXz+b23F3d1ffvn31zjvvaN++fYqLi9M777xjNbzGw8NDw4cP13vvvaf58+frxo0bOnPmjP773/9qwoQJ2XlYAAAAAAAgG+WZRIizs7Pmzp2refPmydPTU82aNVPXrl3l4eFhc1v/93//pxo1aqhmzZoqU6aMYmJi1Lx5c7m6/m/yzg8++EAffPCB3n33Xfn4+Oipp57Sjh071KtXr2w8KgAAAAAAkJ0ey7fGpKamSpIcHO6fxzGbzXJwcLDM8ZHRtvdrzzAMVaxYUX369NG//vWvB4r9drbMams3eGsMAADA44+3xtgH3hqDR4gtv6+dHlJM2SozCZA0d87ZkdG2d5atW7dOR48eVefOnWU2mzVp0iSdOHFCzz3HP+gAAAAAADzO8szQmOz05JNPavfu3apQoYJCQkL0999/a82aNSpevHhuhwYAAAAAAB7AY9kjJKe5u7vriy++0BdffJHboQAAAAAAgGxEjxAAAAAAAGA3SIQAAAAAAAC7wdAYAAAAANnr5Xk52745UTInSIGtJGfevgjANvQIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN0gEQIAAAAAAOwGiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN0gEQIAAAAAAOwGiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN0gEQIAAAAAAOwGiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN0gEQIAAAAAAOwGiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAduOBEyH//e9/NX/+/OyIBQAAAAAAIEfZlAiZMWOGFixYYFW2bNky/fnnn9kaVFZkFBsAPE7MRqq2Xo7Qb2d3auvlCJmN1NwOCQAAAMhznGypvHTpUpUuXVrPPvuspeyll16Sp6dntgdmq4xiA4DHxepzezXx0K86lxhrKSvk6qO3yndQeKGwXIwMAAAAyFsynQj57rvvtH//fp0+fVqDBw+WJI0aNUpnzpyRr6+vpd60adNUrFgxeXl5acOGDUpKStLzzz+vChUqaPXq1Vq9erV8fHzUs2dPBQYGWu3j3Llz+vHHH3X69GmVLFlS3bp1U/78+S3rExISNHfuXB06dEiBgYHq3LmzAgMD7xrbH3/8ob/++kuS5O/vr6eeekqtWrWy2mdW403bztfXV3/88YfMZrOef/55lStXLrOnFAAk3UqCDNs9W8Yd5ecTYzVs92x9XKUnyRAAAAAgm2R6aEyRIkXk4eGh/Pnzq3z58ipfvrxcXV3TDY359ddf9fLLL+vdd9+Vs7Ozdu/ererVq6t3794aO3asfH199eeff6pWrVqKj4+3bLdt2zaFhoZqx44dKliwoNatW6eKFSvqxIkTkiTDMNSoUSPNmDFD/v7+OnXqlFq0aKGoqKi7xlaoUCHLcmpqqvr3769XX33V6riyGu+vv/6qwYMHa9CgQXJwcNCBAwdUtWpVbdu2LcsXA4D9MRupmnjo13RJEEmWso8OLWKYDAAAAJBNTIZhZPT9O0Nt2rRR6dKl9cknn1jKOnTooKCgIE2bNk2SFB4erpiYGO3evVuOjo5KSUlRUFCQihYtqq1bt8rBwUGJiYkqVKiQvvzyS3Xq1EmSFBYWphdffFH/+te/LG0///zzcnFx0axZsxQZGalSpUrp7NmzKly4sCQpNjZWZrNZfn5+GcZ2p0OHDqlSpUo6deqUpXdHVuMNDw/Xzp07FRUVJW9vb0lSt27ddO7cOa1duzbD/ScmJioxMdGyHBcXp+DgYMXGxlrasHvJcVL0csnRTXJ0ze1ogBy39XKE+mybcd96X9d4RTX9Sj+EiAAAeAyYEyVzghTYSnLmezSAW7+vfXx8MvX72qY5QjKradOmcnR0vLUDJyeFhISoQYMGcnC41QHF1dVVwcHBOnXqlCQpMjJS+/bt0+7du/Xaa6/JMAwZhqHTp0/r6tWrkqSCBQvKx8dHH330kYYOHaqQkBD5+PjcN5aVK1dq06ZNunjxolJTU2UymSxDa7Iab5rWrVtbneDu3burY8eOSklJkZNT+lM7YcIEvf/++5k9jQDswIXEa9laDwAAAMC9PfDrczPi5uZmtezo6JhhmdlsliRduHBBklSmTBmVLl1aZcqUUdmyZfXcc89p+PDhkiRPT0+tWbNGp0+fVvXq1VWiRAmNGjVKSUlJd42jV69e6tu3r65du6aQkBCVL19eDg4OiouLe6B40xQoUMBqOSAgQCkpKbp06VKG8YwcOVKxsbGWz52JFQD2J8DVK1vrAQAAALg3m3qEmEymHAkirXdGrVq10k1mervq1atr/vz5Sk1N1d9//61nn31Wfn5+ev3119PFdvXqVc2ePVtbtmxRzZo1JUmXL1/WkCFDsi3u06dPWy2fOnVKrq6uCggIyLC+q6urXF0Z7gHgf6rlL6lCrj46nxib4TwhJkmFXH1VLX/Jhx0aAAAAkCfZ1CMkf/78lqEq2Sk4OFh169bV2LFjdePGDUt5bGys5a0vJ0+e1O7duyVJDg4Oql+/vkqWLKnz589nGFtq6q2JBW/evGkpmzx5crbG/dtvv1kmczWbzZo+fbratGljGVIDAPfjaHLQW+U7SLqV9Lhd2vKI8u3laOLfFQAAACA72NQj5Omnn1afPn0k3RqqMmrUqGwL5LvvvlPbtm1VoUIFNWrUSFeuXNGBAwc0ceJESbd6o/Tp00fu7u4qV66cDh8+rFOnTqlfv353ja1Xr17q2LGj2rZtq8jISF24cEEuLi7ZFnPZsmXVoEEDNWjQQPv27VNMTIwlcQMAmRVeKEwfV+mpiYd+1bnEWEt5IVdfjSjfnlfnAgAAANnIprfGSNLOnTu1a9cu3bhxQz169NDGjRvl6empBg0aSJIWLVqkggULqnbt2pZtFi5cqKCgINWqVctS9tNPP6lcuXJ64oknLGVms1nr169XRESEAgMDVbduXfn6+lrWG4ahv//+W0eOHFGhQoXUtGlT5cuX766x+fr6at26dYqIiFCRIkXUvHlzzZo1S82aNVNISMgDxRseHq4aNWpo4MCB2rRpk1JSUtS6dWureO/Hlllt7QZvjYEdMxup2nElUhcSrynA1UvV8pekJwgAABnhrTEA7mDL72ubEyG4JS0RktZjJStIhGSARAgAAADuh0QIgDvY8vuaPzUCAAAAAAC7YdMcIfifIUOGqGDBgrkdBgAAAAAAsAGJkCxq3759bocAAAAAAABsxNAYAAAAAABgN0iEAAAAAAAAu0EiBAAAAAAA2A0SIQAAAAAAwG6QCAEAAAAAAHaDRAgAAAAAALAbJEIAAAAAAIDdIBECAAAAAADsBokQAAAAAABgN0iEAAAAAAAAu0EiBAAAAAAA2A0SIQAAAAAAwG6QCAEAAAAAAHaDRAgAAAAAALAbJEIAAAAAAIDdIBECAAAAAADsBokQAAAAAABgN0iEAAAAAAAAu0EiBAAAAAAA2A0SIQAAAAAAwG6QCAEAAAAAAHaDRAgAAAAAALAbJEIAAAAAAIDdIBECAAAAAADsBokQAAAAAABgN0iEAAAAAAAAu0EiBAAAAAAA2A0SIQAAAAAAwG6QCAEAAAAAAHaDRAgAAAAAALAbTrkdAPCwha0cntsh2L29zSfndggAAAAA7BQ9QgAAAAAAgN0gEQIAAAAAAOwGiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAdsMptwPIiokTJyokJETu7u5avny5goKC9Pbbb+ubb77RmjVrJEn+/v566qmn1LVrV5lMpnTb+vj4aPXq1TKbzXruuedUu3Ztq32sXr1aCxYskLe3t1q1aqWDBw/KxcVFffv2tdSJiorS7Nmzdfr0aZUsWVK9e/dWkSJFHs5JAAAAAAAANnsse4SsXr1aQ4cO1ccff6zKlSurZs2akqRKlSqpZcuWatmypYoVK6bRo0dbJS7Stn311Vf18ccfq1SpUjKbzapfv762bt1qqfPDDz+oVatWcnd3V2BgoAYPHqzRo0frn3/+sdRZv369atSoocuXL6tWrVqKiopSpUqVdPTo0YdzEgAAAAAAgM0eyx4hkuTr66vVq1fL0dHRUlarVi3VqlXLsvzMM8+oVKlSev/99xUcHGwpL1KkiH7//Xc5ONzKAx04cEBz5sxRzZo1lZqaqpEjR2rUqFEaPXq0JKlr164qUaKE1f779eun9957T0OGDJEkvfTSS0pJSdF7772n77//PsOYExMTlZiYaFmOi4t7sJMAAAAAAABs8tgmQpo0aWKVBJEks9msBQsWaNOmTbp48aJSU1Pl4OCgI0eOWCVCGjZsaEmCSFLZsmV15swZSdKpU6d08uRJPfPMM5b1hQoVUp06dSzLR48e1dGjR7VmzRpt375dhmHIMAwdOnRI8fHxd415woQJev/99x/42AEAAAAAQNY8tokQHx+fdGVdunTRnj171LNnT4WFhcnZ2Vnz5s3TtWvXrOrly5fPatnBwUFms1mSdPHiRUlS/vz5rercvnz58mVJUoMGDVSwYEFLefPmzeXp6XnXmEeOHKlhw4ZZluPi4qwSNAAAAAAAIGc9tomQO12+fFkLFizQzp079cQTT0iSzp8/r+TkZJvaKVasmCTpxIkTKlq0qKX85MmT8vX1lSRL8qJ06dJq165dptt2dXWVq6urTfEAAAAAAIDs81hOlpqRtKEuaT06JGns2LE2txMQEKB69erp008/lWEYkqQNGzZYTaYaGBio8PBwvffee7py5YqlPCYmRitWrMjqIQAAAAAAgByWZ3qE+Pr66tVXX1XHjh0VHh6uqKgoubi4ZKkHxueff67w8HBVqVJFQUFBOnjwoEJDQ63mJPn222/17LPPqmzZsqpdu7auXLmis2fP6pNPPsnGowIAAAAAANnpsUyEjBw5Uv7+/unKP/nkE/Xs2VMREREqUqSI6tSpo/nz56tGjRr33LZnz55Wk5w+8cQTOnbsmP744w95eXmpRo0aatu2rQICAix1ihQpoo0bN2rnzp2KiIhQYGCgqlevnm7+EQAAAAAA8OgwGWnjP2Bx+PBheXl5KTAwUJK0adMm1atXT6tWrVLjxo2zbT9xcXHy8fFRbGysvL29s63dx1pynBS9XHJ0kxxzZj6VsJXDc6RdZN7e5pNzOwQAAPA4MydK5gQpsJXkzPdoALb9vn4se4TkNEdHRzVp0kTFixeX2WzW33//reHDh2drEgQAAAAAADx8JEIyULp0ae3cuVObN2/WjRs39NVXX6l48eK5HRYAAAAAAHhAJELuws3NTY0aNcrtMAAAAAAAQDbKM6/PBQAAAAAAuB8SIQAAAAAAwG4wNAZ2hzeWAAAAAID9okcIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7AaJEAAAAAAAYDdIhAAAAAAAALtBIgQAAAAAANgNEiEAAAAAAMBukAgBAAAAAAB2g0QIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7AaJEAAAAAAAYDdIhAAAAAAAALtBIgQAAAAAANgNEiEAAAAAAMBukAgBAAAAAAB2g0QIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7AaJEAAAAAAAYDdIhAAAAAAAALvhlNsBAAAAAACQU8xms5KTk3M7DGQTFxcXOTg8WJ8OEiEAAAAAgDzHMAzFxMTo6tWruR0KspGDg4NCQkLk4uKS5TZIhAAAAAAA8py0JEjBggXl7u4uk8mU2yHhAaWmpio6Olpnz55VsWLFsnxNSYQAAAAAAPIUs9lsSYL4+/vndjjIRgEBAYqOjlZKSoqcnZ2z1AaTpQIAAAAA8pS0OUHc3d1zORJkt7QhMWazOcttkAgBAAAAAORJDIfJXfv378/2NrPjmjI0BgAAAABgH8wJUmoOvEHGwVlydMv+dh8RBw4cUIUKFWxOQlSpUkUpKSk5FFXWkQgBAAAAAOR95gTp7GrJHJ/9bTu6S0XC82wy5IUXXtA///zzQG9qeZQwNAYAAAAAkPelJt9Kgjg43UpYZNfHwelWu5nsaRIXF6eLFy9K+t/QkdTUVB06dMiq3oEDB6yWU1JSFBUVpYSEBKvyffv2SZKuXLmi8+fP6/Tp07py5YpVncOHDyspKSldLOfPn7fEkpKSon379ll6cFy8eFHnz5+XJM2ZM8cyMWna/i5duqRLly7d8/judPPmTZ04cUKpqak2x5CdSIQAAAAAAOyHyVlydM2+jynzby756KOPVLhwYVWvXl29e/dWlSpVJN1KHtSrV89SLyUlRdWqVbMsf//99woKClKLFi1UtGhRTZs2zbIuLCxMvXv3VvXq1fXTTz/p999/15AhQyzrjx07phYtWsjR0TFdPKtWrdLw4cMlSevXr1dYWJg2bNggSRo2bJhWr14tSapWrZoSExMt++vXr59q1Kih4sWL65NPPrnr8d3u008/VUBAgBo0aKCgoCD99ddfNsWQnUiEAAAAAACQw44dO6ZJkybp0KFDOnHihKpWrZqp7U6dOqUxY8Zo4cKFWrhwoX755ReNGTNGsbGxljoNGjRQZGSkhgwZoueff15r167V5cuXJUkzZ87UK6+8kmEipEmTJlqzZo0kac2aNWrfvr0l8bB27Vo1adIkw5gaN26sqKgobdu2TePGjbvv8R07dkzvvfeedu3apRMnTmjChAnq06fPA8XwIB44EXLw4EFFRkZmRywAAAAAAORJ27ZtU6NGjVSsWDFJsiQC7mfz5s26ePGiXnrpJXXt2lWDBg1SkSJFdO7cOUudbt26Wf7b3d1d3bp10+zZs5WUlKSffvpJ/fv3z7DtIkWKyMvLS4cPH9batWv14Ycfau3atTp06JB8fHxUuHDhDLfr0qWLJKl8+fJKSEhQUlLSPY9v+/btqlu3rkqVKiVJevHFF3X69Gldvnw5yzE8CJsmSz1w4IDc3NwUEhJiKRs5cqSCgoKsuubkhoxiQ/ZJTU1VTEyM4uPj5e7ursKFC8vBgQ5FAAAAAJAZHh4eunr1qmX59nk8XFxcrObwuL2eh4eHSpUqpe3bt9+17Xz58lktDxw4UO3atVORIkUUHh4uf3//u27btGlTLViwQMnJyapUqZISExO1YMECNW3a9K7bODn9L5VgMpmUmpp6z+O7c93169eVkpIid3f3LMfwIGz6Jfvmm2/q008/tSqrWLGiJauTmzKKDdkjKipKP/74o5YuXaq1a9dq6dKl+vHHHxUVFZXboQEAAADAY6Fhw4bau3evPv30U/3zzz9W83i4u7srICBAn376qTZt2qShQ4dabRcbG6vXX39dW7Zs0b59+3Tw4MF77qtUqVIqVqyYhg8fbtVWRpo0aaLJkyerYcOGlv1NmTLF5iEp9zq++vXrKyIiQpMmTdKmTZvUv39/tWrVypLAya4YMivTiZCjR4/qypUrio6O1oYNG7RhwwYlJCTohRdeUPv27S319u3bZ5kF9ujRo5ZZcCUpOTlZu3btuucP6LNnz2rbtm0Zzj4r3cqM7dy502rm2LvFduzYMcvywYMHM5wlN6vxpm1nNpt15MiR+96Ij6uoqCitWrVKN27csCq/ceOGVq1aRTIEAAAAwOPFSJbMidn3MTL3thgvLy8tX75cq1at0ujRo9WvXz+r9XPmzNHSpUs1ZswYvfjii6pUqZKkW0mSP//8Uzdv3tSQIUPUtWtX9ezZ07JdWr07vfjiiypVqpQqV658z7gaNWqkokWLqk2bNpKkNm3aqGjRomrUqJHVPtJGBNy5v4oVK8rBwSHD4wsNDZUkeXt7a82aNdq6datee+01FSxYUN9++61NMWQnk2EYRmYqjh8/XpMnT7YafvLDDz9o6NChVkNjwsPDlZqaqsjISPn6+ioqKkoVK1bUmDFjNGDAAPn4+OjYsWNq27atfvjhB0v7165dU8+ePbVu3TqFhITo2LFj6tixo2bOnGl5V/H48eM1fvx4lS1bVufPn1e1atU0Z84cffHFFxnGNm/ePP3666+SpHPnzunq1auaNWuWnn76act+sxpveHi4nJycdOTIEbm7u+vUqVMKCwvTkiVLlD9//kyd/Li4OPn4+Cg2Nlbe3t6Z2uZhSk1N1Y8//pguCXI7Dw8PdevWLfuGySTHSdHL//+rqFyzp00AAADkLeZEyZwgBbaSnB+979HIfTdv3lRUVJRCQkL+N2zEnCCdXX3rVbfZzdFdKhJ+63eMDZycnCyvis0uycnJ2rNnj0aOHKkBAwaoY8eO2dp+bsvw2sq239eZniPk7bff1saNG1W6dGmr1+NkZPv27dqyZYvKlSunU6dOqWzZsurRo4c2b96sUqVK6ejRo6pYsaIGDBig+vXrS5JeeeUVmc1mnTlzRu7u7rpy5YoaNmyoyZMn6+2339b58+f1zjvv6J9//tFTTz0lSfrtt9904cKFu8Y2fPhwy2t4JOnrr79Wr169dPz4cXl4eDxQvNKt1/ysW7dODRo00OXLl9WgQQONGTNGn332WYbnJTEx0fLKIenWhXqUxcTE3DMJIt3qGRITE6PAwMCHFBUAAAAAZIGj261kRWrmenDYxMHZ5iSIJEuPiex04cIF9enTR02aNFGHDh2yvf28IEdmu3z22WdVrlw5SVJwcLAqVqyoLl26WOYSKVOmjEqWLKm9e/dKujWJyty5c9WmTRvt2bNH//zzjw4ePKh69epp2bJlkmTJkt0+vKV169YqXbr0PWNJSkrSkSNHLImSK1euWA1/yUq8aZo3b64GDRpIkvz8/DR8+HDNmjXrrrFMmDBBPj4+lk9wcPA9Y89t8fGZy5Rmth4AAAAA5CpHt1u9iLL7k4UkiCTt2rUre49PUmBgoHbv3q2pU6fKZDJle/t5gU1vjcmsggULWi27ubkpICAgXVnaD+iIiAilpqbqyy+/lLOzs1W9tJ4GgYGBGjt2rFq1aqXQ0FA1btxY3bt3V1hY2F3jWLBggQYOHCgXFxcFBgbK2dlZhmEoJibmgeJNk5Y8uX352rVrunjxogoUKJAunpEjR2rYsGGW5bi4uEc6GZI2g2921QMAAAAAILflSCLEVm5ut7Jn06ZNU82aNe9a791339Xrr7+uv/76S0uWLFH16tW1ePFitWzZMl3d5ORkvfjii5o6dapeeuklSbd6h7i5uSk1NTVb4r5+/brV8rVr12QymeTl5ZVhfVdXV7m6Pj7zXhQuXFgeHh73nSMkJ97rDAAAAABATrBpaIybm5uSk7N/PFWFChVUqFAhfffdd+nWpSUb4uPjLe8mbtmypb744gvVrVtXK1asyDC28+fPKz4+Xo0bN7aUrVixItuSIJK0Zs0amc1mq/ZDQ0Mfq2THvTg4OKhOnTr3rFOnTp3smygVAAAAALJRdv7+w6Mhk+97uSebeoSEhYXpu+++0++//y5PT09Vr179gQOQJEdHR02bNk3PP/+8UlJS9PTTT+vKlSv67bffVKJECX344Yc6fPiw+vTpo379+qlcuXI6dOiQtmzZojfeeCPD2KpVq6Zy5crp1Vdf1auvvqrIyEh98MEH2fqj/dy5c+rUqZP69eunXbt26fPPP9e8efOyrf1HQUhIiJo1a6aNGzda9Qzx8PBQnTp1LG/pAQAAAIBHhYuLixwcHBQdHa2AgAC5uLgwX0YeYBiGLly4IJPJlG5aDVvYlAh5/fXXFR8fr6lTp+rGjRv64YcfVLFiRav5NMLCwlSiRAmr7SpXrqxixYpZlVWtWlVBQUGW5U6dOikkJEQzZ87UlClTFBgYqHbt2um5556z1J8zZ45mzJihRYsWqVChQvrll1/UvHnzu8a2YsUKjR8/Xv/3f/+nIkWKaMGCBXrvvffk7+//wPFK0uDBgxUUFKSvvvpKKSkpmjdvXp6clTckJETFixdXTEyM4uPj5e7ursKFC9MTBAAAAMAjycHBQSEhITp79qyio6NzOxxkI5PJpKCgIDk6Oma9DSM7+pXYofDwcNWoUUMTJ07Mchu2vOfYbiTHSdHLb8267Jg3hhgBAAAgm5kTJXOCFNjq1hs7gLswDEMpKSlWUxrg8ebs7JxhEsSW39ePxGSpAAAAAABkt7QhFA8yjAJ5D2MbsiijITUAAAAAAODRRo+QLJo6deoDt5E2KikuLu6B28ozkuOka/GSQ5JkImsLAACADBjJUmqKFBcn8ZURgP73uzozs3+QCMlF165dkyQFBwfnciQAAAAAADz+rl27Jh8fn3vWYbLUXJSamqro6Gh5eXnxKqeHJC4uTsHBwTp16hQT1OZRXOO8j2uc93GN8z6ucd7G9c37uMZ53+N4jQ3D0LVr1xQYGHjfN5zSIyQXOTg4pHslLx4Ob2/vx+aBRtZwjfM+rnHexzXO+7jGeRvXN+/jGud9j9s1vl9PkDRMlgoAAAAAAOwGiRAAAAAAAGA3SITArri6umrMmDFydXXN7VCQQ7jGeR/XOO/jGud9XOO8jeub93GN8768fo2ZLBUAAAAAANgNeoQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbjjldgBATktISND27dvTlYeFhWX6PdN4NEVGRio6Olq1atWSi4tLhnUiIiIUGxurihUrys3N7SFHiAd15MgRnT9/XnXr1pXJZLJat2vXLl2/ft2qrHDhwipduvTDDBEP4MaNGzp69KgKFiyowMDADOukpqbqwIEDMpvNCg0NlaOj40OOEg/i2rVrioiIUGBgoAoVKpRu/d9//607p6srWbLkXe8HPHri4+N1+PBh+fn5qXjx4hnWSUpK0v79++Xm5qby5cs/5AjxoK5du2b5tzooKMhq3c2bN7Vt27Z024SGhsrX1/chRYjssm3bNqWkpOipp55Kt+769es6dOiQChQooBIlSjz84LIZk6Uizzt06JAqVKigmjVrWv1Y/uSTT1SjRo1cjAxZtXLlSk2aNEk7duzQ5cuXderUqXT/Y7548aLat2+v/fv3KyAgQBcuXNA333yjjh075lLUsMWvv/6qKVOmaP/+/bpy5YoSEhKUL18+qzpPPPGEYmNjVbRoUUtZ27ZtNWLEiIcdLmwUHR2tt956S4sXL1ZISIiOHz+usLAwfffddypWrJil3oEDB9S+fXtdv35djo6OcnR01IIFC/i3+zEQGRmpN998U2vWrFGJEiV07Ngx1a1bV3PmzFGBAgUs9ZycnFS+fHmrH0yvvvqqOnfunAtRwxZxcXEaMWKE5s2bpxIlSujEiRMKDAzUd999p8qVK1vqrVmzRt26dZOnp6fi4uIUFBSkJUuWKDg4OBejR2ZcuHBBw4cP17Jly1S8eHFFRkaqTJkymjt3rkqWLCnp1h+cypQpoxo1ali9XWTKlCl68skncyt0ZMG8efPUrVs3eXl56erVq1brZs2apcGDBysoKEinT59WvXr19PPPP8vT0zN3gs0GJEKQ56UlQjL6sYzH08cff6zQ0FA5OzurSZMmGV7bzp07KzIyUuvXr5eHh4cmT56s0aNH6+jRo1Y/nPFo+vDDD1W/fn2dP39enTt3vmsipEePHho+fHguRYms+ueff3Ts2DF169ZNjo6Ounbtmlq1aiUXFxetXbtW0q2eIJUrV1aFChU0b948mUwm9erVS3/88YeOHDly115geDSsWrVKcXFxeuaZZ2QymXT58mU1atRI5cuX17x58yz1nJyctHTpUrVs2TIXo0VWREREaNOmTZbnOCkpSc8884xiYmIsPQSuXr2qkiVLasCAAfrwww+VlJSk8PBwOTk5WZ51PLp27typqKgodezYUSaTSQkJCWrWrJk8PT31+++/S/pfIiQqKipP9BKwV1FRUapfv746dOig7777zioRcuDAAVWuXFnffPONXnjhBV26dElPPvmkmjdvrn//+9+5F/QDYo4Q2I2oqCjt3LlT165dy+1Q8ICGDRum5s2bpxsqkebKlSv65ZdfNGzYMHl4eEiShg4dKhcXF/34448PM1Rk0TvvvKMGDRrct97Vq1e1detWRUdHP4SokF1q166tHj16WIa5eHl56YUXXtDGjRstwyQ2b96s/fv3691337U866NGjdKJEyf4AfUYaNasmZ599lnLtfPz81OXLl20YcOGdHXPnj2rbdu26dKlSw87TDyA0qVLWz3HLi4uqlu3rs6cOWOp88svv+jGjRuWnnouLi4aMWKE1q1bp+PHj+dG2LBB1apVLclMSXJzc9OTTz5pdY3T8D378ZWSkqJu3brp/fffz3B48ezZsxUcHKwXXnhBkuTv768BAwZozpw5Sk5OftjhZhsSIbAb3bp1U48ePeTv769XXnlFiYmJuR0ScsjevXtlNptVvXp1S5mLi4uqVKminTt35mJkyG6ffPKJ+vfvr/Lly6tWrVo6cOBAboeELNq6datKlixp+cK9c+dOOTk5WXWxL1WqlPz8/HiOH1Nbt27N8Ev28OHD1bdvXxUtWlTt2rXT+fPncyE6ZNXevXv1559/6r///a8+//xzffDBB5Z1O3fuVJkyZeTt7W0pq1WrlmUdHg87d+7UH3/8oWnTpmnOnDkaM2ZMujo9evSwfM9+6aWXlJCQkAuRIiveeecdBQYGqm/fvhmu37lzp9V3aunWc3z9+nVFREQ8jBBzBJOlIs/z9PTU0qVL9fTTT0uSdu/ercaNG8vHx0cfffRRLkeHnHD58mVJtzLWt/P397esw+Pv9ddfV5cuXZQvXz7FxcWpS5cu6tixo/bs2WM1ThmPvhUrVuibb77Rd999Zym7fPmy/Pz80vX84jl+PM2dO1eLFy+2dKdPM336dPXt21cODg46ffq0WrRood69e2vZsmW5FClsNXPmTG3ZskVHjx5VjRo11Lx5c8u6y5cvp/t/sZ+fn2UdHg9Tp07VwYMHdeTIETVt2lT169e3rPPw8NDixYvVtm1bSbcSY40bN5aXl5emTJmSWyEjk1auXKnvv/9eu3fvvmudy5cvKyQkxKos7bl+nJ9jeoQgzwsKCrIkQSSpSpUqGjhwoObOnZuLUSEnOTs7S7o1k/ntEhISmFcgD+nZs6dl3hBvb29NmjRJR44c0Y4dO3I5Mthi06ZN6ty5s0aOHKlu3bpZyp2dndM9wxLP8eNo5cqV6tWrl6ZMmWL1I1mS+vfvLweHW19Hg4KCNGrUKP3222+Ki4vLjVCRBZ9//rk2b96s6Oho+fn5KTw8XCkpKZIyfo7TlnmOHx/ffvuttm7dqjNnzig+Pl5t2rSxrCtSpIglCSLdeivj4MGD+Z79GEhOTtaLL76ofv366eDBg9qwYYOioqJkNpu1YcMGnTt3TlLGz3Faj5/H+TkmEQK7VKhQoQzHNyJvSHt9353X+MyZM1ZvpEDekvZqTp7tx8fmzZvVokULDRw4UOPGjbNaV7x4ccXFxVmNN09KStKFCxd4jh8jq1atUocOHTRu3Di9/vrr962f9hwz78/jJ1++fBoyZIgiIiIs3eWLFy+e4f+LJfEcP4Y8PT01YMAAbdu2TRcvXrxrvUKFCuns2bNKTU19iNHBVikpKSpdurRWr16tt956S2+99ZaWLFmihIQEvfXWW9q6daukvPsckwhBnnfjxo10ZatWrVJoaGguRIOHoWLFigoMDNTixYstZZGRkdq7d6+aNWuWi5Ehu8THx+vOl56tXLlSklSpUqXcCAk22rp1q1q0aKFXXnlFEydOTLe+cePGcnJy0pIlSyxlK1assLx1Ao++NWvWqH379nrvvfcyfLtTRv9/XrlypTw8PHj7xGMgo+sXEREhk8lkGf7SrFkznTlzxqqn3qJFi+Tt7c2rVR8Dd7vGrq6ultem3u05rlixoqW3Fx5Nbm5u2rBhg9Vn6NCh8vT01IYNGyw9f5o1a6YNGzboypUrlm0XLVqksLAwS/L6ccQcIcjzxo4dq0uXLql58+bKly+f5s2bpxUrVmjRokW5HRqy6OTJkzp58qT27t0r6dYPquPHj6tcuXIKCAiQg4ODJkyYoH79+snf318hISEaO3as6tWrZ9WdE4+uY8eO6ezZszp06JAkaePGjXJxcVFoaKh8fX21f/9+vfrqq+rdu7eKFy+uHTt2aPz48erfv78qVKiQy9Hjfvbv36/mzZurZs2aatu2rdWbRJ566ik5OTmpUKFCev311zV06FAlJibK2dlZb775pvr3769SpUrlYvTIjE2bNqldu3Zq3bq16tSpY3WN69WrJ0n6+eef9csvv+jZZ59VQECAVq9erc8++0yTJk1K97psPHr+/e9/a8+ePWrdurX8/f21c+dOTZw4UQMHDlTBggUlSXXr1lXbtm3VrVs3jR07VhcvXtSYMWP04Ycfco0fA+PGjdOlS5cUHh4uHx8fbdq0Sf/3f/+nt956y3L9JkyYoLNnz6pFixZyc3PTzz//rGXLlumXX37J5eiRXXr06KFPPvlE7dq10xtvvKHdu3dr9uzZ+vXXX3M7tAdiMu78kxqQxxiGoR9//FFLlixRXFycypUrp0GDBvFF+jH23//+V7Nnz05XPnr0aKvx54sXL9bs2bMVFxen2rVr61//+pe8vLweZqjIosmTJ2f4P9gpU6ZY/oq4e/duzZw5U0ePHlXRokXVsWNHtWvX7iFHiqxYunRphr1AJGnZsmXy8fGRJKWmpurLL7/UokWLlJqaqtatW2vAgAFycuLvOI+677//XtOnT89w3e1JkdWrV+v777/X2bNnFRISol69etFT4DGyaNEiLViwQOfOnVNQUJA6deqkVq1aWdW5efOmpk6dqnXr1snNzU1du3a1mg8Ijy7DMDR37lwtWbJEly9fVvHixfX888+rYcOGVnV++uknLV68WLGxsSpbtqwGDhyoMmXK5GLkyKr58+fr66+/1vLly63KL1++rIkTJ2r79u3y9/fXyy+/rKZNm+ZSlNmDRAgAAAAAALAbDNwCAAAAAAB2g0QIAAAAAACwGyRCAAAAAACA3SARAgAAAAAA7AaJEAAAAAAAYDdIhAAAAAAAALtBIgQAAAAAANgNEiEAAECStGbNGu3bty+3w8iyy5cva/ny5Zo7d65u3LiR2+EAAIBHlFNuBwAAAB4NY8aMUXh4uEJDQ7O13dWrVyswMFAVK1bM1nZvFxkZqRo1aqhatWoqUKCAmjZtKg8Pjxzbny1u3LihDRs2KCUlRXXq1FH+/PnT1YmOjtaePXvk4OCgunXrZjr2zLSdmTppYmNjtXz5cjVr1kz+/v5W69auXSt3d3f5+flpx44d94yrRYsWlv0kJCRo27ZtunTpkoKCglSxYkW5u7tn6vgAAMgJJEIAAIAk5UgSRJLeffddtWnTJkcTIfPnz1eZMmW0evXqHNtHVmzdulVt2rRRkSJF5O7urn379umHH35QmzZtLHXee+89TZo0SfXq1dO1a9d07Ngx/frrr6pdu/YDt52ZOrc7deqUunXrpn/++SddIuSDDz5QUFCQunfvrl9//dVSvmLFCgUEBKhatWqWslq1ail//vyaPHmyxo4dq5CQEIWEhCg6Olpnz57VsGHD9Nprr9lwJgEAyD4kQgAAyGNWrFihEiVKyN/fX7t27ZLJZFKDBg3k7OysmJgYbdmyRQUKFFDt2rVlMpks29WvX1+FChVK105AQIB27twpJycnPfXUU3J1dbXUWbx4scLCwhQSEmIp++OPP+Tn56fKlSvrr7/+0qVLl7R3717NnTtXkvTMM8/IxcVFZrNZW7Zs0fnz51WmTJkMEyX79+/XsWPHVLx4cVWuXNkq3jRr167Vhg0blJiYqLlz56pAgQIKDw+3xJ8/f35t2bJF+fPnV926dSXJch5cXV1Vp04deXl5Wdq7ceOGlixZojZt2igmJkYHDx5UsWLFVKVKFUnSnj17FBUVpUqVKql06dJ3vQ6pqanq3r27WrVqpVmzZkm6lRTq2bOnjh8/Li8vL/355596//33tXbtWjVu3FiSNGHCBHXt2lURERFydnbOctuZqZMVrVq1UqtWrSzLTzzxhOrVq6dp06ZZ1Rs3bpzGjx+vX3/9Vc2bN7eUx8bGavHixVnaNwAA2cIAAAB5SpUqVYynnnrKKFasmNGmTRujcOHCRpUqVYwvvvjCKFGihNGmTRsjICDAePbZZ622q1u3rjFmzBirdho3bmyULFnSePrpp40SJUoYFStWNOLi4ix1ihYtanzzzTdW7TRt2tQYMWKEYRiG8dFHHxn+/v5GWFiY0aVLF6NLly5GXFycERUVZYSGhhoVKlQw2rZtawQGBhodO3Y0kpKSDMMwjNTUVKNLly5GQECA0a5dO6NatWpGkyZNjGvXrqU73vfff98oV66cUbhwYaNLly7Gu+++a4m/UaNGRvHixY22bdsaU6dONQzDMD7//HPDzc3NaNSokVG1alXDz8/PWLdunaW9qKgoQ5LRsGFDIywszGjVqpXh7OxsDBs2zOjWrZtRpUoVo2XLloarq6sxe/bsu16Hf/75x5Bk7N6921J2/vx5w9HR0Zg7d65hGIYxceJEo0CBAlbbRUREGJKMlStXWsrWrFlj/PXXXza1nZk6d9q7d68hyfjnn3/SrWvYsKHRvXv3dOVVqlQxBg0aZFV2+fJlw83NzXj77bcz3A8AALmJHiEAAORBFy5c0J49e+Tj46PTp08rJCRE06ZN0549e+Tl5aWjR4+qXLly2rFjh9WQhjsdP35c27dvV/78+RUfH68yZcpo1qxZGjJkSKbiePPNN7Vw4UK1adNG7777rqW8WbNmatmypSZNmiTpVi+MJ598Up9++qmGDx+uPXv2aP78+Tpz5owKFy4sSVq/fr0SExPl6elptY/Ro0crLi5O+/bts/Q6SXP48GHt3r1bAQEBkqSIiAgNGzZMc+bMUZcuXSRJQ4cOVe/evXXo0CGr3i5lypTRzJkzZTKZNGPGDA0YMECDBw/Wrl27JEmTJ0/Wu+++qxdffDHDY9+7d69MJpMqVapkKQsICFDhwoW1d+9edenSRYGBgbpy5YrOnz+vggULSpIOHTokSdq9e7eaNWsm6dawFF9fX9WrVy/TbWemTk5Zv369EhIS9Mwzz+TYPgAAyCreGgMAQB7UpUsX+fj4SJKCgoIUFBSkbt26WYZDlClTRv7+/jpy5Mg92+natatl0kt3d3fVqlVLhw8ffqDYDhw4oM2bN6tEiRL6+eefNX/+fC1btkylS5fWunXrJElubm4yDEN79+61bNegQYN081bcT9euXS1JEElasGCBgoODrZIA77zzjo4fP67NmzdbbfvSSy9ZhuKkzdfx0ksvWdbXrl1bp06dUkJCQob7jo2Nlbe3txwdHa3K/f39dfXqVUlSp06dVL58eTVr1kwzZszQpEmT9MYbb8jT01OxsbGWbZo0aaL69evb1HZm6uSUmJgYSVKxYsVydD8AAGQFPUIAAMiD7nwziKura4ZlN2/evGc7fn5+Nm9zP8ePH5ck/fnnn3Jw+N/fZPLly2fpvVC2bFlNnjxZ3bt3l7u7u5o0aaLevXtbJQMyo0iRIlbLJ06cUMmSJa3KChUqJA8PD504ccKq/PbzldZTJKOyxMREubm5pdu3q6trhq/xvX79uvLlyyfpVsJny5Yt+vLLL7V9+3Z5enpq8eLFqlGjhlXPl9GjR9vcdmbq3Ckt8WMYRrp1hmFkOEdLRtISbpcuXbJKRAEA8CggEQIAALLMwcFBqampVmX3S5R4e3tLujWZZtmyZe9aL+3NIrt379bChQvVuHFjrVixQk2bNs10fHf+cC9QoEC6nh+JiYmKj49XgQIFMt1uZpQqVUopKSmKjo5WYGCgJCkpKUkxMTFWyRh3d3cNHTrUsnzgwAFdu3ZNTzzxxAO1ndn93y4tcXThwoV0686fP68nn3wyU8des2ZNSdKmTZtUvnz5TG0DAMDDwtAYAACQZUWLFlVERIRlOe0NMbfz9PS0So7UqFFD/v7+mjFjhlU9wzAUHR0tSbp48aKSkpLk4OCgqlWrauzYsapUqVK6JIat6tWrp927d+vYsWOWsp9//ln58uW751wpWdGgQQN5enpq/vz5lrIlS5bo5s2batmypaXs4sWLVttNmTJFJUuWtEr4pL0Zx5a2M7v/2/n5+alkyZL6/fffrcojIyN19OhR1apVK1PHXqZMGbVt21bvv/++rly5km79yZMnM9UOAAA5gR4hAAAgy1588UW9+eab8vb2lre3t7766iur4S7SrcTHvHnzVKpUKbm5uemZZ57Rl19+qa5du+rs2bNq0qSJLly4oEWLFqlfv37q37+/Dh8+rL59++q5555TqVKltGPHDkVEROjpp59+oHibN2+u1q1bq1mzZnrttdcUGxurjz76SKNGjbJ6dXB28PT01Pjx4/Xmm2/qypUrcnd318SJE/X6669b9cjo0aOHqlWrpjJlymj58uVatWqVVq5cKSen/31Nu3Oy1My0ndn932natGnq1KmTbt68qbp16+rSpUv697//rWbNmunZZ5/N9PF/8803atu2rSpXrqx+/fopJCRE0dHR2rhxoxwdHfXLL7/YekoBAMgWJEIAAMhjWrZsmW44wtNPP51uGEr79u0VEhJiWQ4PD1doaOg926lTp47V/BIDBgyQv7+/1qxZo/z58+s///mPVqxYYfVDe9SoUQoICLC8SeTpp59Whw4dtGfPHn333XfasGGDihUrpunTp1t6ZdStW1crVqzQnDlz9McffygoKEg7d+6861CaqlWrphvaklH80q0JU7/99lv9/fffcnV11U8//WSVYPHw8FCXLl0s81xIt4bzdOnSRe7u7pYyPz8/denSRS4uLhnGJElDhgxRuXLltHDhQqWkpOg///mPOnfubFVn4cKFmj59utavX68nnnhCn332meVNOWmaNGkiDw8Pm9vOTJ07tWrVSvv27dMPP/ygjRs3Kn/+/Jo0aZI6deqU4RwhLVu2VLly5dKV+/v7a8OGDfrtt9+0du1arVmzRkFBQRowYIBatWp1zxgAAMhJJiOj2bAAAAAAAADyIOYIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN0gEQIAAAAAAOwGiRAAAAAAAGA3SIQAAAAAAAC7QSIEAAAAAADYDRIhAAAAAADAbpAIAQAAAAAAdoNECAAAAAAAsBskQgAAAAAAgN0gEQIAAAAAAOzG/wOGu/O69+nfWQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1100x320 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(11, 3.2))\n",
+    "ref = base\n",
+    "ax.axvspan((q_start - ref) / 1e9 / 60, (q_end - ref) / 1e9 / 60,\n",
+    "           color='#ffd27f', alpha=0.55, label='query window')\n",
+    "\n",
+    "for row, (w, s, e, r, h, c) in enumerate(\n",
+    "        zip(ordered, starts, ends, is_range, hits, inside)):\n",
+    "    color = '#2ca02c' if c else ('#ff7f0e' if h else '#999999')\n",
+    "    if r:\n",
+    "        ax.barh(row, (int(e) - int(s)) / 1e9 / 60, left=(int(s) - ref) / 1e9 / 60,\n",
+    "                height=0.45, color=color)\n",
+    "    else:\n",
+    "        ax.plot((int(s) - ref) / 1e9 / 60, row, 'o', color=color)\n",
+    "\n",
+    "ax.set_yticks(range(len(ordered)))\n",
+    "ax.set_yticklabels(['range' if r else 'timestamp' for r in is_range])\n",
+    "ax.set_xlabel('minutes from 09:00 UTC')\n",
+    "ax.set_title('green = contains, orange = overlaps only, grey = neither')\n",
+    "ax.legend(loc='lower right', fontsize=8)\n",
+    "fig.tight_layout(); plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f0e3544",
+   "metadata": {},
+   "source": [
+    "## 5. Round-trip, and where leap seconds live\n",
+    "\n",
+    "`toc2time` → `to_datetime64` closes the loop. A timestamp round-trips\n",
+    "**exactly** (it decodes to `(t, t)`); a range round-trips to its envelope,\n",
+    "which is the conservative answer by construction.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b8c64514",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:48.183370Z",
+     "iopub.status.busy": "2026-08-10T10:49:48.183157Z",
+     "iopub.status.idle": "2026-08-10T10:49:48.190172Z",
+     "shell.execute_reply": "2026-08-10T10:49:48.188776Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "timestamps round-trip exactly through the toc word\n",
+      "merged granule envelope: [2018-06-14T23:59:59.707696128 .. 2018-06-15T06:00:03.393195008)\n"
+     ]
+    }
+   ],
+   "source": [
+    "rt_start, rt_end = mortie.toc2time(words)\n",
+    "assert np.array_equal(rt_start, t_ns) and np.array_equal(rt_end, t_ns)\n",
+    "assert np.array_equal(mortie.to_datetime64(rt_start), utc)\n",
+    "print('timestamps round-trip exactly through the toc word')\n",
+    "\n",
+    "lo_dt, hi_dt = mortie.to_datetime64(lo), mortie.to_datetime64(hi)\n",
+    "print(f'merged granule envelope: [{lo_dt} .. {hi_dt})')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce98d833",
+   "metadata": {},
+   "source": [
+    "Leap seconds are confined to the UTC boundary. The internal scale is\n",
+    "continuous, so an inserted leap second shows up as a **two-second** internal\n",
+    "gap across a UTC step that looks like one second — that is the leap second\n",
+    "being counted, exactly once, in the right place.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c9f5e6c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T10:49:48.192308Z",
+     "iopub.status.busy": "2026-08-10T10:49:48.192086Z",
+     "iopub.status.idle": "2026-08-10T10:49:48.200315Z",
+     "shell.execute_reply": "2026-08-10T10:49:48.198098Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "UTC step of 1 s  ->  internal step of 2 s (the 2016-12-31 leap second)\n",
+      "mid-leap-second internal instant renders as 2017-01-01T00:00:00.500000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "before = int(mortie.from_datetime64('2016-12-31T23:59:59'))\n",
+    "after = int(mortie.from_datetime64('2017-01-01T00:00:00'))\n",
+    "print(f'UTC step of 1 s  ->  internal step of {(after - before) / 1e9:.0f} s '\n",
+    "      '(the 2016-12-31 leap second)')\n",
+    "\n",
+    "# datetime64 cannot name 23:59:60, so an instant *inside* the leap second\n",
+    "# renders into the following UTC second -- documented, and one-way.\n",
+    "mid = before + 1_500_000_000\n",
+    "print(f'mid-leap-second internal instant renders as {mortie.to_datetime64(mid)}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05d54a68",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- **The API is flat on the package.** `mortie.time2toc`, `span2toc`,\n",
+    "  `toc2time`, `toc_merge`, `toc_reduce`, `toc_is_range`, `toc_overlaps`,\n",
+    "  `toc_contains`, `from_datetime64`, `to_datetime64`, `from_gps_ns`,\n",
+    "  `to_gps_ns`; the constants live on the module (`mortie.toc.Q_START_NS`,\n",
+    "  `Q_END_NS`, `TOC_MAX_NS`, `GPS_EPOCH_NS`). Rendered reference:\n",
+    "  [docs/api/toc.md](../docs/api/toc.md).\n",
+    "- **Range ends are exclusive.** `toc2time` returns a half-open envelope; a\n",
+    "  timestamp returns `(t, t)`, the one closed case.\n",
+    "- **Ceiling.** Both encoders reject times at or past `TOC_MAX_NS`\n",
+    "  (~4.3 s short of the year-2142 span ceiling) so that every encodable word is\n",
+    "  mergeable — a timestamp in that final window would overflow the end field on\n",
+    "  its first merge.\n",
+    "- **Pre-1972 UTC** uses a zero-offset proleptic convention (naive day-count\n",
+    "  seconds), which is what pins the epoch identity\n",
+    "  `from_datetime64('1850-01-01') == 0`; conversion is exact and invertible\n",
+    "  from 1972 on. See the `from_datetime64` docstring.\n",
+    "- **Not an IVOA T-MOC**, and the interval-set algebra over collections of\n",
+    "  words (unions of disjoint ranges, ragged per-cell temporal covers) is\n",
+    "  deferred to [#177](https://github.com/espg/mortie/issues/177) — this\n",
+    "  notebook is the flat-array elementwise surface only.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/toc_temporal_coverage.ipynb
+++ b/examples/toc_temporal_coverage.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "758979c2",
+   "id": "0275750b",
    "metadata": {},
    "source": [
     "# toc words: temporal order coverage\n",
@@ -40,19 +40,20 @@
     "\n",
     "All data here is synthetic — nothing is downloaded — so the notebook is\n",
     "[runnable on Binder](https://mybinder.org/v2/gh/espg/mortie/HEAD?labpath=examples%2Ftoc_temporal_coverage.ipynb) as-is (see `binder/` for the\n",
-    "repo2docker config). Only `numpy`, `matplotlib` and `mortie` are imported.\n"
+    "repo2docker config). The only third-party imports are `numpy`, `matplotlib`\n",
+    "and `mortie` itself.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "0c40eb7e",
+   "id": "9440f2b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:46.848471Z",
-     "iopub.status.busy": "2026-08-10T10:49:46.848263Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.653608Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.652650Z"
+     "iopub.execute_input": "2026-08-10T10:52:47.711103Z",
+     "iopub.status.busy": "2026-08-10T10:52:47.710737Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.427749Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.427049Z"
     }
    },
    "outputs": [
@@ -80,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50b2f710",
+   "id": "d56afb06",
    "metadata": {},
    "source": [
     "## The internal timescale\n",
@@ -102,13 +103,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "56ad4e76",
+   "id": "aa8a95d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.657512Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.657145Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.664910Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.663142Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.430165Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.429881Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.436007Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.435050Z"
     }
    },
    "outputs": [
@@ -134,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "996a0ac1",
+   "id": "068892e1",
    "metadata": {},
    "source": [
     "## 1. Encoding instants — `time2toc`\n",
@@ -147,13 +148,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "adde0f06",
+   "id": "e478607d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.667718Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.667388Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.677262Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.675894Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.438128Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.437919Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.445002Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.444095Z"
     }
    },
    "outputs": [
@@ -187,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72a9e8dc",
+   "id": "b024048d",
    "metadata": {},
    "source": [
     "The first row is one of the type's **golden fixtures** (pinned in the test\n",
@@ -200,13 +201,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "77a28264",
+   "id": "78dd0dcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.679416Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.679178Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.684957Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.683650Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.446816Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.446636Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.451584Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.450743Z"
     }
    },
    "outputs": [
@@ -226,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1074f49",
+   "id": "29c1804b",
    "metadata": {},
    "source": [
     "### The GPS path\n",
@@ -251,13 +252,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c167cb81",
+   "id": "ff940e07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.687115Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.686865Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.701936Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.700615Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.453260Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.453117Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.459758Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.458784Z"
     }
    },
    "outputs": [
@@ -293,7 +294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "851cad93",
+   "id": "2a1f4666",
    "metadata": {},
    "source": [
     "## 2. The dual type — exact leaves, conservative ranges\n",
@@ -308,13 +309,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "c7b9b851",
+   "id": "ca4969ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.705473Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.705155Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.713955Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.712725Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.461968Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.461121Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.467718Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.466807Z"
     }
    },
    "outputs": [
@@ -349,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08e8ca97",
+   "id": "763ed17d",
    "metadata": {},
    "source": [
     "The bound is absolute, not relative: **at most one 2^31 ns quantum of slack at\n",
@@ -361,13 +362,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "047d6b78",
+   "id": "beed11cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.716436Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.716183Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.933288Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.932026Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.469400Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.469120Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.668994Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.667686Z"
     }
    },
    "outputs": [
@@ -407,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01fc367d",
+   "id": "7dbe7db9",
    "metadata": {},
    "source": [
     "### Merge: where the dual type earns its keep\n",
@@ -421,13 +422,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4150d8d4",
+   "id": "ddbdbfaa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.935477Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.935291Z",
-     "iopub.status.idle": "2026-08-10T10:49:47.952279Z",
-     "shell.execute_reply": "2026-08-10T10:49:47.951051Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.671171Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.670955Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.689729Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.688520Z"
     }
    },
    "outputs": [
@@ -466,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a81d461",
+   "id": "43965ae5",
    "metadata": {},
    "source": [
     "Two laws make that reduction safe to run anywhere — in parallel, out of order,\n",
@@ -482,13 +483,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1ca6be3d",
+   "id": "d45df948",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:47.954332Z",
-     "iopub.status.busy": "2026-08-10T10:49:47.954101Z",
-     "iopub.status.idle": "2026-08-10T10:49:48.005967Z",
-     "shell.execute_reply": "2026-08-10T10:49:48.005171Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.691856Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.691642Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.742167Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.740942Z"
     }
    },
    "outputs": [
@@ -519,7 +520,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e96e9316",
+   "id": "fac1d15e",
    "metadata": {},
    "source": [
     "## 3. Sorting — one `np.sort`, no comparator\n",
@@ -533,13 +534,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "69cf6d4d",
+   "id": "9b5665f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:48.008024Z",
-     "iopub.status.busy": "2026-08-10T10:49:48.007568Z",
-     "iopub.status.idle": "2026-08-10T10:49:48.015555Z",
-     "shell.execute_reply": "2026-08-10T10:49:48.014779Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.744275Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.744067Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.752845Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.752244Z"
     }
    },
    "outputs": [
@@ -585,7 +586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93957040",
+   "id": "9c79a17c",
    "metadata": {},
    "source": [
     "## 4. Window queries — `toc_overlaps` and `toc_contains`\n",
@@ -605,13 +606,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "8585b3b9",
+   "id": "7ba9d7a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:48.017241Z",
-     "iopub.status.busy": "2026-08-10T10:49:48.017073Z",
-     "iopub.status.idle": "2026-08-10T10:49:48.022127Z",
-     "shell.execute_reply": "2026-08-10T10:49:48.021445Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.754634Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.754437Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.758921Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.758338Z"
     }
    },
    "outputs": [
@@ -645,14 +646,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1da4b66f",
+   "id": "95da298a",
    "metadata": {},
    "source": [
     "### Seeing the quantum at a window edge\n",
     "\n",
-    "Both edge behaviours are constructible on purpose. Snap the window to the\n",
-    "quantum grid — `q_start` onto the 2^31 grid, `q_end` one nanosecond past a\n",
-    "2^32 grid line — and:\n",
+    "Both edge behaviours are constructible on purpose. The snapping below is what\n",
+    "makes them *reproducible* rather than lucky: whether a given window edge shows\n",
+    "the quantum depends on where it falls against the grid, so `q_start` is floored\n",
+    "onto the 2^31 grid and `q_end` is put one nanosecond past a 2^32 grid line.\n",
+    "Then:\n",
     "\n",
     "1. a range whose real interval ends *just inside* the window still has its\n",
     "   envelope end ceil past `q_end`, so `contains` is `False` (under-report);\n",
@@ -663,13 +666,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "db914f13",
+   "id": "8880057d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:48.023725Z",
-     "iopub.status.busy": "2026-08-10T10:49:48.023483Z",
-     "iopub.status.idle": "2026-08-10T10:49:48.033309Z",
-     "shell.execute_reply": "2026-08-10T10:49:48.032261Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.760632Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.760434Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.765534Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.765056Z"
     }
    },
    "outputs": [
@@ -712,13 +715,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "439d943b",
+   "id": "a7aee902",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:48.035788Z",
-     "iopub.status.busy": "2026-08-10T10:49:48.035597Z",
-     "iopub.status.idle": "2026-08-10T10:49:48.181098Z",
-     "shell.execute_reply": "2026-08-10T10:49:48.179752Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.767209Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.766904Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.899784Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.898627Z"
     }
    },
    "outputs": [
@@ -758,7 +761,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f0e3544",
+   "id": "5eb2f3e9",
    "metadata": {},
    "source": [
     "## 5. Round-trip, and where leap seconds live\n",
@@ -771,13 +774,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b8c64514",
+   "id": "2be6d993",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:48.183370Z",
-     "iopub.status.busy": "2026-08-10T10:49:48.183157Z",
-     "iopub.status.idle": "2026-08-10T10:49:48.190172Z",
-     "shell.execute_reply": "2026-08-10T10:49:48.188776Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.901896Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.901698Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.908241Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.907013Z"
     }
    },
    "outputs": [
@@ -802,7 +805,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce98d833",
+   "id": "76bd660e",
    "metadata": {},
    "source": [
     "Leap seconds are confined to the UTC boundary. The internal scale is\n",
@@ -814,13 +817,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "c9f5e6c7",
+   "id": "d35a2fc9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T10:49:48.192308Z",
-     "iopub.status.busy": "2026-08-10T10:49:48.192086Z",
-     "iopub.status.idle": "2026-08-10T10:49:48.200315Z",
-     "shell.execute_reply": "2026-08-10T10:49:48.198098Z"
+     "iopub.execute_input": "2026-08-10T10:52:48.910200Z",
+     "iopub.status.busy": "2026-08-10T10:52:48.909988Z",
+     "iopub.status.idle": "2026-08-10T10:52:48.915629Z",
+     "shell.execute_reply": "2026-08-10T10:52:48.914528Z"
     }
    },
    "outputs": [
@@ -847,7 +850,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05d54a68",
+   "id": "0f1196af",
    "metadata": {},
    "source": [
     "## Notes\n",

--- a/mortie/tests/test_example_notebooks.py
+++ b/mortie/tests/test_example_notebooks.py
@@ -1,0 +1,52 @@
+"""Drift pin for the example notebooks' Binder launch links (issue #180).
+
+CLAUDE.md requires every notebook under ``examples/`` to be runnable on Binder
+*and* to carry an explicit launch link in the rendered notebook.  The link
+embeds the notebook's own path (``?labpath=examples%2F<name>.ipynb``), so a
+rename breaks the launch **silently**: the badge still renders, the URL still
+resolves, and Binder builds the image and lands on a missing file.  Nothing
+else in the repo reads that path, so this test is the only thing tying it to
+the filename.
+
+Deliberately not checked: that the notebook executes.  Running the notebooks
+would need a runner dependency and a workflow change (see the PR thread on
+issue #180); this file pins only what is cheap and static.
+"""
+
+import json
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "examples"
+BINDER_PREFIX = "https://mybinder.org/v2/gh/espg/mortie/HEAD?labpath="
+
+
+def first_markdown_source(path):
+    """The source text of a notebook's first cell, which must be markdown."""
+    nb = json.loads(path.read_text())
+    assert nb["nbformat"] == 4, f"{path.name}: expected nbformat 4"
+    cell = nb["cells"][0]
+    assert cell["cell_type"] == "markdown", (
+        f"{path.name}: first cell is {cell['cell_type']}, so the Binder link "
+        "is not the first thing a reader sees"
+    )
+    return "".join(cell["source"])
+
+
+def test_example_notebooks_found():
+    # Guards the parametrize below: an empty glob would skip every case
+    # silently instead of failing (mirrors test_docs_api_pages.py).
+    assert sorted(EXAMPLES_DIR.glob("*.ipynb")), (
+        f"no notebooks found under {EXAMPLES_DIR}")
+
+
+@pytest.mark.parametrize("notebook", sorted(EXAMPLES_DIR.glob("*.ipynb")),
+                         ids=lambda p: p.name)
+def test_binder_link_targets_the_notebook_itself(notebook):
+    expected = BINDER_PREFIX + quote(f"examples/{notebook.name}", safe="")
+    assert expected in first_markdown_source(notebook), (
+        f"{notebook.name}: intro cell has no Binder launch link for itself; "
+        f"expected {expected}"
+    )


### PR DESCRIPTION
Closes #180

## What this is

`examples/toc_temporal_coverage.ipynb` — the binder-runnable example notebook for the toc word (`mortie/toc.py`), deferred out of PR #178 by the [scope ruling](https://github.com/espg/mortie/issues/175#issuecomment-5230097527).

It walks the type end-to-end on **synthetic data only** — nothing is downloaded, nothing is read from the tree — so the Binder launch works as-is against the pinned wheel in `binder/postBuild`. Imports are `numpy`, `matplotlib`, `mortie` (plus stdlib `functools`): all already in the `examples` extra and the `binder/environment.yml` image, so no new dependency.

Structure follows `examples/morton_set_algebra.ipynb` (the other synthetic, dependency-light notebook): Binder badge as the first thing in the first markdown cell, a second in-prose "runnable on Binder" link, narrative markdown between short code cells, a closing **Notes** section. Sections, per the issue's content list:

1. **Encode** — `from_datetime64` → `time2toc`, the golden fixture from PR #178 asserted inline (2018-01-01T00:00:00 UTC = internal ns 5,301,590,418,000,000,000 → `0x932610CAE9813400`), then the GPS path with an ICESat-2-flavored `delta_time` + `atlas_sdp_gps_epoch` ingest through `from_gps_ns` (adding the epoch in integer ns, since `(epoch + delta) * 1e9` in float64 loses hundreds of ns at that magnitude).
2. **The dual type under merge** — `span2toc` and the outward-rounded envelope, the ~2.15 s start / ~4.29 s end quantization shown as absolute slack against a five-minute segment and then against a 6-hour, 200k-timestamp granule reduced to one word (0.017% wide); idempotence and fold-tree independence asserted.
3. **The sort property** — timestamps and ranges in one array, plain `np.sort`, chronological interleave, no comparator.
4. **Window queries** — `toc_overlaps` / `toc_contains` with the error directions stated (overlaps never under-reports, contains never over-reports), then both edge behaviours *constructed on purpose* by snapping the window to the quantum grid (`q_end` one ns past a 2^32 grid line).
5. **Round-trip** — `toc2time` → `to_datetime64` exact for timestamps, plus the leap-second note: the 2016-12-31 leap second shows as a two-second internal gap across a one-second UTC step, and a mid-leap-second instant rendering into the following UTC second.

Two small matplotlib figures (envelope-vs-real timeline; window predicate colouring). Every cell carries its executed output.

Wiring, matching how the existing notebooks are wired (Binder badge in-notebook; the notebooks are not in the mkdocs nav today): a short **Example notebooks** section in `README.md`, and a worked-example pointer at the top of `docs/api/toc.md`. Both notebook links from the docs page are absolute GitHub/Binder URLs — `mkdocs.yml` sets `strict: true`, and a relative link from `docs/` to a file outside `docs/` fails that build.

Plus a drift pin, `mortie/tests/test_example_notebooks.py`: the Binder launch URL embeds the notebook's own path (`?labpath=examples%2F<name>.ipynb`), so a rename breaks the launch silently — badge still renders, Binder still builds, lands on a missing file. The test asserts, for every notebook in `examples/`, that the first cell is markdown and contains the launch link for itself. Same shape as `mortie/tests/test_docs_api_pages.py`, and it pins all seven notebooks, not just the new one.

## Phases

- [x] Phase 1 — the notebook: authored, executed clean top to bottom against the locally built extension.
- [x] Phase 2 — wiring: the Binder-link drift pin, the README section, and the `docs/api/toc.md` pointer; phase-1 self-review findings folded in.
- [x] Phase 3 — phase-2 self-review finding folded in (`blob/main` → `blob/HEAD`); final green run of the full gate.

## Testing

Built and run in an isolated venv in the worktree (Python 3.11.15): `maturin develop --release`, then

```
jupyter nbconvert --execute --to notebook --inplace examples/toc_temporal_coverage.ipynb
```

executes all 15 code cells with no error and no cell failure — the committed notebook is that executed output, not a hand-written one, and it was re-executed after every prose edit. Several cells are self-checking (`assert` on the golden fixture, the epoch identity, fold-tree independence, sort monotonicity, the two window-edge predicates), so a regression in the toc path fails the notebook rather than silently changing a printed number. Inputs are literals and a seeded `np.random.default_rng(0)`, so the outputs are reproducible.

Repo gate, all clean: `flake8 mortie --select=E9,F63,F7,F82`; the style pass at `--max-line-length=88` on the new test; `numpydoc lint mortie/*.py`; `pytest -q` → **1442 passed, 16 skipped** in 238 s. No Rust changed, so `cargo test` / `cargo clippy` were not exercised. Nothing pre-existing was skipped or worked around.

The nbconvert / matplotlib / ipykernel tooling used to execute it is already declared in the `examples` extra of `pyproject.toml` (`jupyterlab`, `notebook`, `ipykernel`, `matplotlib`) and in `binder/environment.yml`; nothing was added.

## Questions for review

- **Should notebook execution be enforced in CI?** Right now nothing runs the notebooks — a change to `mortie/toc.py` can silently break this one, and the asserts only bite when someone runs it. Enforcing it would mean adding `nbmake` (or an nbconvert step) as a dependency plus a workflow edit, both of which need sign-off (§4, and workflows are out of scope for this issue). Left as-is; flagging so the choice is explicit. Options: (1) leave it manual, (2) add a `pytest --nbmake` job over `examples/*.ipynb` with `nbmake` in the `test` extra, (3) run only the synthetic, download-free notebooks (this one and `morton_set_algebra`) in CI and skip the data-fetching ones.
- **Notebook placement in the docs.** The example notebooks are not in the mkdocs nav today (no nbconvert / mkdocs-jupyter in the docs group), so "wired into the docs the same way the existing ones are" was read as the Binder badge plus in-repo links, and that is what landed. Say the word if you'd rather the notebooks render on the docs site — that is a new docs dependency and a nav change.
- **Synthetic data only.** The issue's content list called for it and it keeps the Binder image small, but the other geo notebooks all show real data. If you want a real-data leg (e.g. ATL03 `delta_time` from an actual granule via `earthaccess`), that is a different notebook shape and I'd rather not fold it in silently.
