### PR TITLE
small fixes: fold the standing #185 review threads

### DIFF
--- a/benchmarks/measure_batch_coverage.py
+++ b/benchmarks/measure_batch_coverage.py
@@ -7,13 +7,23 @@ loop over ``morton_coverage_moc`` against one ``polygons_to_morton_mocs``
 call on N synthetic ~1 degree granule-footprint quads.
 
 Run:
-    python benchmarks/measure_batch_coverage.py [N] [order]
+    python benchmarks/measure_batch_coverage.py [N] [order]      # timing sweep
+    python benchmarks/measure_batch_coverage.py --mem N [order]  # peak-memory case
 
 Defaults: N=100_000 footprints, order=8.
+
+``--mem`` re-runs the memory table quoted in
+:func:`mortie.batch.polygons_to_morton_mocs` and in ``coverage::batch``'s
+module docs, which the timing arm left as a claim on trust (issue #162
+adversarial review).  It reports **input, result and peak**, since the peak is
+``input copy + result + one chunk`` and quoting it against the result alone
+omits the binding's ``to_vec()`` of the vertex arrays.
 """
 
 import os
+import resource
 import sys
+import threading
 import time
 
 import numpy as np
@@ -35,8 +45,70 @@ def footprints(n, rng):
     return lats, lons, offsets
 
 
+def rss_mb():
+    """Current resident set size in MiB, or None where it is unreadable.
+
+    ``/proc/self/statm`` field 2 is resident pages -- *current* residency, so
+    sampling it across a call gives the call's true peak.  Only Linux has it;
+    elsewhere the caller falls back to the ``ru_maxrss`` watermark, which is a
+    lower bound (it reads as no growth whenever an earlier phase out-peaked
+    the call).
+    """
+    try:
+        with open("/proc/self/statm") as fh:
+            return int(fh.read().split()[1]) * os.sysconf("SC_PAGE_SIZE") / 2 ** 20
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def watermark_mb():
+    """Peak-RSS high-water mark so far, in MiB (Linux reports KiB, macOS bytes)."""
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return peak / 2 ** 20 if sys.platform == "darwin" else peak / 1024
+
+
+def mem_case(n, order):
+    """Peak of one ``polygons_to_morton_mocs`` call against input and result."""
+    rng = np.random.default_rng(153)
+    lats, lons, offsets = footprints(n, rng)
+    in_mb = (lats.nbytes + lons.nbytes + offsets.nbytes) / 2 ** 20
+
+    sampled = rss_mb()
+    stop = threading.Event()
+    peak = [sampled] if sampled is not None else []
+
+    def sample():
+        while not stop.wait(0.002):
+            peak.append(rss_mb())
+
+    base = sampled if sampled is not None else watermark_mb()
+    sampler = threading.Thread(target=sample, daemon=True)
+    if sampled is not None:
+        sampler.start()
+    values, out = mortie.polygons_to_morton_mocs(lats, lons, offsets, order=order)
+    stop.set()
+    if sampled is not None:
+        sampler.join()
+        top = max(peak)
+        how = "statm sampled"
+    else:
+        top = watermark_mb()
+        how = "ru_maxrss watermark (lower bound; no /proc/self/statm)"
+
+    out_mb = (values.nbytes + out.nbytes) / 2 ** 20
+    growth = top - base
+    print(f"n={n} order={order} cells={len(values)}  [{how}]")
+    print(f"input  : {in_mb:8.1f} MiB   result: {out_mb:8.1f} MiB")
+    print(f"peak   : {growth:8.1f} MiB   = {growth / out_mb:5.2f}x the result "
+          f"alone, {growth / (in_mb + out_mb):5.2f}x of input + result")
+
+
 def main():
-    """Time the scalar loop vs the batch call and print the comparison."""
+    """Time the scalar loop vs the batch call, or run the one --mem case."""
+    if len(sys.argv) > 2 and sys.argv[1] == "--mem":
+        mem_case(int(sys.argv[2]),
+                 int(sys.argv[3]) if len(sys.argv) > 3 else 8)
+        return
     n = int(sys.argv[1]) if len(sys.argv) > 1 else 100_000
     order = int(sys.argv[2]) if len(sys.argv) > 2 else 8
     rng = np.random.default_rng(153)

--- a/mortie/batch.py
+++ b/mortie/batch.py
@@ -65,7 +65,9 @@ def polygons_to_morton_mocs(lats, lons, offsets, order=18, tolerance=None,
     non-contiguous slice — adds the conversion's own copy on top, so hand it
     contiguous ``float64``/``int64`` arrays to pay the copy only once.
     Measured on a cold call over synthetic ~1 degree footprints at order 8,
-    sampling ``/proc/self/statm`` while the call runs: 100k footprints is
+    sampling ``/proc/self/statm`` while the call runs
+    (``benchmarks/measure_batch_coverage.py --mem``, which re-runs this table):
+    100k footprints is
     6.9 MiB of input and a 12.9 MiB result behind a 21.9 MiB peak, and 555,867
     (the ATL03 catalog scale) is 38.2 MiB of input and a 71.6 MiB result behind
     a 112.0 MiB peak — **1.70x and 1.56x the result alone**, but 1.11x and

--- a/src_rust/src/coverage/batch.rs
+++ b/src_rust/src/coverage/batch.rs
@@ -24,7 +24,8 @@
 //! `lons` and `offsets` are each copied whole before the GIL is released and
 //! stay resident for the call.  Nothing short of giving up the GIL release
 //! removes it — it is a floor, not an inefficiency.  Measured on a cold call
-//! over synthetic ~1° footprints at order 8: 100k is 6.9 MiB of input and a
+//! over synthetic ~1° footprints at order 8 (`benchmarks/measure_batch_coverage.py
+//! --mem`, which re-runs this table): 100k is 6.9 MiB of input and a
 //! 12.9 MiB result behind a 21.9 MiB peak, and 555,867 (catalog scale) is
 //! 38.2 MiB of input and a 71.6 MiB result behind a 112.0 MiB peak — 1.70x and
 //! 1.56x the *result alone*, but 1.11x and 1.02x of `input + result`.  Those

--- a/src_rust/src/moc/batch.rs
+++ b/src_rust/src/moc/batch.rs
@@ -124,6 +124,11 @@ fn validate_batch(
             ));
         }
         if let Some(budget) = max_cells {
+            // `run_moc`'s `?` is the live arm (a malformed word).  The inner
+            // one is defence in depth: `to_order_count` fails only on an
+            // out-of-range `order`, refused by the check opening this function
+            // — prefixed anyway so both spellings of this call keep the
+            // documented per-MOC contract (issue #162 review).
             let estimated = run_moc(i, || to_order_count(&values[s as usize..e as usize], order))?
                 .map_err(|msg| format!("moc {i}: {msg}"))?;
             if estimated > budget {
@@ -270,6 +275,9 @@ pub fn mocs_to_orders(
             .into_par_iter()
             .map(|i| {
                 let (s, e) = (offsets[i] as usize, offsets[i + 1] as usize);
+                // Same two arms as the estimate above: the panic is live, the
+                // inner `Err` is defence in depth against a future caller that
+                // reaches this kernel without `validate_batch`'s order check.
                 run_moc(i, || to_order(&values[s..e], order))?
                     .map_err(|msg| format!("moc {i}: {msg}"))
             })


### PR DESCRIPTION
Folds the last standing adversarial-review threads from PR #185, which was rebase-merged before they were addressed. espg ruled in session (2026-08-16) that they be folded rather than left standing, so they land here on a fresh branch off `main`.

Refs #185 (the originating threads):
- https://github.com/espg/mortie/pull/185#discussion_r3749046199 — unreachable `map_err` arm + `|e|` shadowing in `moc::batch`
- https://github.com/espg/mortie/pull/185#discussion_r3749047866 — `coverage::batch` doc accuracy (misattached parenthetical, stale `CHUNK` peak claim)
- https://github.com/espg/mortie/pull/185#discussion_r3749049206 — the same parenthetical mirrored in `mortie/batch.py`, the conversion-copy floor, and the missing `--mem` harness

Refs #161, Refs #162.

### Phases

- [x] **Name the defence-in-depth `order` arms** (`3d95c6f`) — the review's live half of r3749046199.
- [x] **Give the batch-coverage memory table a `--mem` harness** (`fb4e175`) — the live half of r3749049206.
- [x] Verify the rest of those threads against post-merge `main` — see "Already folded" below.

### What changed

**1. `3d95c6f` — defence-in-depth arms named.** `mocs_to_orders` has two `map_err(|msg| format!("moc {i}: {msg}"))` arms, at `validate_batch`'s budget estimate and in the parallel pass. Both are unreachable: the only `Err` `to_order` / `to_order_count` return is an out-of-range `order`, and `validate_batch` opens by refusing `!(0..=29).contains(&order)`. They are kept as defence in depth against a future caller that reaches a kernel without that check, which is not something the next reader can tell from the code — so each now says so in a comment, pointing at the live arm (`run_moc`'s `?`, a malformed word) next to it. Comment-only; no behavior change.

**2. `fb4e175` — the memory table is re-runnable.** `polygons_to_morton_mocs`' docstring and `coverage::batch`'s module header quote a measured table (100k footprints → 6.9 MiB input, 12.9 MiB result, 21.9 MiB peak; 555,867 → 38.2 / 71.6 / 112.0), and `benchmarks/measure_batch_coverage.py` was timing-only, so the numbers rested on trust — unlike `mocs_and`, which cites `benchmarks/measure_mocs_and.py --mem`. That script now takes `--mem N [order]` and reports input, result and peak, plus both ratios, because the peak is `input copy + result + one chunk` and quoting it against the result alone omits the binding's `to_vec()`.

It samples `/proc/self/statm` while the call runs — the method the docstring names, and a true peak rather than a watermark — falling back to the `ru_maxrss` high-water mark where `/proc` is absent, with the fallback named in the output so a lower bound is never mistaken for a peak:

```
$ python benchmarks/measure_batch_coverage.py --mem 20000 8
n=20000 order=8 cells=318029  [ru_maxrss watermark (lower bound; no /proc/self/statm)]
input  :      1.4 MiB   result:      2.6 MiB
peak   :      6.3 MiB   =  2.43x the result alone,  1.59x of input + result
```

Both docs now cite the harness at the table.

### Already folded — verified, no change needed

Checked each remaining claim against post-merge `main` rather than against the thread text, since `1d7a412` ("fold review: stale CHUNK peak claim, conversion-copy floor, run_moc serial gap") landed between the review and the merge:

- **`|e|` shadowing** (r3749046199 point 2) — already `|msg|` at both call sites in `1d7a412`.
- **Misattached parenthetical** (r3749047866 point 1, mirrored in r3749049206) — the header now reads "Those ratios stay near 1 because this path has no coarsen direction that can shrink the result to nothing — `crate::moc::batch`'s densify does, and reaches 60x there"; the clauses attach to *here*, as the review asked.
- **Stale `CHUNK` peak claim** (r3749047866 point 2) — now "~1.1x of `input + result` (the module header's model; that sweep quoted it against the result alone, which omits the input copy)". The arithmetic checks: 21.9 / (6.9 + 12.9) = 1.11.
- **Conversion-copy floor** (r3749049206) — the docstring already calls the second resident copy a floor and names `float32` / lists / non-contiguous slices as adding another on top.

### Testing

- `cargo fmt --check` clean; `cargo clippy --all-targets` reports nothing on either touched Rust file; `cargo test --lib` 374 passed / 0 failed / 1 ignored.
- `pytest mortie/tests` 1492 passed / 40 skipped / 0 failed.
- `flake8 mortie --select=E9,F63,F7,F82` clean; `flake8 benchmarks/measure_batch_coverage.py --max-line-length=88` clean.
- `benchmarks/measure_batch_coverage.py --mem 20000 8` run end to end (output above).

### Questions for review

- The `--mem` case was verified only on its **macOS fallback path** — this machine has no `/proc/self/statm`, so the statm sampler that reproduces the documented numbers is exercised by construction, not by a run. Worth one Linux run before trusting the table's reproducibility end to end.
- The `--mem` addition answers a review ask for a harness rather than a defect. If it reads as scope creep for a small-fixes PR, `fb4e175` can be dropped on its own and the two doc citations reverted with it.
