### PR TITLE
Segmented toc reduce: tocs_reduce (issue #177 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `toc_reduce`: ragged `(words, offsets)` in arrow list layout in, one merged
   `uint64` out per group, GIL released and rayon across groups. Result `i` is
   bit-identical to `toc_reduce` on group `i` alone — same semilattice join,
-  same instant preservation, same fold-tree independence. An **empty group is
+  same instant preservation, same fold-tree independence — over
+  encoder-produced words, the scope `toc_merge` already carries (an arbitrary
+  bit pattern is garbage in, garbage out, and the two fold trees may then
+  differ, each deterministically). An **empty group is
   an error**, not an empty slot (the merge has no identity element), and
   layout failures name the offending group. The consumer is a per-cell
   temporal fold (englacial/zagg#410). The interval-set algebra of issue #177

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Segmented toc reduce: `tocs_reduce`** (issue #177)
+  ([#192](https://github.com/espg/mortie/pull/192)). The ragged sibling of
+  `toc_reduce`: ragged `(words, offsets)` in arrow list layout in, one merged
+  `uint64` out per group, GIL released and rayon across groups. Result `i` is
+  bit-identical to `toc_reduce` on group `i` alone — same semilattice join,
+  same instant preservation, same fold-tree independence. An **empty group is
+  an error**, not an empty slot (the merge has no identity element), and
+  layout failures name the offending group. The consumer is a per-cell
+  temporal fold (englacial/zagg#410). The interval-set algebra of issue #177
+  (`normalize` / union / intersect / minus) remains deferred.
+
 ## [0.9.8] - 2026-08-16
 
 - Authalic latitude convention: new default latitude="authalic" (issue #186) ([#188](https://github.com/espg/mortie/pull/188)) by @espg

--- a/docs/api/toc.md
+++ b/docs/api/toc.md
@@ -6,10 +6,13 @@ as a plain unsigned integer and closed under a semilattice merge. Times are
 ns since 1850-01-01 on a continuous, leap-free, GPS-aligned scale; the
 `datetime64` / GPS converters are the only place leap seconds exist. Not an
 IVOA T-MOC. These flat-array elementwise ops are the type's scalar surface
-(the same relationship [mortie.moc](moc.md) has to its ops over one cover);
-the ragged many-cover plurals land in [mortie.batch](batch.md) when the
-interval-set algebra (issue #177) activates. The names stay flat on the
-package (`mortie.time2toc`, ...).
+(the same relationship [mortie.moc](moc.md) has to its ops over one cover),
+plus one ragged operator — `tocs_reduce`, the segmented sibling of
+`toc_reduce` (issue #177), kept here because it folds the word type itself
+rather than operating over covers. The many-*cover* plurals still land in
+[mortie.batch](batch.md), and wait on the interval-set algebra, which stays
+deferred for want of a consumer. The names stay flat on the package
+(`mortie.time2toc`, ...).
 
 Worked example:
 [examples/toc_temporal_coverage.ipynb](https://github.com/espg/mortie/blob/HEAD/examples/toc_temporal_coverage.ipynb)
@@ -26,6 +29,7 @@ boundary, and the UTC/GPS round-trip
         - toc2time
         - toc_merge
         - toc_reduce
+        - tocs_reduce
         - toc_is_range
         - toc_overlaps
         - toc_contains

--- a/mortie/__init__.py
+++ b/mortie/__init__.py
@@ -123,6 +123,7 @@ from .toc import (
     toc_merge,
     toc_overlaps,
     toc_reduce,
+    tocs_reduce,
 )
 
 __all__ = [
@@ -197,6 +198,7 @@ __all__ = [
     'toc_is_range',
     'toc_overlaps',
     'toc_contains',
+    'tocs_reduce',
     'from_datetime64',
     'to_datetime64',
     'from_gps_ns',

--- a/mortie/tests/test_toc.py
+++ b/mortie/tests/test_toc.py
@@ -315,8 +315,15 @@ def test_tocs_reduce_arbitrary_bit_patterns_do_not_panic():
     Unlike a morton word there is no malformed toc word -- the merge only
     shifts and compares, so every bit pattern decodes (the module docstring's
     "garbage in, garbage out").  What the batch must still guarantee is the
-    issue #185 posture: junk cannot take the process down, and the segmented
-    answer stays the scalar's.
+    issue #185 posture: junk cannot take the process down, and the answer is
+    the sequential in-group fold.
+
+    Parity with :func:`toc_reduce` is deliberately *not* asserted here: the
+    merge is associative over encoder-produced words only, so on junk the two
+    fold trees may legitimately differ (pinned in
+    :func:`test_tocs_reduce_junk_fold_is_tree_dependent`).  The oracle is the
+    same one the cargo twin uses -- a sequential fold of the reference merge
+    (``arbitrary_bit_patterns_fold_without_panicking``, src_rust/src/toc.rs).
     """
     rng = np.random.default_rng(1772)
     junk = rng.integers(0, 1 << 63, size=64, dtype=np.uint64) * np.uint64(2)
@@ -324,7 +331,29 @@ def test_tocs_reduce_arbitrary_bit_patterns_do_not_panic():
     offsets = np.arange(0, 65, 8, dtype=np.int64)
     got = tocs_reduce(junk, offsets)
     for i in range(8):
-        assert int(got[i]) == toc_reduce(junk[8 * i:8 * (i + 1)]), f"group {i}"
+        expected = reduce(py_merge, (int(w) for w in junk[8 * i:8 * (i + 1)]))
+        assert int(got[i]) == expected, f"group {i}"
+
+
+def test_tocs_reduce_junk_fold_is_tree_dependent():
+    """Out-of-domain words can merge onto the flag bit, so the tree matters.
+
+    ``merge``'s associativity is a *valid-word* property (see its doc comment
+    in src_rust/src/toc.rs): an out-of-domain "timestamp" of ``2**64 - 1``
+    decodes to an end code of ``2**31``, and the merged word carries that
+    **on** the timestamp flag, so it re-reads as a timestamp and the answer
+    stops being fold-tree independent.  Junk still gets the two guarantees
+    that are promised -- no panic, and a deterministic answer from each entry
+    point -- but only the segmented form is pinned to the sequential fold.
+    """
+    junk = np.array([0, 1, 1, 1, 1, 1, 1, 2 ** 64 - 1], dtype=np.uint64)
+    sequential = reduce(py_merge, (int(w) for w in junk))
+    assert sequential & FLAG          # merged onto the timestamp flag
+    for _ in range(3):
+        assert int(tocs_reduce(junk, [0, junk.size])[0]) == sequential
+    # toc_reduce splits this group its own way; whatever tree it picks, the
+    # answer is stable -- it just need not be ``sequential``.
+    assert toc_reduce(junk) == toc_reduce(junk)
 
 
 def test_tocs_reduce_offsets_guards():

--- a/mortie/tests/test_toc.py
+++ b/mortie/tests/test_toc.py
@@ -379,6 +379,26 @@ def test_tocs_reduce_offsets_guards():
         tocs_reduce(np.array([-1, 2]), [0, 2])
 
 
+def test_tocs_reduce_uint64_offsets_out_of_int64_range():
+    """A uint64 offset the int64 cast cannot hold is named, not wrapped.
+
+    ``uint64`` offsets are the natural output of ``np.cumsum`` over unsigned
+    counts, and anything at or above ``2**63`` wraps negative on the cast.
+    That failed closed only by accident -- every wrapped value is negative, so
+    the ``offsets[0] == 0`` pin tripped the monotonicity check -- with a
+    message describing the wrapped copy rather than the offset passed in.
+    """
+    words = time2toc(np.array([1, 2, 3, 4], dtype=np.uint64))
+    with pytest.raises(ValueError, match=r"must fit in int64, got 9223372036854775813"):
+        tocs_reduce(words, np.array([0, 2 ** 63 + 5], dtype=np.uint64))
+    # In-range uint64 offsets stay accepted -- this is a range check, not a
+    # rejection of the dtype cumsum hands you.
+    offsets = np.array([0, 2, 4], dtype=np.uint64)
+    np.testing.assert_array_equal(
+        tocs_reduce(words, offsets),
+        [toc_reduce(words[:2]), toc_reduce(words[2:])])
+
+
 def test_tocs_reduce_lowest_index_offender_across_the_chunk_seam():
     """The named group is the lowest-index offender, wherever it sits.
 

--- a/mortie/tests/test_toc.py
+++ b/mortie/tests/test_toc.py
@@ -28,10 +28,15 @@ from mortie.toc import (
     toc_merge,
     toc_overlaps,
     toc_reduce,
+    tocs_reduce,
 )
 
 FLAG = 1 << 31
 LOW_MASK = FLAG - 1
+
+# The Rust batch steps through 2048 groups at a time, so offenders are placed
+# either side of that seam rather than at arbitrary indices.
+CHUNK = 2048
 
 
 def py_timestamp(t):
@@ -183,6 +188,236 @@ def test_merged_envelope_contains_inputs():
     assert (fs <= starts).all()
     assert (ends[is_rng] <= fe).all()
     assert (starts[~is_rng] < fe).all()
+
+
+# ── segmented reduce (issue #177) ───────────────────────────────────────
+
+
+def py_codes(w):
+    """Reference conservative (start_code, end_code) of a word."""
+    if w & FLAG:                      # timestamp
+        return w >> 32, (w >> 33) + 1
+    return w >> 32, w & LOW_MASK      # range: codes verbatim
+
+
+def py_merge(a, b):
+    """Reference semilattice join: equal words unchanged, else min/max."""
+    if a == b:
+        return a
+    (sa, ea), (sb, eb) = py_codes(a), py_codes(b)
+    return (min(sa, sb) << 32) | max(ea, eb)
+
+
+def ragged(groups):
+    """Concatenate word groups into (words, offsets) arrow list layout."""
+    words = np.concatenate([np.asarray(g, dtype=np.uint64) for g in groups]
+                           or [np.empty(0, np.uint64)])
+    offsets = np.zeros(len(groups) + 1, dtype=np.int64)
+    offsets[1:] = np.cumsum([len(g) for g in groups])
+    return words, offsets
+
+
+def random_groups(rng, n, size=(1, 9)):
+    """*n* groups of 1-8 mixed timestamp/range words."""
+    sizes = rng.integers(*size, size=n)
+    flat = rand_words(rng, int(sizes.sum()))
+    cuts = np.cumsum(sizes)[:-1]
+    return np.split(flat, cuts)
+
+
+def test_tocs_reduce_parity_with_a_scalar_loop():
+    """Group i is bit-identical to toc_reduce on that group alone.
+
+    Swept past the 2048-group chunk seam so the parallel path is exercised,
+    not just the first chunk.
+    """
+    rng = np.random.default_rng(177)
+    groups = random_groups(rng, CHUNK + 137)
+    got = tocs_reduce(*ragged(groups))
+    assert got.dtype == np.uint64 and got.shape == (len(groups),)
+    for i, g in enumerate(groups):
+        assert int(got[i]) == toc_reduce(g), f"group {i}"
+
+
+def test_tocs_reduce_property_against_a_python_reference():
+    """Randomized groups match a pure-Python fold of the reference merge."""
+    rng = np.random.default_rng(1770)
+    groups = random_groups(rng, 400, size=(1, 20))
+    got = tocs_reduce(*ragged(groups))
+    for i, g in enumerate(groups):
+        expected = reduce(py_merge, (int(w) for w in g))
+        assert int(got[i]) == expected, f"group {i}"
+
+
+def test_tocs_reduce_permutation_invariant_within_a_group():
+    """The join is commutative and associative, so group order cannot matter."""
+    rng = np.random.default_rng(1771)
+    groups = random_groups(rng, 300, size=(2, 12))
+    reference = tocs_reduce(*ragged(groups))
+    shuffled = [rng.permutation(g) for g in groups]
+    np.testing.assert_array_equal(tocs_reduce(*ragged(shuffled)), reference)
+    np.testing.assert_array_equal(
+        tocs_reduce(*ragged([g[::-1].copy() for g in groups])), reference)
+
+
+def test_tocs_reduce_preserves_instants_per_group():
+    """A group of bitwise-equal timestamps stays that timestamp.
+
+    The load-bearing case of the merge, per group: it must not collapse to
+    the pair's range envelope.  A group of one comes back verbatim.
+    """
+    t = time2toc(123_456_789_012)
+    groups = [[t], [t] * 17, [t] * 3]
+    got = tocs_reduce(*ragged(groups))
+    assert (got == t).all()
+    assert not toc_is_range(got).any()
+
+
+def test_tocs_reduce_mixed_instant_and_range_groups():
+    """Instant-only, range-only and mixed groups in one call, each parity-checked."""
+    t0, t1 = time2toc(10 * Q_END_NS), time2toc(11 * Q_END_NS)
+    r0 = span2toc(3 * Q_END_NS, 5 * Q_END_NS)
+    r1 = span2toc(20 * Q_END_NS, 21 * Q_END_NS)
+    groups = [[t0], [t0, t1], [r0, r1], [t0, r0], [r0, t1, r1, t0]]
+    got = tocs_reduce(*ragged(groups))
+    for i, g in enumerate(groups):
+        assert int(got[i]) == toc_reduce(np.asarray(g, np.uint64)), f"group {i}"
+    # Only the singleton keeps the timestamp flag; every unequal pair merges
+    # to a range word.
+    np.testing.assert_array_equal(toc_is_range(got),
+                                  [False, True, True, True, True])
+
+
+def test_tocs_reduce_empty_segment_is_a_catchable_named_error():
+    """An empty group refuses, names itself, and survives ``except Exception``.
+
+    The merge has no identity element, so many->one over no words has no
+    answer -- :func:`toc_reduce`'s ruling, inherited.  Asserted through the
+    handler shape a consumer actually writes, not only ``pytest.raises``: the
+    PR #160 / issue #185 lesson is that a ``pyo3_runtime.PanicException``
+    derives from ``BaseException`` and escapes even ``except Exception``.
+    """
+    words = time2toc(np.array([1, 2, 3], dtype=np.uint64))
+    with pytest.raises(ValueError, match=r"group 1: .*empty segment"):
+        tocs_reduce(words, [0, 1, 1, 3])
+    caught = None
+    try:
+        tocs_reduce(words, [0, 1, 1, 3])
+    except Exception as exc:      # must not escape as PanicException
+        caught = exc
+    assert isinstance(caught, ValueError)
+    assert "group 1" in str(caught) and "identity element" in str(caught)
+
+
+def test_tocs_reduce_arbitrary_bit_patterns_do_not_panic():
+    """Junk words are garbage-in-garbage-out, never an uncatchable panic.
+
+    Unlike a morton word there is no malformed toc word -- the merge only
+    shifts and compares, so every bit pattern decodes (the module docstring's
+    "garbage in, garbage out").  What the batch must still guarantee is the
+    issue #185 posture: junk cannot take the process down, and the segmented
+    answer stays the scalar's.
+    """
+    rng = np.random.default_rng(1772)
+    junk = rng.integers(0, 1 << 63, size=64, dtype=np.uint64) * np.uint64(2)
+    junk[:4] = [0, 1, np.uint64((1 << 64) - 1), FLAG]
+    offsets = np.arange(0, 65, 8, dtype=np.int64)
+    got = tocs_reduce(junk, offsets)
+    for i in range(8):
+        assert int(got[i]) == toc_reduce(junk[8 * i:8 * (i + 1)]), f"group {i}"
+
+
+def test_tocs_reduce_offsets_guards():
+    """Layout failures are catchable ValueErrors naming the group or endpoint."""
+    words = time2toc(np.array([1, 2, 3], dtype=np.uint64))
+    with pytest.raises(ValueError, match=r"group 1: .*monotonically"):
+        tocs_reduce(words, [0, 3, 1])
+    with pytest.raises(ValueError, match=r"group 1: offset 99 exceeds"):
+        tocs_reduce(words, [0, 1, 99])
+    with pytest.raises(ValueError, match="must start at 0"):
+        tocs_reduce(words, [1, 3])
+    with pytest.raises(ValueError, match="must end at the word count"):
+        tocs_reduce(words, [0, 2])
+    with pytest.raises(ValueError, match="at least one element"):
+        tocs_reduce(words, np.empty(0, dtype=np.int64))
+    # Offsets are integer-typed by the same rule words are: a float array
+    # would otherwise cast silently, truncating a boundary rather than saying so.
+    with pytest.raises(ValueError, match="offsets must be integer-typed"):
+        tocs_reduce(words, [0.0, 1.5, 3.0])
+    with pytest.raises(ValueError, match="words must be integer-typed"):
+        tocs_reduce(np.array([1.5, 2.5]), [0, 2])
+    with pytest.raises(ValueError, match="words must be non-negative"):
+        tocs_reduce(np.array([-1, 2]), [0, 2])
+
+
+def test_tocs_reduce_lowest_index_offender_across_the_chunk_seam():
+    """The named group is the lowest-index offender, wherever it sits.
+
+    Collapsing ``offsets[i + 1]`` onto ``offsets[i]`` empties group ``i`` and
+    hands its word to group ``i + 1``, so the layout stays exactly covering
+    and only the empty-group refusal is under test.  rayon may finish any
+    group first; the reported index must still be the lowest offender, so the
+    calls are repeated.
+    """
+    n = 2 * CHUNK
+    words = time2toc(np.arange(n, dtype=np.uint64) * np.uint64(10**9))
+    offsets = np.arange(n + 1, dtype=np.int64)
+    offenders = [7, CHUNK - 1, CHUNK + 3]
+    for i in offenders:
+        offsets[i + 1] = offsets[i]
+    for k, expect in enumerate(offenders):
+        for _ in range(3):
+            with pytest.raises(ValueError, match=rf"group {expect}: "):
+                tocs_reduce(words, offsets)
+        offsets[expect + 1] = expect + 1       # heal the lowest survivor
+    assert len(tocs_reduce(words, offsets)) == n
+
+
+def test_tocs_reduce_empty_batch_and_group_of_one():
+    got = tocs_reduce(np.empty(0, dtype=np.uint64), [0])
+    assert got.shape == (0,) and got.dtype == np.uint64
+    words = rand_words(np.random.default_rng(1773), 500)
+    # Every group a singleton: each word comes back verbatim.
+    np.testing.assert_array_equal(
+        tocs_reduce(words, np.arange(len(words) + 1, dtype=np.int64)), words)
+
+
+def test_tocs_reduce_deterministic_across_runs():
+    rng = np.random.default_rng(1774)
+    args = ragged(random_groups(rng, 5000))
+    first = tocs_reduce(*args)
+    for _ in range(9):
+        np.testing.assert_array_equal(tocs_reduce(*args), first)
+
+
+def test_tocs_reduce_consumer_shape_per_cell_fold():
+    """The zagg#410 consumer shape: a per-cell fold equals the scalar loop.
+
+    GEDI shot pooling -- many shots' instants folding into one word per cell --
+    and the ATL03 overview cascade, where a level's per-cell words are folded
+    again into the coarser level (envelope of envelopes).  The cascade is the
+    stronger claim: folding twice must equal folding the leaves once, which is
+    the merge's associativity carried through the segmented form.
+    """
+    rng = np.random.default_rng(410)
+    shots = rand_words(rng, 4096)
+    # Unique cut points: zagg's fold sites never present an empty cell (they
+    # short-circuit before the fold), which is why the empty segment refuses.
+    per_cell = np.unique(rng.integers(1, len(shots), size=255))
+    cell_offsets = np.concatenate([[0], per_cell, [len(shots)]]).astype(np.int64)
+    cells = tocs_reduce(shots, cell_offsets)
+    # Scalar loop equivalence, the thing the batch replaces.
+    loop = [toc_reduce(shots[a:b])
+            for a, b in zip(cell_offsets[:-1], cell_offsets[1:])]
+    np.testing.assert_array_equal(cells, np.asarray(loop, dtype=np.uint64))
+    # One pyramid level up: 4 cells per parent, envelope of envelopes.
+    parents = np.arange(0, len(cells) + 1, 4, dtype=np.int64)
+    if parents[-1] != len(cells):
+        parents = np.append(parents, len(cells))
+    up = tocs_reduce(cells, parents)
+    direct = [toc_reduce(shots[cell_offsets[a]:cell_offsets[b]])
+              for a, b in zip(parents[:-1], parents[1:])]
+    np.testing.assert_array_equal(up, np.asarray(direct, dtype=np.uint64))
 
 
 # ── sort property ───────────────────────────────────────────────────────

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -74,13 +74,21 @@ def _as_offsets(offsets):
 
     Integer-typed by the same rule :func:`_as_u64` applies to words: a float
     offset array would otherwise cast silently, truncating ``2.9`` to a group
-    boundary at 2 rather than saying so.  Range and monotonicity are the Rust
-    validator's job -- it names the offending group.
+    boundary at 2 rather than saying so.  The same standard rules out the
+    ``uint64`` values the cast cannot represent -- at or above ``2**63`` they
+    would wrap negative, and the Rust validator would then describe the
+    wrapped copy rather than the offset that was passed.  Monotonicity and
+    bounds stay the Rust validator's job -- it names the offending group.
     """
     arr = np.atleast_1d(np.asarray(offsets))
     if arr.dtype.kind not in "iu":
         raise ValueError(
             f"offsets must be integer-typed, got dtype {arr.dtype}")
+    if arr.dtype.kind == "u" and arr.size:
+        too_big = arr > np.iinfo(np.int64).max
+        if too_big.any():
+            raise ValueError(
+                f"offsets must fit in int64, got {int(arr[too_big][0])}")
     return np.ascontiguousarray(arr.astype(np.int64).ravel())
 
 

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -33,9 +33,12 @@ recommendation (different epoch, timescale, and cell model -- see the
 T-MOC research on zagg#410 for why the hierarchical cell was rejected).
 
 These flat-array elementwise ops are the type's scalar surface, mirroring
-the relationship :mod:`mortie.moc` has to its ops over one cover; the
-ragged many-cover plurals land in :mod:`mortie.batch` when the interval-set
-algebra (issue #177) activates.
+the relationship :mod:`mortie.moc` has to its ops over one cover.
+:func:`tocs_reduce` is the one ragged operator here: the segmented sibling
+of :func:`toc_reduce`, kept beside its scalar because it is a fold over the
+word type itself rather than an op over covers (issue #177).  The
+many-*cover* plurals still land in :mod:`mortie.batch`, and wait on the
+interval-set algebra, which stays deferred for want of a consumer.
 """
 
 import operator
@@ -64,6 +67,21 @@ def _as_u64(values, name):
     if arr.dtype.kind == "i" and arr.size and np.any(arr < 0):
         raise ValueError(f"{name} must be non-negative")
     return arr.astype(np.uint64)
+
+
+def _as_offsets(offsets):
+    """Validate arrow list offsets and return them as contiguous int64.
+
+    Integer-typed by the same rule :func:`_as_u64` applies to words: a float
+    offset array would otherwise cast silently, truncating ``2.9`` to a group
+    boundary at 2 rather than saying so.  Range and monotonicity are the Rust
+    validator's job -- it names the offending group.
+    """
+    arr = np.atleast_1d(np.asarray(offsets))
+    if arr.dtype.kind not in "iu":
+        raise ValueError(
+            f"offsets must be integer-typed, got dtype {arr.dtype}")
+    return np.ascontiguousarray(arr.astype(np.int64).ravel())
 
 
 def _as_scalar_ns(value, name):
@@ -230,6 +248,7 @@ def toc_merge(a, b):
     See Also
     --------
     toc_reduce : merge a whole array to one word.
+    tocs_reduce : the segmented form, one word per group.
     """
     is_scalar = np.isscalar(a) and np.isscalar(b)
     wa, wb = np.broadcast_arrays(_as_u64(a, "a"), _as_u64(b, "b"))
@@ -267,9 +286,84 @@ def toc_reduce(words):
     See Also
     --------
     toc_merge : the elementwise pairwise form.
+    tocs_reduce : the segmented form, one word per group.
     """
     w = _as_u64(words, "words")
     return int(_rustie.rust_toc_reduce(np.ascontiguousarray(w.ravel())))
+
+
+def tocs_reduce(words, offsets):
+    """Merge each group of toc words down to one word, in one call.
+
+    The **segmented** sibling of :func:`toc_reduce` (issue #177), named in the
+    batch family's plural convention (``mocs_and``, ``mocs_to_orders``): the
+    whole ragged group set crosses the Python/Rust boundary once, the GIL is
+    released for the batch, and Rust parallelizes across groups.  Result ``i``
+    is bit-identical to ``toc_reduce(words[offsets[i]:offsets[i + 1]])`` — same
+    join, same instant preservation (a group of bitwise-equal timestamps comes
+    back as that timestamp, not as its range envelope), same fold-tree
+    independence.
+
+    Input is ragged in the arrow list layout the batch family uses; the
+    **output is dense** — one ``uint64`` per group — because the reduction is
+    many→one per group, so there are no output offsets to carry.  The consumer
+    this exists for is a per-cell fold: zagg's GEDI shot pooling and its ATL03
+    overview envelopes-of-envelopes both run the scalar reduce once per cell
+    (`zagg#410 <https://github.com/englacial/zagg/issues/410>`_), which is the
+    Python loop this call replaces.
+
+    Parameters
+    ----------
+    words : array-like
+        Flat toc words (``uint64``), all groups concatenated.
+    offsets : array-like
+        ``int64`` arrow list offsets: group ``i`` spans
+        ``[offsets[i], offsets[i + 1])``, so there are ``len(offsets) - 1``
+        groups.  The offsets must **exactly cover** ``words`` --
+        ``offsets[0] == 0`` and ``offsets[-1] == len(words)`` -- so a sliced
+        arrow array must be re-based before it gets here; anything else is an
+        error naming the endpoint that failed.  An **empty group is an
+        error**, not an empty slot: the merge has no identity element, so
+        many→one over no words has no answer, exactly as :func:`toc_reduce`
+        refuses an empty array.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``uint64`` array of ``len(offsets) - 1`` merged words, one per group.
+
+    Raises
+    ------
+    ValueError
+        Fail-fast, naming the offending group (e.g. ``group 4217:
+        tocs_reduce of an empty segment ...``): an empty group, or a *layout*
+        failure -- non-monotone / out-of-bounds offsets, or offsets that do not
+        exactly cover ``words`` (the message names which endpoint failed).
+        Also if ``words`` is negative or non-integer-typed.  The index named
+        is the lowest-index offender **within its pass**: layout is checked for
+        the whole batch first, so a layout failure at a high index is reported
+        ahead of an empty group at a low one -- deliberate, since the group
+        indices an empty-group error is reported *by* are read out of
+        ``offsets``.
+
+    See Also
+    --------
+    toc_reduce : the whole-array (one group) form.
+    toc_merge : the elementwise pairwise join both reduce with.
+
+    Examples
+    --------
+    Two cells' shot times fold to one word each:
+
+    >>> import mortie, numpy as np
+    >>> w = mortie.time2toc(np.array([10, 20, 30, 40], dtype=np.uint64) * 10**9)
+    >>> got = mortie.tocs_reduce(w, [0, 3, 4])
+    >>> int(got[0]) == mortie.toc_reduce(w[:3]) and int(got[1]) == int(w[3])
+    True
+    """
+    w = _as_u64(words, "words")
+    return np.asarray(_rustie.rust_tocs_reduce(
+        np.ascontiguousarray(w.ravel()), _as_offsets(offsets)))
 
 
 def toc_is_range(words):

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -264,8 +264,11 @@ def toc_reduce(words):
     """Merge an array of toc words down to one word.
 
     The fold tree is unspecified (parallel under the hood) -- safe because
-    the merge is exactly associative, commutative, and idempotent, so
-    every fold tree produces the identical ``uint64``.
+    the merge is exactly associative, commutative, and idempotent over
+    encoder-produced words, so every fold tree produces the identical
+    ``uint64``.  Arbitrary bit patterns are garbage in, garbage out (see
+    :func:`toc_merge`): each fold tree still answers deterministically, but
+    the trees need not agree with one another.
 
     Parameters
     ----------
@@ -302,7 +305,11 @@ def tocs_reduce(words, offsets):
     is bit-identical to ``toc_reduce(words[offsets[i]:offsets[i + 1]])`` — same
     join, same instant preservation (a group of bitwise-equal timestamps comes
     back as that timestamp, not as its range envelope), same fold-tree
-    independence.
+    independence.  That identity is a guarantee over **encoder-produced**
+    words, the scope :func:`toc_merge` carries: an out-of-domain "timestamp"
+    can merge to a word with the timestamp flag set, and past that point the
+    two functions' fold trees may disagree — each deterministic, neither
+    wrong, since junk in is junk out.
 
     Input is ragged in the arrow list layout the batch family uses; the
     **output is dense** — one ``uint64`` per group — because the reduction is

--- a/src_rust/src/lib.rs
+++ b/src_rust/src/lib.rs
@@ -1960,6 +1960,7 @@ fn _rustie(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(toc::rust_toc2time, m)?)?;
     m.add_function(wrap_pyfunction!(toc::rust_toc_merge, m)?)?;
     m.add_function(wrap_pyfunction!(toc::rust_toc_reduce, m)?)?;
+    m.add_function(wrap_pyfunction!(toc::rust_tocs_reduce, m)?)?;
     m.add_function(wrap_pyfunction!(toc::rust_toc_is_range, m)?)?;
     m.add_function(wrap_pyfunction!(toc::rust_toc_window, m)?)?;
     m.add_function(wrap_pyfunction!(rust_wkb_rings, m)?)?;

--- a/src_rust/src/toc.rs
+++ b/src_rust/src/toc.rs
@@ -42,6 +42,7 @@ use numpy::{IntoPyArray, PyArrayMethods, PyReadonlyArray1};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// Discriminator bit position: 1 = timestamp, 0 = range.
 pub const FLAG_BIT: u32 = 31;
@@ -296,6 +297,158 @@ pub fn rust_toc_reduce(py: Python<'_>, words: PyReadonlyArray1<u64>) -> PyResult
         ));
     }
     Ok(py.allow_threads(|| data.par_iter().copied().reduce(|| data[0], merge)))
+}
+
+// ---------------------------------------------------------------------------
+// Segmented reduce (issue #177). The ragged sibling of `rust_toc_reduce`:
+// group `i` is `words[offsets[i]..offsets[i + 1]]` in the arrow list layout the
+// batch family uses, one reduced word out per group.  Consumers are zagg's
+// per-cell folds (englacial/zagg#410) — GEDI shot pooling and ATL03 overview
+// envelopes-of-envelopes — where the scalar reduce runs once per cell.
+// ---------------------------------------------------------------------------
+
+/// Groups reduced per parallel chunk.
+///
+/// Same value and same reason as [`crate::moc::batch`]'s: the batch runs chunk
+/// by chunk so only one chunk's per-group outcomes are ever resident, and 2048
+/// is large enough that the per-chunk fork-join is noise against the work.
+const CHUNK: usize = 2048;
+
+/// Validate a ragged arrow list layout over `n_words` words.
+///
+/// Checks, in order: a non-empty `offsets` starting at 0, then per group
+/// (lowest index first) offset monotonicity and bounds, and finally the
+/// endpoint requirement `offsets[n_groups] == n_words`.  The offsets must
+/// **exactly cover** the word array — both endpoints are checked and each names
+/// which one failed — so stale or misaligned offsets that happen to stay in
+/// bounds cannot silently reduce a valid-looking wrong set.  This is the same
+/// offsets contract, and the same lowest-index rule, that
+/// [`crate::decimal_morton::batch`] enforces for `common_ancestors`; the two are
+/// not folded into one helper because they live in unrelated modules and the
+/// duplication is a dozen lines of message text, not logic worth a callback.
+fn validate_ragged(n_words: usize, offsets: &[i64]) -> Result<usize, String> {
+    if offsets.is_empty() {
+        return Err("offsets must have at least one element".to_string());
+    }
+    if offsets[0] != 0 {
+        return Err(format!("offsets must start at 0, got {}", offsets[0]));
+    }
+    let n_groups = offsets.len() - 1;
+    for i in 0..n_groups {
+        let (s, e) = (offsets[i], offsets[i + 1]);
+        if e < s {
+            return Err(format!(
+                "group {i}: offsets must be monotonically non-decreasing ({e} < {s})"
+            ));
+        }
+        if e as usize > n_words {
+            return Err(format!(
+                "group {i}: offset {e} exceeds word array length {n_words}"
+            ));
+        }
+    }
+    // Exact coverage: the last offset must land on the end of the word array.
+    // Checked after the per-group pass so an out-of-bounds group is still
+    // reported by index (the lowest-index rule).
+    if offsets[n_groups] as usize != n_words {
+        return Err(format!(
+            "offsets must end at the word count: offsets[{n_groups}] is {} but \
+             words has {n_words} entries",
+            offsets[n_groups]
+        ));
+    }
+    Ok(n_groups)
+}
+
+/// Run one group's fold, turning a panic into a group-named error.
+///
+/// The capture is **defensive rather than load-bearing**: [`merge`] is total
+/// over arbitrary bit patterns (garbage in, garbage out — it only shifts and
+/// compares), so no word a caller can pass makes the fold panic today.  It is
+/// here because the issue #161 / #185 lesson is about the *posture*: a kernel
+/// that gains a `debug_assert`, a slice index, or an arithmetic edge later must
+/// surface as a catchable `ValueError` naming the group, never as a
+/// `pyo3_runtime.PanicException` — which derives from `BaseException` and
+/// escapes even `except Exception`.  Pinned by an injected panicking kernel in
+/// the tests below, the way [`crate::moc::batch`]'s `run_moc` is.
+fn run_group<T, F>(i: usize, kernel: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String>,
+{
+    match catch_unwind(AssertUnwindSafe(kernel)) {
+        Ok(r) => r.map_err(|e| format!("group {i}: {e}")),
+        Err(e) => Err(format!(
+            "group {i}: {}",
+            crate::panic_msg(e, "toc kernel panicked")
+        )),
+    }
+}
+
+/// Reduce each group of words to one word: the segmented [`merge`] fold.
+///
+/// Group `i` is `words[offsets[i]..offsets[i + 1]]` (arrow list layout) and the
+/// result is dense — one `u64` per group, `offsets.len() - 1` of them — because
+/// the reduction is many→one per group, so no output offsets are needed.  Each
+/// output word is bit-identical to the whole-array reduce over that group alone
+/// (the fold tree is irrelevant: [`merge`] is exactly associative, commutative
+/// and idempotent).
+///
+/// # Errors
+/// A layout problem (see [`validate_ragged`]) or an **empty group** — the merge
+/// has no identity element, so many→one over no words has no answer, exactly as
+/// [`rust_toc_reduce`] refuses an empty array.  Both name the offending group.
+/// The index named is the lowest-index offender within its pass: layout is
+/// checked for the whole batch first, so a layout failure at a high index is
+/// reported ahead of an empty group at a low one — deliberate, since the group
+/// indices an empty-group error is reported *by* are read out of `offsets`.
+pub fn segmented_reduce(words: &[u64], offsets: &[i64]) -> Result<Vec<u64>, String> {
+    let n_groups = validate_ragged(words.len(), offsets)?;
+    let mut out = Vec::with_capacity(n_groups);
+    // Chunk the parallel pass so only one chunk's outcomes are resident, and
+    // drain each chunk (in index order) before the next one is built — which is
+    // what makes the surfaced error the lowest-index failure under any rayon
+    // schedule.
+    for base in (0..n_groups).step_by(CHUNK) {
+        let end = (base + CHUNK).min(n_groups);
+        let folded: Vec<Result<u64, String>> = (base..end)
+            .into_par_iter()
+            .map(|i| {
+                let (s, e) = (offsets[i] as usize, offsets[i + 1] as usize);
+                run_group(i, || {
+                    words[s..e].iter().copied().reduce(merge).ok_or_else(|| {
+                        "tocs_reduce of an empty segment (the merge has no \
+                         identity element)"
+                            .to_string()
+                    })
+                })
+            })
+            .collect();
+        for word in folded {
+            out.push(word?);
+        }
+    }
+    Ok(out)
+}
+
+/// Segmented semilattice reduce: one merged word per group (issue #177).
+///
+/// Ragged input in arrow list layout — group `i` is
+/// `words[offsets[i]..offsets[i + 1]]` — and a **dense** `u64` output, one word
+/// per group.  Raises `ValueError` naming the offending group on a layout
+/// problem or an empty group.  The GIL is released for the whole batch; rayon
+/// parallelizes across groups.
+#[pyfunction]
+pub fn rust_tocs_reduce(
+    py: Python<'_>,
+    words: PyReadonlyArray1<u64>,
+    offsets: PyReadonlyArray1<i64>,
+) -> PyResult<PyObject> {
+    let w = words.to_vec()?;
+    let off = offsets.to_vec()?;
+    match py.allow_threads(|| segmented_reduce(&w, &off)) {
+        Ok(out) => Ok(out.into_pyarray_bound(py).into_any().unbind()),
+        Err(msg) => Err(PyValueError::new_err(msg)),
+    }
 }
 
 /// Variant predicate: true where the word is a range (vectorized).
@@ -591,6 +744,148 @@ mod tests {
                     "every fold tree must produce the identical u64"
                 );
             }
+        }
+    }
+
+    // ── segmented reduce (issue #177) ────────────────────────────────────
+
+    /// Concatenate word groups into (words, offsets) arrow list layout.
+    fn ragged(groups: &[Vec<u64>]) -> (Vec<u64>, Vec<i64>) {
+        let mut words = Vec::new();
+        let mut offsets = vec![0i64];
+        for g in groups {
+            words.extend_from_slice(g);
+            offsets.push(words.len() as i64);
+        }
+        (words, offsets)
+    }
+
+    #[test]
+    fn segmented_reduce_matches_the_scalar_fold_per_group() {
+        let mut st = 0x177;
+        // Group sizes swept past the chunk seam so the parallel path is real.
+        let groups: Vec<Vec<u64>> = (0..CHUNK + 37)
+            .map(|_| {
+                let n = 1 + (splitmix64(&mut st) % 9) as usize;
+                (0..n).map(|_| rand_word(&mut st)).collect()
+            })
+            .collect();
+        let (words, offsets) = ragged(&groups);
+        let got = segmented_reduce(&words, &offsets).unwrap();
+        assert_eq!(got.len(), groups.len());
+        for (i, g) in groups.iter().enumerate() {
+            let want = g.iter().copied().reduce(merge).unwrap();
+            assert_eq!(got[i], want, "group {i}");
+        }
+    }
+
+    #[test]
+    fn segmented_reduce_preserves_instants_and_singletons() {
+        // A group of bitwise-equal timestamps must come back as that
+        // timestamp, not as its range envelope — per-group idempotence.
+        let t = encode_timestamp(123_456_789_012).unwrap();
+        let groups = vec![vec![t], vec![t; 17], vec![t, encode_range(0, 10).unwrap()]];
+        let (words, offsets) = ragged(&groups);
+        let got = segmented_reduce(&words, &offsets).unwrap();
+        assert_eq!(got[0], t);
+        assert_eq!(got[1], t);
+        assert!(!is_range(got[1]));
+        assert!(is_range(got[2]), "a mixed group merges to a range");
+    }
+
+    #[test]
+    fn segmented_reduce_is_permutation_invariant_within_a_group() {
+        let mut st = 0xF0F0;
+        for _ in 0..200 {
+            let n = 2 + (splitmix64(&mut st) % 12) as usize;
+            let mut g: Vec<u64> = (0..n).map(|_| rand_word(&mut st)).collect();
+            let (words, offsets) = ragged(std::slice::from_ref(&g));
+            let reference = segmented_reduce(&words, &offsets).unwrap()[0];
+            g.reverse();
+            let (words, offsets) = ragged(std::slice::from_ref(&g));
+            assert_eq!(segmented_reduce(&words, &offsets).unwrap()[0], reference);
+        }
+    }
+
+    #[test]
+    fn segmented_reduce_refuses_an_empty_group_by_index() {
+        let words = vec![encode_timestamp(1).unwrap(), encode_timestamp(2).unwrap()];
+        let err = segmented_reduce(&words, &[0, 1, 1, 2]).unwrap_err();
+        assert!(err.starts_with("group 1: "), "{err}");
+        assert!(err.contains("empty segment"), "{err}");
+        // An empty *batch* is fine: no groups, no answers required.
+        assert!(segmented_reduce(&[], &[0]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn segmented_reduce_layout_errors_name_the_group() {
+        let words = vec![encode_timestamp(1).unwrap(); 3];
+        let err = segmented_reduce(&words, &[0, 3, 1]).unwrap_err();
+        assert!(
+            err.starts_with("group 1: ") && err.contains("monotonically"),
+            "{err}"
+        );
+        let err = segmented_reduce(&words, &[0, 1, 99]).unwrap_err();
+        assert!(
+            err.starts_with("group 1: ") && err.contains("exceeds"),
+            "{err}"
+        );
+        assert!(segmented_reduce(&words, &[1, 3])
+            .unwrap_err()
+            .contains("must start at 0"));
+        assert!(segmented_reduce(&words, &[0, 2])
+            .unwrap_err()
+            .contains("must end at the word count"));
+        assert!(segmented_reduce(&words, &[])
+            .unwrap_err()
+            .contains("at least one element"));
+    }
+
+    #[test]
+    fn segmented_reduce_lowest_index_offender_wins() {
+        // Empty groups at several indices: the lowest is always the one named,
+        // including across a chunk seam.
+        let n = 2 * CHUNK;
+        let words: Vec<u64> = (0..n as u64)
+            .map(|t| encode_timestamp(t).unwrap())
+            .collect();
+        let mut offsets: Vec<i64> = (0..=n as i64).collect();
+        // Collapsing offsets[i + 1] onto offsets[i] empties group i and hands
+        // its word to group i + 1 — the layout stays monotone and still covers
+        // the words exactly, so only the empty-group refusal is under test.
+        for &i in &[7usize, CHUNK - 1, CHUNK + 3] {
+            offsets[i + 1] = offsets[i];
+        }
+        for _ in 0..5 {
+            // Repeated: a rayon-schedule-dependent answer would show up here.
+            let err = segmented_reduce(&words, &offsets).unwrap_err();
+            assert!(err.starts_with("group 7: "), "{err}");
+        }
+        offsets[8] = 8; // heal the lowest; the next seam offender is named
+        let err = segmented_reduce(&words, &offsets).unwrap_err();
+        assert!(err.starts_with(&format!("group {}: ", CHUNK - 1)), "{err}");
+    }
+
+    #[test]
+    fn a_panicking_group_kernel_is_a_named_error_not_a_panic() {
+        // `merge` cannot panic today, so the capture is pinned by injection —
+        // the mechanism must name the group rather than unwind into Python as a
+        // `PanicException` (issues #161 / #185).
+        let err = run_group::<u64, _>(9, || panic!("kernel exploded")).unwrap_err();
+        assert_eq!(err, "group 9: kernel exploded");
+        assert_eq!(run_group(3, || Ok::<u64, String>(7)).unwrap(), 7);
+    }
+
+    #[test]
+    fn arbitrary_bit_patterns_fold_without_panicking() {
+        // Words are garbage-in-garbage-out by design (see [`merge`]); the
+        // segmented fold inherits that and must not abort on junk input.
+        let mut st = 0xBADF00D;
+        let junk: Vec<u64> = (0..64).map(|_| splitmix64(&mut st)).collect();
+        let offsets: Vec<i64> = (0..=8).map(|i| i * 8).collect();
+        let got = segmented_reduce(&junk, &offsets).unwrap();
+        for (i, chunk) in junk.chunks(8).enumerate() {
+            assert_eq!(got[i], chunk.iter().copied().reduce(merge).unwrap());
         }
     }
 

--- a/src_rust/src/toc.rs
+++ b/src_rust/src/toc.rs
@@ -391,7 +391,11 @@ where
 /// the reduction is many→one per group, so no output offsets are needed.  Each
 /// output word is bit-identical to the whole-array reduce over that group alone
 /// (the fold tree is irrelevant: [`merge`] is exactly associative, commutative
-/// and idempotent).
+/// and idempotent).  That identity is scoped to encoder-produced words, as
+/// [`merge`] is: an arbitrary bit pattern is garbage in, garbage out, and once
+/// a junk "timestamp" merges to a word with the flag bit set the fold tree does
+/// matter — this fold is sequential within a group while [`rust_toc_reduce`]
+/// splits, so the two may then differ, each deterministically.
 ///
 /// # Errors
 /// A layout problem (see [`validate_ragged`]) or an **empty group** — the merge


### PR DESCRIPTION
Refs #177 — the v1 scope only. The interval-set algebra (`normalize` / union / intersect / minus) stays deferred, so this does **not** close the issue: the three rulings the issue parks (canonical form, adjacency, the difference trap) are untouched and still want a consumer. See the plan comment for the split.

## What this adds

One function, `tocs_reduce(words, offsets) -> words` — the **segmented** sibling of `toc_reduce`, named in the batch family's plural convention (`mocs_and`, `mocs_to_orders`).

```python
>>> cells = mortie.tocs_reduce(shot_words, cell_offsets)   # one word per cell
```

Ragged in (arrow list layout: group `i` is `words[offsets[i]:offsets[i+1]]`), **dense out** — one `uint64` per group, because the reduction is many→one per group so there are no output offsets to carry. Result `i` is bit-identical to `toc_reduce` on group `i` alone — over encoder-produced words, the scope `toc_merge` already carries (junk in, junk out: an out-of-domain "timestamp" can merge onto the flag bit, past which the two fold trees may differ, each deterministically).

### Approach

- **Rust kernel** beside `rust_toc_reduce` in `src_rust/src/toc.rs`: `segmented_reduce()` validates the layout serially, then folds groups in 2048-group chunks under `py.allow_threads` with rayon across groups — the `common_ancestors` shape (`src_rust/src/decimal_morton/batch.rs:247`) with `common_ancestor` swapped for `toc::merge`. Each chunk's outcomes are materialized and walked in index order before any is allowed to fail, so the reported index is the lowest-index offender under any rayon schedule.
- **Semantics inherited wholesale from `toc_reduce`**, per group: the same join, instant preservation (a group of bitwise-equal timestamps comes back as that timestamp, *not* as its range envelope), and fold-tree independence — safe because `merge` is exactly associative, commutative and idempotent **over encoder-produced words**, which the existing cargo law tests pin (they draw from `rand_word`). The scope matters: `merge`'s own doc comment notes an out-of-domain "timestamp" can merge to a word with the flag bit set, and once that happens the fold tree stops being irrelevant — `segmented_reduce` folds sequentially within a group while `rust_toc_reduce` splits, so on junk the two may disagree. Documented at all three sites (`mortie/toc.py`, `src_rust/src/toc.rs`, CHANGELOG) and pinned by test rather than asserted away.
- **An empty segment refuses**, catchably, naming the group: the merge has no identity element, so many→one over no words has no answer. That is `toc_reduce`'s existing ruling (`src_rust/src/toc.rs`, `"the merge has no identity element"`), inherited rather than re-decided; zagg's fold sites never present an empty cell (they short-circuit before the fold).
- **Panic-capture posture** (#161 / #185): every group's fold runs under `run_group`, which turns a panic into a `ValueError` naming the group. Stated plainly in the code: this is **defensive, not load-bearing** — `merge` is total over arbitrary bit patterns (it only shifts and compares), so there is no malformed toc word the way there is a malformed morton word, and nothing a caller can pass panics today. It is here so a later `debug_assert` or arithmetic edge surfaces as a catchable named error rather than a `pyo3_runtime.PanicException`, which derives from `BaseException` and escapes even `except Exception`. Pinned by an injected panicking kernel, the way `moc/batch.rs`'s `run_moc` is.
- **Python skin** in `mortie/toc.py` with the module's `_as_u64` validation, plus a matching `_as_offsets` that requires integer-typed offsets — a float offsets array would otherwise cast silently, truncating `2.9` to a boundary at 2 rather than saying so. The same standard rejects a `uint64` offset at or above `2**63` (the natural output of `np.cumsum` over unsigned counts), which the `int64` cast would otherwise wrap negative — the error names the value passed in, not the wrapped copy. Exported from `mortie/__init__.py` beside the other toc names; `See Also` links both directions (`toc_merge` and `toc_reduce` each gained the back-reference).

## Phases

- [x] Phase 1 — Rust kernel, binding, cargo tests (`0613d49`)
- [x] Phase 2 — Python skin, exports, pytest suite (`3c0521e`)
- [x] Phase 3 — docs page + CHANGELOG

## How it was tested

Cargo (`cargo test --lib`, **382 passed**), 7 new tests in `src_rust/src/toc.rs`:

| test | what it pins |
|---|---|
| `segmented_reduce_matches_the_scalar_fold_per_group` | parity over 2085 randomized groups — past the 2048 chunk seam, so the parallel path is real |
| `segmented_reduce_preserves_instants_and_singletons` | a group of equal timestamps stays a timestamp; a mixed group merges to a range |
| `segmented_reduce_is_permutation_invariant_within_a_group` | commutativity/associativity through the segmented form |
| `segmented_reduce_refuses_an_empty_group_by_index` | the no-identity refusal, named; an empty *batch* is still fine |
| `segmented_reduce_layout_errors_name_the_group` | monotonicity, bounds, `start at 0`, `end at the word count`, empty offsets |
| `segmented_reduce_lowest_index_offender_wins` | offenders at 7 / `CHUNK-1` / `CHUNK+3`; the lowest is named, repeated 5× against a schedule-dependent answer |
| `a_panicking_group_kernel_is_a_named_error_not_a_panic` + `arbitrary_bit_patterns_fold_without_panicking` | the capture mechanism, and junk-word totality |

Python (`pytest mortie/tests`, **1544 passed, 16 skipped**; `test_toc.py` alone is 48 passed, `mortie/toc.py` at 100% coverage), 14 new tests:

- `..._parity_with_a_scalar_loop` — 2185 groups vs a loop of `toc_reduce`, across the chunk seam.
- `..._property_against_a_python_reference` — 400 randomized groups vs a pure-Python fold of a reference `py_merge` written from the bit layout, so the parity is against an independent implementation rather than the same kernel.
- `..._permutation_invariant_within_a_group`, `..._preserves_instants_per_group`, `..._mixed_instant_and_range_groups` (instant-only / range-only / mixed in one call, with the resulting `toc_is_range` flags pinned).
- `..._empty_segment_is_a_catchable_named_error` — asserted through `except Exception` and an `isinstance(..., ValueError)`, not only `pytest.raises`, because that is the handler shape a consumer writes and the exact shape a `PanicException` would slip past.
- `..._arbitrary_bit_patterns_do_not_panic` — junk words including `0`, `1`, `2**64-1` and the bare flag bit; the answer must be the sequential in-group fold of `py_merge`, the same oracle the cargo twin uses (`arbitrary_bit_patterns_fold_without_panicking`). Parity with `toc_reduce` is deliberately *not* asserted on junk — see the next test.
- `..._junk_fold_is_tree_dependent` — the counterexample behind that scope: `[0, 1, 1, 1, 1, 1, 1, 2**64-1]` merges onto the flag bit, so `tocs_reduce` (sequential) answers `2**31` where `toc_reduce` (split) answers `1`. Both deterministic, neither a panic — which is the whole junk-domain promise.
- `..._offsets_guards` — non-monotone, out-of-range, bad endpoints, empty offsets, float offsets, float words, negative words.
- `..._uint64_offsets_out_of_int64_range` — a `uint64` offset of `2**63 + 5` is refused by value rather than wrapping to a negative int64 and being reported as a monotonicity failure; in-range `uint64` offsets still work.
- `..._lowest_index_offender_across_the_chunk_seam`, `..._empty_batch_and_group_of_one`, `..._deterministic_across_runs` (10 identical results over 5000 groups).
- `..._consumer_shape_per_cell_fold` — **the plan's consumer smoke**: 4096 shot words folded to ~250 cells equals the scalar loop, and then one pyramid level up (4 cells per parent, envelope of envelopes) equals folding the leaves directly. That second half is the ATL03 overview claim from the zagg#410 plan — associativity carried through the segmented form.

Lints, all clean: `cargo fmt --check`, `cargo clippy --all-targets` (no findings on `toc.rs`; the handful of pre-existing warnings elsewhere are untouched), `flake8 mortie --select=E9,F63,F7,F82`, `flake8 --max-line-length=88` on the touched files, `ruff check`, and `numpydoc lint mortie/toc.py` (the `lint.yml` hard gate).

## Questions for review

**(1) `mortie/toc.py` vs `mortie/batch.py` — the one placement call, and it cuts against a stated convention.** The plan comment says `mortie/toc.py`, and that is what this PR does. But `mortie/batch.py`'s own docstring says "*Every function here is the batch twin of a scalar that lives elsewhere in the package*", consolidated by arity under issue #170 — and `mortie/toc.py`'s docstring promised, before this PR, that "*the ragged many-cover plurals land in `mortie.batch` when the interval-set algebra (issue #177) activates*". `tocs_reduce` is a ragged batch twin of a scalar, so on a literal read of #170 it belongs in `batch.py`.

The reason I kept it here anyway, and reworded both that line and `docs/api/toc.md` to match: `tocs_reduce` folds the **word type itself**, where every current `batch.py` resident (`mocs_and`, `mocs_to_orders`, `common_ancestors`, `children_of`, `from_wkbs`, `polygons_to_morton_mocs`) operates over *covers or geometry*. The deferred many-cover plurals — a segmented `tocs_overlaps`, and whatever the algebra eventually needs — are the ones #170's promise was about, and they still point at `batch.py`. Moving it is a one-line import change if you disagree; say the word and I will.

**(2) Naming: `tocs_reduce` vs `toc_reduce_segmented`.** Flagged in the plan and not agonized over — the plural matches `mocs_*`. It does read slightly oddly next to `toc_reduce` (one letter apart, and the `s` is the only signal), which is the one argument for the suffix form. Happy to rename; it is mechanical.

**(3) The panic capture on a kernel that cannot panic.** `run_group` + `catch_unwind` is ~15 lines guarding a fold that only shifts and compares. CLAUDE.md §4 says no speculative abstraction; the #161/#185 posture says never let a `PanicException` reach Python. I sided with the posture and documented the tension in the doc comment rather than silently picking one. If you would rather this be a plain fold with no capture, it is a small deletion.

**(4) `_as_offsets` is stricter than the batch family.** `mocs_to_orders` and friends do `np.asarray(offsets, dtype=np.int64)`, which silently truncates a float offsets array. The new helper refuses one instead, matching `toc.py`'s own `_as_u64`, which refuses float words. That is a deliberate local divergence from `batch.py` — the toc module is the stricter one throughout — but it does mean `tocs_reduce` and `mocs_to_orders` answer differently to the same bad input. Not proposing to change `batch.py` here; flagging it so the inconsistency is a choice on the record. The helper now also range-checks `uint64` offsets before the `int64` cast, for the same reason — `batch.py` still wraps silently there.

**(5) Not shipped, deliberately.** No benchmark (the plan's honest expectation is the bandwidth-bound `mocs_to_orders` band, not #154's 19.9× — a toc word decodes in two shifts, so there is nothing to hoist out of the loop), and no notebook change. `docs/specification.md` covers no toc surface at all today, so only `docs/api/toc.md` needed the member entry.

