### PR TITLE
API consolidation: one polymorphic function per operation (issue #187)

### DIFF
--- a/mortie/arrow.py
+++ b/mortie/arrow.py
@@ -211,6 +211,8 @@ def from_morton_index(array):
     already-built Arrow array goes back through :func:`to_morton_index`, not
     here.)
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     array : MortonIndexArray or array_like
@@ -243,6 +245,8 @@ def to_morton_index(array):
 
     Arrow nulls come back as the all-zero empty sentinel word, so the pandas
     :meth:`isna` reports them as missing.
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------

--- a/mortie/batch.py
+++ b/mortie/batch.py
@@ -82,6 +82,10 @@ def polygons_to_morton_mocs(lats, lons, offsets, order=18, tolerance=None,
     its MOC is ``values[out_offsets[i]:out_offsets[i+1]]`` in the result —
     byte-identical to ``morton_coverage_moc`` on that ring alone.
 
+    **Batch native**: this is itself the batch entry point — the scalar
+    :func:`mortie.coverage.morton_coverage_moc` has no ragged form that
+    reaches it.
+
     Parameters
     ----------
     lats, lons : array_like
@@ -183,6 +187,9 @@ def from_wkbs(blobs, order=18, tolerance=None, max_cells=None, normalize=True,
     cost that dominates a Python loop over half a million footprints is paid
     once.  Result ``i`` is byte-identical to
     ``from_wkb(blobs[i], order=order, moc=True, ...)``.
+
+    **Batch native**: this is itself the batch entry point — the scalar
+    :func:`mortie.geometry.from_wkb` has no column form that reaches it.
 
     Memory: a chunk ends at 2048 blobs **or 64 MiB, whichever comes first**,
     and peak is the returned ``values`` array plus **one chunk of copied input
@@ -363,6 +370,9 @@ def mocs_to_orders(values, offsets, order, max_cells=_FLAT_COVER_WARN_THRESHOLD)
         cells, off = mortie.polygons_to_morton_mocs(lats, lons, off_in, order=8)
         flat, flat_off = mortie.mocs_to_orders(cells, off, 8)
 
+    **Batch native**: reached polymorphically by
+    :func:`mortie.moc.moc_to_order`'s ``offsets`` form (issue #187).
+
     MOCs are densified in chunks and each chunk is copied into the ragged output
     as it lands, so the per-MOC flat lists never all coexist — not the ~2.5x of
     holding every one of them to concatenate at the end.  Peak is then **the
@@ -478,6 +488,9 @@ def mocs_and(a, values, offsets):
     it does not matter which side of your loop was "the AOI": pass either
     operand as ``a``.
 
+    **Batch native**: reached polymorphically by :func:`mortie.moc.moc_and`'s
+    ``offsets`` form (issue #187).
+
     An empty intersection keeps its slot (``out_offsets[i] ==
     out_offsets[i+1]``), as does every slot when ``a`` is empty — so the ragged
     output always agrees with :func:`mocs_intersect` on which items overlap.
@@ -576,6 +589,9 @@ def mocs_intersect(a, values, offsets):
     by intersecting once and testing membership — which would silently drop
     dense regions that compact to a parent cell.
 
+    **Batch native**: reached polymorphically by
+    :func:`mortie.moc.moc_intersects`'s ``offsets`` form (issue #187).
+
     Memory: no results are materialized; peak is the input copy the binding
     makes before releasing the GIL, one ``bool`` per MOC out, plus the
     in-flight items' normalize scratch (one chunk at most).
@@ -638,6 +654,9 @@ def common_ancestors(values, offsets):
     and :func:`mocs_to_orders` use; the **output is dense** — one ``uint64`` per
     group — because the reduction is many→one per group, so there are no output
     offsets to carry.
+
+    **Batch native**: reached polymorphically by
+    :func:`mortie.moc.common_ancestor`'s ``offsets`` form (issue #187).
 
     The consumer this exists for is a per-worker inner loop, not a one-off:
     zagg's t-digest reduction runs ``for j in np.flatnonzero(~single):`` over
@@ -747,6 +766,9 @@ def children_of(words, order, max_cells=None):
     zagg calls the scalar the same way per sub-chunk on every worker
     (``grids/healpix.py:199``) and per shard in the shardmap reprojection
     (``catalog/shardmap.py:708``).
+
+    **Batch native**: reached polymorphically by
+    :func:`mortie.orders.generate_morton_children`'s array form (issue #187).
 
     Memory: the result is the whole of it, and it is ``n * 4**d * 8`` bytes —
     refining 100k parents by 5 orders is 100k x 1024 x 8 B = 819 MB.  The

--- a/mortie/buffer.py
+++ b/mortie/buffer.py
@@ -24,6 +24,9 @@ def morton_buffer(morton_indices, k=1):
     Returns only cells NOT in the input set (the expansion ring).
     User can union: ``np.union1d(morton_indices, border)``
 
+    **Not batch vectorized**: one cell set per call — the ring is a set
+    operation over the whole input, not an elementwise map.
+
     Parameters
     ----------
     morton_indices : array-like
@@ -70,6 +73,8 @@ def morton_buffer_meters(morton_indices, width_m):
     The cell width used for the calculation is the HEALPix angular
     resolution ``sqrt(pi/3) / nside`` converted to meters via the Earth's
     mean radius (6,371,008.77 m).
+
+    **Not batch vectorized**: one cell set per call, as :func:`morton_buffer`.
 
     Parameters
     ----------

--- a/mortie/convert.py
+++ b/mortie/convert.py
@@ -74,6 +74,8 @@ def geodetic_to_authalic(lats):
     for callers who need the raw latitude mapping (e.g. to reproduce a
     binning decision or to label an external dataset).
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     lats : float or array-like
@@ -106,6 +108,8 @@ def authalic_to_geodetic(lats):
     The inverse of :func:`geodetic_to_authalic`, exact to the same
     <= 1e-13 rad series bound — see there for the convention background
     (issue #186).
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------
@@ -140,6 +144,8 @@ def unique2parent(unique):
     each cell is reduced against its own order. This function previously
     collapsed those per-element orders to a scalar and raised
     ``NotImplementedError`` on anything mixed.
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------
@@ -179,6 +185,9 @@ def norm2mort(normed, parent, order):
     packed ``decimal_morton`` word (issue #58; the prefix is ``base+1``, so bit 63
     is set — a large unsigned value — for base cells 7-11), not the retired
     decimal encoding.
+
+    **Batch vectorized**: array in, array out, elementwise (one shared
+    ``order``).
 
     Parameters
     ----------
@@ -270,6 +279,8 @@ def geo2uniq(lats, lons, order=MAX_ORDER, *, latitude="authalic"):
     :meth:`~mortie.morton_index.MortonIndexArray.from_latlon` with
     ``points=True``.
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     lats : float or array-like
@@ -348,6 +359,9 @@ def geo2mort(lats, lons, order=None, points=None, *, latitude="authalic"):
     Non-finite ``lat``/``lon`` encode to the reserved empty word ``0`` (base
     cell 0 is the null sentinel) on both the area and point routes.
 
+    **Batch vectorized**: array in, array out, elementwise (one shared
+    ``order``).
+
     Parameters
     ----------
     lats : array-like
@@ -403,6 +417,9 @@ def geo2mort(lats, lons, order=None, points=None, *, latitude="authalic"):
 
 def mort2norm(morton):
     """Convert morton index back to normalized address and parent cell.
+
+    **Batch vectorized**: array in, arrays out, elementwise — but the words
+    must share one order, since the returned order is a single scalar.
 
     Parameters
     ----------
@@ -474,6 +491,8 @@ def norm2uniq(normed, parent, order=MAX_ORDER):
     and a cell index, with no kind bit (see :func:`geo2uniq` for the full note
     and the point-capable alternatives). An order-29 result is the
     max-resolution **area** cell, not a point.
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------
@@ -548,6 +567,8 @@ def uniq2geo(uniq, *, latitude="authalic"):
     ``pix2ang`` kernel, mirroring the group-by-order dispatch :func:`mort2geo`
     uses for mixed-order morton words (issue #116).
 
+    **Batch vectorized**: array in, arrays out, elementwise.
+
     Parameters
     ----------
     uniq : int or array-like
@@ -606,6 +627,8 @@ def mort2geo(morton, *, latitude="authalic"):
     results scatter back to input positions. Point words (spec §4) are order
     29 by definition and group with order 29 — a point's location is exactly
     what mort2geo returns.
+
+    **Batch vectorized**: array in, arrays out, elementwise.
 
     Parameters
     ----------
@@ -672,6 +695,8 @@ def mort2bbox(morton, *, latitude="authalic"):
     of its containing order-29 cell (the cell that contains the point), which
     is exactly the bbox of the order-29 **area** word at the same location. A
     group of points therefore covers a well-defined area, element by element.
+
+    **Batch vectorized**: array in, one bbox dict per word out, elementwise.
 
     Parameters
     ----------
@@ -849,6 +874,8 @@ def _normalize_antimeridian_polygon(vertices):
 def mort2polygon(morton, step=1, *, latitude="authalic"):
     """Convert morton index to polygon representation.
 
+    **Batch vectorized**: array in, one ring per word out, elementwise.
+
     Parameters
     ----------
     morton : int or array-like
@@ -956,6 +983,9 @@ def mort2polygon(morton, step=1, *, latitude="authalic"):
 
 def mort2healpix(morton):
     """Convert morton index to HEALPix cell ID and order.
+
+    **Batch vectorized**: array in, array out, elementwise — but the words
+    must share one order, since the returned order is a single scalar.
 
     Parameters
     ----------

--- a/mortie/coverage.py
+++ b/mortie/coverage.py
@@ -189,6 +189,9 @@ def morton_coverage(lats, lons, order=18, normalize=True, *,
     outer rings are unioned (with no seam along shared interior borders), and a
     ring nested inside another carves a **hole** (a donut is ``[outer, hole]``).
 
+    **Not batch vectorized**: one polygon (ring-set) per call, covered to one
+    cover.
+
     Parameters
     ----------
     lats : array_like or list of array_like
@@ -314,6 +317,9 @@ def morton_coverage_moc(lats, lons, order=18, tolerance=None, max_cells=None,
     even-odd descent — disjoint parts union with no internal seam, and nested
     rings carve holes (a donut is ``[outer, hole]``).
 
+    **Not batch vectorized**: one polygon (ring-set) per call; the batch form
+    is :func:`mortie.batch.polygons_to_morton_mocs`.
+
     Parameters
     ----------
     lats, lons : array_like
@@ -415,6 +421,8 @@ def ring_validity(lats, lons, *, latitude="authalic"):
     function -- the verdicts say which documented convention resolves the
     ambiguity, not that the cover is wrong.
 
+    **Not batch vectorized**: one ring per call.
+
     Parameters
     ----------
     lats, lons : array_like
@@ -485,6 +493,8 @@ def ring_is_simple(lats, lons, *, latitude="authalic"):
     crossing predicate -- no sweep line, ``O(V log V)``-ish on realistic
     rings.  Consecutive duplicate vertices and a duplicated closing vertex
     are handled exactly as coverage ingest handles them.
+
+    **Not batch vectorized**: one ring per call.
 
     Parameters
     ----------

--- a/mortie/geometry.py
+++ b/mortie/geometry.py
@@ -317,6 +317,8 @@ def from_geometry(geom, order=18, moc=False, normalize=True,
       Holes and disjoint parts are handled by the one even-odd descent.
     * **LineString / MultiLineString** → :func:`mortie.linestring_coverage`.
 
+    **Not batch vectorized**: one geometry per call.
+
     Parameters
     ----------
     geom : backend geometry
@@ -375,6 +377,9 @@ def from_wkb(data, order=18, moc=False, normalize=True,
     produced: same rings, same descent.  (:func:`from_wkt` still decodes via a
     backend — #157 scoped the Rust parser to WKB.)
 
+    **Not batch vectorized**: one blob per call; the batch form is
+    :func:`mortie.batch.from_wkbs`.
+
     Parameters
     ----------
     data : bytes, str, or buffer
@@ -426,6 +431,8 @@ def from_wkt(text, order=18, moc=False, normalize=True,
     :func:`from_geometry`.  Unlike :func:`from_wkb`, this **does** need a
     backend installed — mortie has no Rust WKT parser (issue #157 scoped the
     reader to WKB).
+
+    **Not batch vectorized**: one WKT string per call.
 
     Parameters
     ----------
@@ -509,6 +516,8 @@ def _per_cell_polygons(mod, morton, step, latitude):
 def to_geometry(morton, dissolve=True, step=1, *, latitude="authalic"):
     """Convert a morton cover to a backend geometry (issue #71).
 
+    **Not batch vectorized**: one cover per call, emitted as one geometry.
+
     Parameters
     ----------
     morton : array_like of uint64
@@ -568,6 +577,8 @@ def to_geometry(morton, dissolve=True, step=1, *, latitude="authalic"):
 def to_wkb(morton, dissolve=True, step=1, srid=None, *, latitude="authalic"):
     """Emit a morton cover as WKB (or EWKB) bytes.
 
+    **Not batch vectorized**: one cover per call, emitted as one blob.
+
     Parameters
     ----------
     morton : array_like of uint64
@@ -604,6 +615,8 @@ def to_wkb(morton, dissolve=True, step=1, srid=None, *, latitude="authalic"):
 
 def to_wkt(morton, dissolve=True, step=1, srid=None, *, latitude="authalic"):
     """Emit a morton cover as WKT (or EWKT) text.
+
+    **Not batch vectorized**: one cover per call, emitted as one string.
 
     Parameters
     ----------

--- a/mortie/linestring.py
+++ b/mortie/linestring.py
@@ -85,6 +85,9 @@ def linestring_coverage(lats, lons, order=18, *, latitude="authalic"):
     deduplicated across lines — if the caller wants the union, they can
     concatenate and call ``np.unique`` themselves.
 
+    **Not batch vectorized**: one line per Rust call — the multi-linestring
+    form loops over the lines in Python.
+
     Parameters
     ----------
     lats : array_like or list of array_like

--- a/mortie/moc.py
+++ b/mortie/moc.py
@@ -55,7 +55,8 @@ def compress_moc(morton):
     return np.asarray(_rustie.rust_moc_normalize(morton))
 
 
-def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD):
+def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD, *,
+                 offsets=None):
     """Densify a (mixed-order) morton set to a flat list at ``order``.
 
     Unlike :func:`morton_coverage`'s post-hoc warning, the densify path can
@@ -80,34 +81,54 @@ def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD):
     the binding maps it to the same :class:`ValueError` (issue #161), so this
     check is defence in depth rather than the only defence.
 
+    **Batch vectorized** (issue #187): one MOC in, one flat cover out; pass
+    ``offsets`` and the same call densifies a whole ragged column of MOCs in
+    one crossing, returning the ``(values, out_offsets)`` pair.  The input
+    shape selects the form — there is no separate plural entry point to keep in
+    parity.
+
     Parameters
     ----------
     morton : array_like
-        Morton indices (mixed order allowed).
+        Morton indices (mixed order allowed).  With ``offsets``, the flat
+        ``uint64`` concatenation of every MOC in the column.
     order : int
-        Target HEALPix order (0-29) to densify to.
+        Target HEALPix order (0-29) to densify to, shared by every MOC.
     max_cells : int or None, optional
         Pre-emptive budget on the densified flat cell count.  Raises
         :class:`ValueError` if the estimate exceeds it (default
         ``1 << 20`` — the same ~1M-cell line as the flat-cover warning).  Pass
-        ``None`` to opt out and densify unconditionally.
+        ``None`` to opt out and densify unconditionally.  With ``offsets`` the
+        budget applies **per MOC**, and the refusal names the lowest-index
+        offending MOC.
+    offsets : array_like or None, optional
+        ``int64`` arrow list offsets selecting the ragged batch form: MOC ``i``
+        spans ``morton[offsets[i]:offsets[i + 1]]``, and the offsets must
+        exactly cover ``morton``.  ``None`` (default) is the single-MOC form.
 
     Returns
     -------
-    numpy.ndarray
-        Sorted 1-D array of flat morton indices at ``order`` (``uint64``).
+    numpy.ndarray or tuple of numpy.ndarray
+        Without ``offsets``, a sorted 1-D array of flat morton indices at
+        ``order`` (``uint64``).  With ``offsets``, the ragged
+        ``(values, out_offsets)`` pair — slice ``i`` is byte-identical to the
+        single-MOC result on MOC ``i`` alone.
 
     Raises
     ------
     ValueError
         If ``order`` is outside 0-29, or the estimated densified count exceeds
-        ``max_cells``.
+        ``max_cells``.  In the ragged form, also for offsets that are
+        non-monotone, out of bounds, or do not exactly cover ``morton``.
 
     See Also
     --------
     morton_coverage : flat single-order cover (post-hoc large-cover warning).
-    mortie.batch.mocs_to_orders : the ragged batch form (many MOCs in one call).
+    mortie.batch.mocs_to_orders : the ragged batch kernel this delegates to.
     """
+    if offsets is not None:
+        from .batch import mocs_to_orders
+        return mocs_to_orders(morton, offsets, order, max_cells)
     morton = np.asarray(morton, dtype=np.uint64).ravel()
     if not 0 <= order <= 29:
         raise ValueError(f"Order must be between 0 and 29, got {order}")
@@ -150,33 +171,47 @@ def moc_or(a, b):
     return np.asarray(_rustie.rust_moc_or(a, b))
 
 
-def moc_and(a, b):
+def moc_and(a, b, *, offsets=None):
     r"""Intersection of two morton covers (the cells in both ``a`` and ``b``).
+
+    **Batch vectorized** (issue #187): pass ``offsets`` and ``b`` is read as a
+    ragged column of MOCs, all intersected against the shared cover ``a`` in
+    one crossing.  The broadcast builds ``a``'s BMOC once instead of once per
+    item, which is the structural win a Python loop cannot get.
 
     Parameters
     ----------
     a, b : array_like
-        Morton covers (mixed order allowed).
+        Morton covers (mixed order allowed).  With ``offsets``, ``b`` is the
+        flat concatenation of the column and ``a`` stays the shared operand.
+    offsets : array_like or None, optional
+        ``int64`` arrow list offsets selecting the ragged batch form: MOC ``i``
+        spans ``b[offsets[i]:offsets[i + 1]]``, and the offsets must exactly
+        cover ``b``.  ``None`` (default) is the two-cover form.
 
     Returns
     -------
-    numpy.ndarray
-        Sorted, compacted intersection (``uint64``).
+    numpy.ndarray or tuple of numpy.ndarray
+        Without ``offsets``, the sorted, compacted intersection (``uint64``).
+        With ``offsets``, the ragged ``(values, out_offsets)`` pair; an empty
+        intersection keeps its slot.
 
     See Also
     --------
     moc_or : union of two covers.
     moc_minus : difference ``a \ b``.
     moc_intersects : tests for overlap without materializing this result.
-    mortie.batch.mocs_and : the 1 x N broadcast form (one shared cover
-        against many ragged MOCs).
+    mortie.batch.mocs_and : the 1 x N broadcast kernel this delegates to.
     """
+    if offsets is not None:
+        from .batch import mocs_and
+        return mocs_and(a, b, offsets)
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
     return np.asarray(_rustie.rust_moc_and(a, b))
 
 
-def moc_intersects(a, b):
+def moc_intersects(a, b, *, offsets=None):
     """Whether two morton covers intersect (share any area at any order).
 
     The predicate twin of :func:`moc_and` (issue #173): ``moc_intersects(a, b)``
@@ -186,22 +221,36 @@ def moc_intersects(a, b):
     overlap, never identity against a compacted cover, so a dense region that
     compacts to its parent still answers ``True`` for any cell inside it.
 
+    **Batch vectorized** (issue #187): pass ``offsets`` and ``b`` is read as a
+    ragged column of MOCs, each tested against the shared cover ``a``, giving
+    one ``bool`` per item.
+
     Parameters
     ----------
     a, b : array_like
-        Morton covers (mixed order allowed).
+        Morton covers (mixed order allowed).  With ``offsets``, ``b`` is the
+        flat concatenation of the column and ``a`` stays the shared operand.
+    offsets : array_like or None, optional
+        ``int64`` arrow list offsets selecting the ragged batch form: MOC ``i``
+        spans ``b[offsets[i]:offsets[i + 1]]``, and the offsets must exactly
+        cover ``b``.  ``None`` (default) is the two-cover form.
 
     Returns
     -------
-    bool
-        ``True`` if the two covers share any area.
+    bool or numpy.ndarray
+        Without ``offsets``, ``True`` if the two covers share any area.  With
+        ``offsets``, a ``bool`` array of length ``len(offsets) - 1``, agreeing
+        item-for-item with the non-empty slots of the ``offsets`` form of
+        :func:`moc_and`.
 
     See Also
     --------
     moc_and : materializes the intersection this only tests.
-    mortie.batch.mocs_intersect : the 1 x N broadcast form (one shared cover
-        against many ragged MOCs).
+    mortie.batch.mocs_intersect : the 1 x N broadcast kernel this delegates to.
     """
+    if offsets is not None:
+        from .batch import mocs_intersect
+        return mocs_intersect(a, b, offsets)
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
     return bool(_rustie.rust_moc_intersects(a, b))
@@ -346,7 +395,7 @@ def moc_not(cover, domain=None):
     return moc_minus(domain, cover)
 
 
-def common_ancestor(morton):
+def common_ancestor(morton, *, offsets=None):
     """Deepest common ancestor (highest-order common parent) of a morton set.
 
     The array-reduction sibling of :func:`clip2order` (coarsen): where coarsening
@@ -357,33 +406,44 @@ def common_ancestor(morton):
     common base cell, capped at each word's own order — so mixed-order input is
     fine (each word is capped at its own order).
 
+    **Batch vectorized** (issue #187): one group in, one word out; pass
+    ``offsets`` and the same call reduces a whole ragged column of groups in
+    one crossing, giving one word per group.
+
     Parameters
     ----------
     morton : array_like
         Morton indices (mixed order allowed).  A single index returns itself.
+        With ``offsets``, the flat concatenation of every group in the column.
+    offsets : array_like or None, optional
+        ``int64`` arrow list offsets selecting the ragged batch form: group
+        ``i`` spans ``morton[offsets[i]:offsets[i + 1]]``, and the offsets must
+        exactly cover ``morton``.  ``None`` (default) is the one-group form.
 
     Returns
     -------
-    numpy.uint64
+    numpy.uint64 or numpy.ndarray
         The packed morton index of the deepest cell that contains every input.
         A batch (more than one input) always yields an **area** cell — even when
         the inputs collapse to a single order-29 cell, since the shared cell is
         an enclosing area, not any one input point.  Only a single-element input
         is returned unchanged (its area/point kind preserved), so a lone area or
-        point returns itself.
+        point returns itself.  With ``offsets``, a ``uint64`` array holding that
+        word for each group.
 
     Raises
     ------
     ValueError
         If ``morton`` is empty, contains an empty/invalid word, or spans more
         than one HEALPix base cell — there is then no common ancestor above the
-        (non-existent) whole-sphere root.
+        (non-existent) whole-sphere root.  In the ragged form the message names
+        the lowest-index offending group, and bad offsets raise here too.
 
     See Also
     --------
     clip2order : coarsen each word to a fixed order (the elementwise form;
         ``common_ancestor`` is its reduce-by-common-coarsening reduction).
-    mortie.batch.common_ancestors : the batch form (many groups in one call).
+    mortie.batch.common_ancestors : the ragged batch kernel this delegates to.
 
     Examples
     --------
@@ -395,6 +455,9 @@ def common_ancestor(morton):
     >>> int(mortie.common_ancestor(kids)) == int(parent)
     True
     """
+    if offsets is not None:
+        from .batch import common_ancestors
+        return common_ancestors(morton, offsets)
     morton = np.asarray(morton, dtype=np.uint64).ravel()
     return np.uint64(_rustie.rust_moc_min(morton))
 

--- a/mortie/moc.py
+++ b/mortie/moc.py
@@ -30,6 +30,12 @@ import warnings
 import numpy as np
 
 from . import _rustie
+from .batch import (
+    common_ancestors,
+    mocs_and,
+    mocs_intersect,
+    mocs_to_orders,
+)
 from .convert import norm2mort
 from .coverage import _FLAT_COVER_WARN_THRESHOLD
 
@@ -85,9 +91,11 @@ def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD, *,
 
     **Batch vectorized** (issue #187): one MOC in, one flat cover out; pass
     ``offsets`` and the same call densifies a whole ragged column of MOCs in
-    one crossing, returning the ``(values, out_offsets)`` pair.  The input
-    shape selects the form — there is no separate plural entry point to keep in
-    parity.
+    one crossing, returning the ``(values, out_offsets)`` pair.  Passing
+    ``offsets`` is what selects the form: a MOC is itself an array, so unlike
+    :func:`~mortie.morton_index.decimal_to_word` there is no rank difference
+    to dispatch on.  :func:`mortie.batch.mocs_to_orders` is still exported and
+    still the kernel underneath; retiring that name is phase 4 of issue #187.
 
     Parameters
     ----------
@@ -102,7 +110,9 @@ def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD, *,
         ``1 << 20`` — the same ~1M-cell line as the flat-cover warning).  Pass
         ``None`` to opt out and densify unconditionally.  With ``offsets`` the
         budget applies **per MOC**, and the refusal names the lowest-index
-        offending MOC.
+        offending MOC *within its kind* — offset-layout errors are screened in
+        their own pass ahead of the budget, so a bad layout is reported before
+        an over-budget MOC at a lower index.
     offsets : array_like or None, optional
         ``int64`` arrow list offsets selecting the ragged batch form: MOC ``i``
         spans ``morton[offsets[i]:offsets[i + 1]]``, and the offsets must
@@ -129,7 +139,6 @@ def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD, *,
     mortie.batch.mocs_to_orders : the ragged batch kernel this delegates to.
     """
     if offsets is not None:
-        from .batch import mocs_to_orders
         return mocs_to_orders(morton, offsets, order, max_cells)
     morton = np.asarray(morton, dtype=np.uint64).ravel()
     if not 0 <= order <= 29:
@@ -188,7 +197,10 @@ def moc_and(a, b, *, offsets=None):
     ----------
     a, b : array_like
         Morton covers (mixed order allowed).  With ``offsets``, ``b`` is the
-        flat concatenation of the column and ``a`` stays the shared operand.
+        flat concatenation of the column and ``a`` stays the shared operand —
+        so the two are **not** interchangeable in the batch form even though
+        the operation itself is commutative, and swapping them is a different
+        question rather than an error.
     offsets : array_like or None, optional
         ``int64`` arrow list offsets selecting the ragged batch form: MOC ``i``
         spans ``b[offsets[i]:offsets[i + 1]]``, and the offsets must exactly
@@ -209,7 +221,6 @@ def moc_and(a, b, *, offsets=None):
     mortie.batch.mocs_and : the 1 x N broadcast kernel this delegates to.
     """
     if offsets is not None:
-        from .batch import mocs_and
         return mocs_and(a, b, offsets)
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
@@ -234,7 +245,10 @@ def moc_intersects(a, b, *, offsets=None):
     ----------
     a, b : array_like
         Morton covers (mixed order allowed).  With ``offsets``, ``b`` is the
-        flat concatenation of the column and ``a`` stays the shared operand.
+        flat concatenation of the column and ``a`` stays the shared operand —
+        so the two are **not** interchangeable in the batch form even though
+        the operation itself is commutative, and swapping them is a different
+        question rather than an error.
     offsets : array_like or None, optional
         ``int64`` arrow list offsets selecting the ragged batch form: MOC ``i``
         spans ``b[offsets[i]:offsets[i + 1]]``, and the offsets must exactly
@@ -254,7 +268,6 @@ def moc_intersects(a, b, *, offsets=None):
     mortie.batch.mocs_intersect : the 1 x N broadcast kernel this delegates to.
     """
     if offsets is not None:
-        from .batch import mocs_intersect
         return mocs_intersect(a, b, offsets)
     a = np.asarray(a, dtype=np.uint64).ravel()
     b = np.asarray(b, dtype=np.uint64).ravel()
@@ -451,7 +464,9 @@ def common_ancestor(morton, *, offsets=None):
         If ``morton`` is empty, contains an empty/invalid word, or spans more
         than one HEALPix base cell — there is then no common ancestor above the
         (non-existent) whole-sphere root.  In the ragged form the message names
-        the lowest-index offending group, and bad offsets raise here too.
+        the lowest-index offending group *within its kind* (layout errors are
+        screened in their own pass, ahead of the per-group content check), and
+        bad offsets raise here too.
 
     See Also
     --------
@@ -470,7 +485,6 @@ def common_ancestor(morton, *, offsets=None):
     True
     """
     if offsets is not None:
-        from .batch import common_ancestors
         return common_ancestors(morton, offsets)
     morton = np.asarray(morton, dtype=np.uint64).ravel()
     return np.uint64(_rustie.rust_moc_min(morton))

--- a/mortie/moc.py
+++ b/mortie/moc.py
@@ -41,6 +41,8 @@ def compress_moc(morton):
     any cell already contained in a coarser one.  Use after unioning covers from
     several polygons / parts so that sibling groups spanning the seams collapse.
 
+    **Not batch vectorized**: one MOC per call.
+
     Parameters
     ----------
     morton : array_like
@@ -149,6 +151,9 @@ def moc_or(a, b):
 
     Equivalent to ``compress_moc(concatenate([a, b]))``, but computed by the
     healpix-crate BMOC ``or`` rather than a concatenate-then-compress pass.
+
+    **Not batch vectorized**: one pair of covers per call — there is no batch
+    kernel behind it, unlike :func:`moc_and`.
 
     Parameters
     ----------
@@ -261,6 +266,9 @@ def moc_minus(a, b):
 
     Computes ``a \ b``.
 
+    **Not batch vectorized**: one pair of covers per call — there is no batch
+    kernel behind it, unlike :func:`moc_and`.
+
     Parameters
     ----------
     a, b : array_like
@@ -288,6 +296,9 @@ def moc_xor(a, b):
     ``moc_minus(moc_or(a, b), moc_and(a, b))``.  Useful for "what changed"
     between two coverages: against an earlier cover ``a`` and a later cover
     ``b``, ``moc_xor`` is exactly the cells that gained *or* lost coverage.
+
+    **Not batch vectorized**: one pair of covers per call — there is no batch
+    kernel behind it, unlike :func:`moc_and`.
 
     Parameters
     ----------
@@ -332,6 +343,9 @@ def moc_not(cover, domain=None):
     only well-defined relative to a bounded domain, so ``moc_not`` is a
     domain-bounded difference: it returns ``domain \ cover``, i.e.
     ``moc_minus(domain, cover)``.
+
+    **Not batch vectorized**: one cover per call — there is no batch kernel
+    behind it, unlike :func:`moc_and`.
 
     Parameters
     ----------
@@ -478,6 +492,8 @@ def split_base_cells(words, sort=False):
     describing (a packed word the same 64 bits wide as the data) and from which
     the base cell id is cheap to recover (e.g. ``mort2healpix`` /
     ``MortonIndexArray.base_cell``).
+
+    **Not batch vectorized**: one word set per call.
 
     Parameters
     ----------

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -159,16 +159,24 @@ def decimal_to_word(s, dtype=np.uint64):
     decimals_to_words : the vectorized kernel the array form delegates to.
     """
     if not isinstance(s, str):
-        try:
-            uint64_asked = np.dtype(dtype) == np.uint64
-        except TypeError:
+        # `MortonIndexScalar` is a uint64 subclass, so `np.dtype` resolves it
+        # to uint64 -- it has to be ruled out by identity before that check, or
+        # asking for it on array input would silently return bare words.
+        if isinstance(dtype, type) and issubclass(dtype, MortonIndexScalar):
             uint64_asked = False
+        else:
+            try:
+                uint64_asked = np.dtype(dtype) == np.uint64
+            except TypeError:
+                uint64_asked = False
         if not uint64_asked:
             raise TypeError(
                 f"decimal_to_word dtype must be np.uint64 (the default) for "
                 f"array input, which is always uint64; got {dtype!r}"
             )
-        return decimals_to_words(s)
+        words = decimals_to_words(s)
+        # numpy semantics exactly: a 0-d input is a scalar, not a 0-d array.
+        return words if words.ndim else np.uint64(words)
     word = int(_rustie.rust_mi_from_decimal([s])[0])
     if dtype is int:
         return word

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -198,6 +198,8 @@ def decimals_to_words(decimals):
     Rust in one pass. Shape is preserved; the result is always ``uint64``.
     numpy-only, like :func:`decimal_to_word`.
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     decimals : array_like of str

--- a/mortie/morton_index.py
+++ b/mortie/morton_index.py
@@ -119,12 +119,18 @@ def decimal_to_word(s, dtype=np.uint64):
     is unmarked).
 
     numpy-only: calling this imports no pandas, so it is usable from hot
-    per-key parse paths. Use :func:`decimals_to_words` for arrays.
+    per-key parse paths.
+
+    **Batch vectorized** (issue #187), with numpy semantics literally: a
+    ``str`` in gives one word out, anything else is treated as an array of ids
+    and gives an array of words back, parsed in Rust in one pass. The array
+    form is always ``uint64``, so ``dtype`` applies to the scalar form only.
 
     Parameters
     ----------
-    s : str
-        The decimal Morton id, e.g. ``"-31123"``.
+    s : str or array_like of str
+        The decimal Morton id, e.g. ``"-31123"``, or an array of them (any
+        shape) for the vectorized form.
     dtype : type, optional
         The return shape. ``np.uint64`` (default) returns the bare packed
         word, staying numpy-native for hot loops; ``int`` returns a Python
@@ -134,21 +140,35 @@ def decimal_to_word(s, dtype=np.uint64):
 
     Returns
     -------
-    numpy.uint64 or int or MortonIndexScalar
-        The packed word, in the shape requested by ``dtype``.
+    numpy.uint64 or int or MortonIndexScalar or numpy.ndarray
+        The packed word, in the shape requested by ``dtype``; for array input,
+        a ``uint64`` array in the shape of ``s``.
 
     Raises
     ------
     ValueError
-        If ``s`` is a malformed decimal Morton id.
+        If ``s`` is a malformed decimal Morton id -- naming the first
+        offender, in input order, for the array form.
     TypeError
         If ``dtype`` is not ``np.uint64`` (or a spelling of it), ``int``, or
-        :class:`MortonIndexScalar`.
+        :class:`MortonIndexScalar`; or if a non-``uint64`` ``dtype`` is asked
+        for alongside array input, which has no scalar shape to return.
 
     See Also
     --------
-    decimals_to_words : The vectorized array counterpart.
+    decimals_to_words : the vectorized kernel the array form delegates to.
     """
+    if not isinstance(s, str):
+        try:
+            uint64_asked = np.dtype(dtype) == np.uint64
+        except TypeError:
+            uint64_asked = False
+        if not uint64_asked:
+            raise TypeError(
+                f"decimal_to_word dtype must be np.uint64 (the default) for "
+                f"array input, which is always uint64; got {dtype!r}"
+            )
+        return decimals_to_words(s)
     word = int(_rustie.rust_mi_from_decimal([s])[0])
     if dtype is int:
         return word

--- a/mortie/orders.py
+++ b/mortie/orders.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 import numpy as np
 
 from . import _rustie
+from .batch import children_of
 
 # One row of the res2display resolution ladder (issue #68): the display pair
 # (value + unit, rounded within its bracket) alongside the unrounded km, so
@@ -403,20 +404,24 @@ def generate_morton_children(parent_morton, target_order, *, max_cells=None):
     gives the 1-D ``(4**d,)`` block of its children, and an *array* of parents
     gives the dense ``(n, 4**d)`` matrix — one row per parent, in input order.
     Every parent in an array must sit at one shared order, which is what makes
-    the result dense rather than ragged.  Passing an array used to silently
-    describe only its first element, so the array form is new behaviour rather
-    than a re-spelling.
+    the result dense rather than ragged.  The array form is **new behaviour,
+    not a re-spelling**: an array used to be coerced through ``np.uint64`` and
+    describe only its first element whenever ``target_order`` was finer than
+    the parents' order (at equal order it happened to return the parents
+    themselves), so a caller who was passing one gets a corrected answer of a
+    different shape.  Only 1-D is accepted — a higher-rank array raises rather
+    than flattening, since a flattened result could not be indexed back.
 
     Parameters
     ----------
     parent_morton : int or array_like
-        Parent packed morton word, or an array of them (all at one order).
+        Parent packed morton word, or a 1-D array of them (all at one order).
     target_order : int
         Target order for children (must be >= parent order).
     max_cells : int or None, optional
-        Budget on the total children produced, applied to the array form only
-        (the scalar form's result is bounded by its one parent).  ``None``
-        (default) is unbudgeted.
+        Budget on the total children produced, refused pre-emptively in both
+        forms (``4**d`` for a scalar parent, ``n * 4**d`` for an array).
+        ``None`` (default) is unbudgeted.
 
     Returns
     -------
@@ -444,8 +449,12 @@ def generate_morton_children(parent_morton, target_order, *, max_cells=None):
     morton words via the kernel. If already at target_order, returns the parent
     itself.
     """
+    if np.ndim(parent_morton) > 1:
+        raise ValueError(
+            f"parent_morton must be a scalar or 1-D, got "
+            f"{np.ndim(parent_morton)}-D"
+        )
     if np.ndim(parent_morton) > 0:
-        from .batch import children_of
         return children_of(parent_morton, target_order, max_cells)
     # Decode the parent to its (nested, depth) via the packed kernel.
     parent_morton = np.uint64(parent_morton)
@@ -458,6 +467,13 @@ def generate_morton_children(parent_morton, target_order, *, max_cells=None):
     if target_order < parent_order:
         raise ValueError(
             f"target_order ({target_order}) must be >= parent_order ({parent_order})"
+        )
+
+    if max_cells is not None and 4 ** (target_order - parent_order) > max_cells:
+        raise ValueError(
+            f"generate_morton_children would produce "
+            f"{4 ** (target_order - parent_order)} children at order "
+            f"{target_order}, exceeding max_cells={max_cells}"
         )
 
     if target_order == parent_order:

--- a/mortie/orders.py
+++ b/mortie/orders.py
@@ -54,6 +54,8 @@ def order2res(order):
     ``order`` may be a scalar (returns a ``float``) or an array of orders such
     as :func:`orders_of` yields (returns an ``ndarray``).
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     order : int or array-like
@@ -86,6 +88,8 @@ def res2display(max_order=MAX_ORDER):
     rounded to three decimals within that bracket, so fine orders read
     naturally (order 12 -> ``1.592 km``, order 13 -> ``795.852 m``) rather
     than as tiny km fractions.
+
+    **Not batch vectorized**: one ladder per call.
 
     Parameters
     ----------
@@ -158,6 +162,8 @@ def orders_of_uniq(uniq):
     to *some* order. UNIQ has no such total decode -- a value outside
     ``[4, 4**31)`` names no cell at any order -- so this raises instead of
     inventing an answer.
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------
@@ -232,6 +238,8 @@ def orders_of(morton):
     words). This is the per-element, mixed-order-native counterpart of
     :func:`infer_order_from_morton`.
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     morton : int or array-like
@@ -263,6 +271,8 @@ def is_point(morton):
     table). Pure bit arithmetic; words are not validated (see
     :func:`validate_morton`).
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     morton : int or array-like
@@ -287,6 +297,9 @@ def infer_order_from_morton(morton):
     raises, naming the distinct orders (issue #116 — previously the first
     element's order was returned silently). For per-element orders of a mixed
     array use :func:`orders_of`.
+
+    **Batch vectorized**: array in, one order out — a reduction, not
+    elementwise.
 
     Parameters
     ----------
@@ -363,6 +376,9 @@ def clip2order(clip_order, midx):
     order-19..29 words this package now encodes. There is no replacement: the
     levels a word actually drops is ``order - clip_order`` for its own decoded
     order, which :func:`orders_of` gives directly.
+
+    **Batch vectorized**: array in, array out, elementwise (one shared
+    ``clip_order``).
 
     Parameters
     ----------

--- a/mortie/orders.py
+++ b/mortie/orders.py
@@ -380,31 +380,46 @@ def clip2order(clip_order, midx):
     return _rustie.rust_mi_coarsen(midx, int(clip_order))
 
 
-def generate_morton_children(parent_morton, target_order):
+def generate_morton_children(parent_morton, target_order, *, max_cells=None):
     """Generate all child morton indices at a target order.
+
+    **Batch vectorized** (issue #187), with numpy semantics: a scalar parent
+    gives the 1-D ``(4**d,)`` block of its children, and an *array* of parents
+    gives the dense ``(n, 4**d)`` matrix — one row per parent, in input order.
+    Every parent in an array must sit at one shared order, which is what makes
+    the result dense rather than ragged.  Passing an array used to silently
+    describe only its first element, so the array form is new behaviour rather
+    than a re-spelling.
 
     Parameters
     ----------
-    parent_morton : int
-        Parent packed morton word.
+    parent_morton : int or array_like
+        Parent packed morton word, or an array of them (all at one order).
     target_order : int
         Target order for children (must be >= parent order).
+    max_cells : int or None, optional
+        Budget on the total children produced, applied to the array form only
+        (the scalar form's result is bounded by its one parent).  ``None``
+        (default) is unbudgeted.
 
     Returns
     -------
     children : ndarray
         Array of child packed morton words at target_order.
         If target_order equals parent_order, returns array with parent_morton.
+        For array input, the ``(n, 4**d)`` matrix of every parent's children.
 
     Raises
     ------
     ValueError
-        If ``target_order`` is coarser than the parent word's own order.
+        If ``target_order`` is coarser than the parent word's own order, or
+        (array form) the parents do not share one order or the result would
+        exceed ``max_cells``.
 
     See Also
     --------
-    mortie.batch.children_of : the batch form (many parents at one order,
-        in one call).
+    mortie.batch.children_of : the dense batch kernel the array form delegates
+        to.
 
     Notes
     -----
@@ -413,6 +428,9 @@ def generate_morton_children(parent_morton, target_order):
     morton words via the kernel. If already at target_order, returns the parent
     itself.
     """
+    if np.ndim(parent_morton) > 0:
+        from .batch import children_of
+        return children_of(parent_morton, target_order, max_cells)
     # Decode the parent to its (nested, depth) via the packed kernel.
     parent_morton = np.uint64(parent_morton)
     nested, depths = _rust_mort2nested(

--- a/mortie/prefix_trie.py
+++ b/mortie/prefix_trie.py
@@ -295,6 +295,8 @@ def _rebuild_tree_from_flat(flat_nodes, permutation, morton_array):
 def split_children(morton_array, max_depth=4):
     """Build a compacted prefix trie over *morton_array* and return root children.
 
+    **Not batch vectorized**: one array of words → one trie per call.
+
     Parameters
     ----------
     morton_array : array-like of int
@@ -326,6 +328,8 @@ def split_children(morton_array, max_depth=4):
 def split_children_geo(lats, lons, order=18, max_depth=4, *,
                        latitude="authalic"):
     """Build compacted prefix trie from geographic coordinates.
+
+    **Not batch vectorized**: one coordinate set → one trie per call.
 
     Parameters
     ----------
@@ -364,6 +368,8 @@ def geo_morton_polygon(lats, lons, n_cells, order=18, max_depth=None, *,
     - ``n_cells=4``  → bounding box (4 prefix-cells)
     - ``n_cells=12`` → polygon (tighter fit, 12 prefix-cells)
 
+    **Not batch vectorized**: one coordinate set → one refinement per call.
+
     Parameters
     ----------
     lats, lons : array-like
@@ -398,6 +404,8 @@ def geo_morton_polygon(lats, lons, n_cells, order=18, max_depth=None, *,
 
 def morton_polygon_from_array(morton_array, n_cells, max_depth=None):
     """Build trie and refine to *n_cells* in one call.
+
+    **Not batch vectorized**: one array of words → one refinement per call.
 
     Parameters
     ----------
@@ -477,6 +485,8 @@ def morton_polygon(roots, n_cells):
 
     Coverage is preserved because expansion only replaces a parent with its
     exact children — no points are lost or duplicated.
+
+    **Not batch vectorized**: one trie per call, expanded in a Python loop.
 
     Parameters
     ----------

--- a/mortie/rank_xy.py
+++ b/mortie/rank_xy.py
@@ -101,6 +101,9 @@ def rank_to_xy(rank, depth):
     face-0 pixels. Input is the rank *within* a subtree (e.g. after
     stripping a shard prefix), never a packed morton word.
 
+    **Batch vectorized**: array in, arrays out, elementwise (one shared
+    ``depth``).
+
     Parameters
     ----------
     rank : int or array-like
@@ -142,6 +145,9 @@ def xy_to_rank(x, y, depth):
     The exact inverse of :func:`rank_to_xy`: ``x`` supplies the even bits
     of the rank, ``y`` the odd bits (healpy / HEALPix C++ ``xyf2pix``
     convention). ``x`` and ``y`` broadcast against each other.
+
+    **Batch vectorized**: array in, array out, elementwise (one shared
+    ``depth``).
 
     Parameters
     ----------

--- a/mortie/tests/test_polymorphic_api.py
+++ b/mortie/tests/test_polymorphic_api.py
@@ -1,0 +1,165 @@
+"""Tests for the polymorphic (one-function-per-operation) API (issue #187).
+
+Each operation is meant to have **one** public entry point whose input shape
+selects the form: the bare call is the single-item form, and passing the ragged
+``offsets`` keyword makes the same call the batch form.  The contract asserted
+here is that the polymorphic form is not a second semantics -- it is
+byte-identical both to the plural sibling it delegates to and to a Python loop
+over the single-item form -- and that the error surface passes through
+unchanged (the batch refusals still name the lowest-index offender, and still
+arrive as catchable :class:`ValueError`).
+"""
+
+import numpy as np
+import pytest
+
+import mortie
+
+# ---------------------------------------------------------------------------
+# Fixtures: a small ragged column of MOCs with a mixed-order, empty and
+# single-cell item, so every slot shape the batch admits is exercised.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def column():
+    """Ragged (values, offsets) column of four MOCs, one of them empty."""
+    base = mortie.norm2mort(np.arange(16), np.zeros(16, dtype=int), 2)
+    mocs = [
+        base[:4],                       # four siblings (compacts to a parent)
+        base[5:9],                      # a straddling run
+        base[:0],                       # empty MOC -- legal, keeps its slot
+        base[10:11],                    # single cell
+    ]
+    values = np.concatenate(mocs).astype(np.uint64)
+    offsets = np.cumsum([0] + [len(m) for m in mocs]).astype(np.int64)
+    return values, offsets
+
+
+def _slices(values, offsets):
+    return [values[offsets[i]:offsets[i + 1]] for i in range(len(offsets) - 1)]
+
+
+# ---------------------------------------------------------------------------
+# moc_to_order
+# ---------------------------------------------------------------------------
+
+
+def test_moc_to_order_offsets_matches_plural(column):
+    values, offsets = column
+    got_v, got_o = mortie.moc_to_order(values, 4, offsets=offsets)
+    want_v, want_o = mortie.mocs_to_orders(values, offsets, 4)
+    np.testing.assert_array_equal(got_v, want_v)
+    np.testing.assert_array_equal(got_o, want_o)
+
+
+def test_moc_to_order_offsets_matches_scalar_loop(column):
+    values, offsets = column
+    got_v, got_o = mortie.moc_to_order(values, 4, offsets=offsets)
+    for i, moc in enumerate(_slices(values, offsets)):
+        np.testing.assert_array_equal(
+            got_v[got_o[i]:got_o[i + 1]], mortie.moc_to_order(moc, 4)
+        )
+
+
+def test_moc_to_order_offsets_none_is_the_scalar_form(column):
+    values, offsets = column
+    moc = values[offsets[0]:offsets[1]]
+    np.testing.assert_array_equal(
+        mortie.moc_to_order(moc, 4, offsets=None), mortie.moc_to_order(moc, 4)
+    )
+
+
+def test_moc_to_order_offsets_keeps_per_item_budget_refusal(column):
+    values, offsets = column
+    with pytest.raises(ValueError, match="moc 0"):
+        mortie.moc_to_order(values, 12, max_cells=8, offsets=offsets)
+
+
+def test_moc_to_order_offsets_is_keyword_only(column):
+    values, offsets = column
+    with pytest.raises(TypeError):
+        mortie.moc_to_order(values, 4, None, offsets)
+
+
+# ---------------------------------------------------------------------------
+# moc_and / moc_intersects
+# ---------------------------------------------------------------------------
+
+
+def test_moc_and_offsets_matches_plural(column):
+    values, offsets = column
+    shared = mortie.norm2mort(np.arange(8), np.zeros(8, dtype=int), 2)
+    got_v, got_o = mortie.moc_and(shared, values, offsets=offsets)
+    want_v, want_o = mortie.mocs_and(shared, values, offsets)
+    np.testing.assert_array_equal(got_v, want_v)
+    np.testing.assert_array_equal(got_o, want_o)
+
+
+def test_moc_and_offsets_matches_scalar_loop(column):
+    values, offsets = column
+    shared = mortie.norm2mort(np.arange(8), np.zeros(8, dtype=int), 2)
+    got_v, got_o = mortie.moc_and(shared, values, offsets=offsets)
+    for i, moc in enumerate(_slices(values, offsets)):
+        np.testing.assert_array_equal(
+            got_v[got_o[i]:got_o[i + 1]], mortie.moc_and(shared, moc)
+        )
+
+
+def test_moc_intersects_offsets_matches_plural_and_loop(column):
+    values, offsets = column
+    shared = mortie.norm2mort(np.arange(8), np.zeros(8, dtype=int), 2)
+    got = mortie.moc_intersects(shared, values, offsets=offsets)
+    np.testing.assert_array_equal(
+        got, mortie.mocs_intersect(shared, values, offsets)
+    )
+    np.testing.assert_array_equal(
+        got,
+        [mortie.moc_intersects(shared, m) for m in _slices(values, offsets)],
+    )
+
+
+def test_moc_intersects_offsets_agrees_with_moc_and_slots(column):
+    values, offsets = column
+    shared = mortie.norm2mort(np.arange(8), np.zeros(8, dtype=int), 2)
+    hits = mortie.moc_intersects(shared, values, offsets=offsets)
+    _, out_off = mortie.moc_and(shared, values, offsets=offsets)
+    np.testing.assert_array_equal(hits, np.diff(out_off) > 0)
+
+
+def test_moc_and_offsets_rejects_offsets_not_covering_values(column):
+    values, offsets = column
+    shared = values[:2]
+    with pytest.raises(ValueError):
+        mortie.moc_and(shared, values, offsets=offsets[:-1])
+
+
+# ---------------------------------------------------------------------------
+# common_ancestor (and its moc_min alias)
+# ---------------------------------------------------------------------------
+
+
+def test_common_ancestor_offsets_matches_plural_and_loop(column):
+    values, offsets = column
+    # The empty slot has no common ancestor, so reduce over the non-empty ones.
+    keep = np.array([0, 4, 8, 9], dtype=np.int64)
+    got = mortie.common_ancestor(values, offsets=keep)
+    np.testing.assert_array_equal(got, mortie.common_ancestors(values, keep))
+    np.testing.assert_array_equal(
+        got, [mortie.common_ancestor(m) for m in _slices(values, keep)]
+    )
+
+
+def test_moc_min_alias_is_polymorphic_too(column):
+    values, _ = column
+    keep = np.array([0, 4, 8, 9], dtype=np.int64)
+    np.testing.assert_array_equal(
+        mortie.moc_min(values, offsets=keep),
+        mortie.common_ancestor(values, offsets=keep),
+    )
+
+
+def test_common_ancestor_offsets_refusal_names_the_group(column):
+    values, offsets = column
+    with pytest.raises(ValueError, match="group 2|2:"):
+        mortie.common_ancestor(values, offsets=offsets)

--- a/mortie/tests/test_polymorphic_api.py
+++ b/mortie/tests/test_polymorphic_api.py
@@ -163,3 +163,101 @@ def test_common_ancestor_offsets_refusal_names_the_group(column):
     values, offsets = column
     with pytest.raises(ValueError, match="group 2|2:"):
         mortie.common_ancestor(values, offsets=offsets)
+
+
+# ---------------------------------------------------------------------------
+# toc_reduce
+# ---------------------------------------------------------------------------
+
+
+def test_toc_reduce_offsets_matches_plural_and_loop():
+    words = np.array(
+        [mortie.time2toc(t) for t in (10**9, 2 * 10**9, 5 * 10**9, 7 * 10**9)],
+        dtype=np.uint64,
+    )
+    offsets = np.array([0, 2, 3, 4], dtype=np.int64)
+    got = mortie.toc_reduce(words, offsets=offsets)
+    np.testing.assert_array_equal(got, mortie.tocs_reduce(words, offsets))
+    np.testing.assert_array_equal(
+        got, [mortie.toc_reduce(g) for g in _slices(words, offsets)]
+    )
+
+
+def test_toc_reduce_offsets_none_is_the_whole_array_form():
+    words = np.array([mortie.time2toc(10**9), mortie.time2toc(3 * 10**9)],
+                     dtype=np.uint64)
+    assert mortie.toc_reduce(words, offsets=None) == mortie.toc_reduce(words)
+
+
+def test_toc_reduce_offsets_refuses_an_empty_group():
+    words = np.array([mortie.time2toc(10**9)], dtype=np.uint64)
+    with pytest.raises(ValueError):
+        mortie.toc_reduce(words, offsets=np.array([0, 0, 1], dtype=np.int64))
+
+
+# ---------------------------------------------------------------------------
+# decimal_to_word
+# ---------------------------------------------------------------------------
+
+
+def test_decimal_to_word_array_matches_plural_and_loop():
+    ids = np.array(["-31123", "12341", "6444"])
+    got = mortie.decimal_to_word(ids)
+    np.testing.assert_array_equal(got, mortie.decimals_to_words(ids))
+    np.testing.assert_array_equal(
+        got, [mortie.decimal_to_word(s) for s in ids]
+    )
+    assert got.dtype == np.uint64
+
+
+def test_decimal_to_word_preserves_shape_and_scalar_form():
+    ids = np.array([["-31123", "12341"], ["6444", "12341"]])
+    assert mortie.decimal_to_word(ids).shape == (2, 2)
+    # A bare str stays scalar -- not a 0-d array.
+    assert isinstance(mortie.decimal_to_word("12341"), np.uint64)
+    assert mortie.decimal_to_word("12341", dtype=int) == int(
+        mortie.decimal_to_word("12341")
+    )
+
+
+def test_decimal_to_word_rejects_non_uint64_dtype_for_arrays():
+    with pytest.raises(TypeError, match="always uint64"):
+        mortie.decimal_to_word(["12341"], dtype=int)
+
+
+# ---------------------------------------------------------------------------
+# generate_morton_children
+# ---------------------------------------------------------------------------
+
+
+def test_generate_morton_children_array_matches_plural_and_loop():
+    parents = mortie.norm2mort(np.arange(4), np.zeros(4, dtype=int), 3)
+    got = mortie.generate_morton_children(parents, 5)
+    np.testing.assert_array_equal(got, mortie.children_of(parents, 5))
+    np.testing.assert_array_equal(
+        got, [mortie.generate_morton_children(p, 5) for p in parents]
+    )
+    assert got.shape == (4, 16)
+
+
+def test_generate_morton_children_scalar_stays_one_dimensional():
+    parent = mortie.norm2mort(0, 0, 3)
+    kids = mortie.generate_morton_children(parent, 5)
+    assert kids.ndim == 1 and kids.shape == (16,)
+
+
+def test_generate_morton_children_length_one_array_is_a_row():
+    """A length-1 array used to describe only its first element (silently)."""
+    # norm2mort squeezes a length-1 input to a scalar, so build the array here.
+    parents = np.asarray([mortie.norm2mort(0, 0, 3)], dtype=np.uint64)
+    got = mortie.generate_morton_children(parents, 5)
+    assert got.shape == (1, 16)
+    np.testing.assert_array_equal(
+        got[0], mortie.generate_morton_children(parents[0], 5)
+    )
+
+
+def test_generate_morton_children_array_honours_max_cells():
+    parents = mortie.norm2mort(np.arange(4), np.zeros(4, dtype=int), 3)
+    with pytest.raises(ValueError):
+        mortie.generate_morton_children(parents, 8, max_cells=4)

--- a/mortie/tests/test_polymorphic_api.py
+++ b/mortie/tests/test_polymorphic_api.py
@@ -72,7 +72,7 @@ def test_moc_to_order_offsets_none_is_the_scalar_form(column):
 
 def test_moc_to_order_offsets_keeps_per_item_budget_refusal(column):
     values, offsets = column
-    with pytest.raises(ValueError, match="moc 0"):
+    with pytest.raises(ValueError, match=r"^moc 0: moc_to_order would densify"):
         mortie.moc_to_order(values, 12, max_cells=8, offsets=offsets)
 
 
@@ -130,7 +130,7 @@ def test_moc_intersects_offsets_agrees_with_moc_and_slots(column):
 def test_moc_and_offsets_rejects_offsets_not_covering_values(column):
     values, offsets = column
     shared = values[:2]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"offsets must end at the value count"):
         mortie.moc_and(shared, values, offsets=offsets[:-1])
 
 
@@ -161,7 +161,9 @@ def test_moc_min_alias_is_polymorphic_too(column):
 
 def test_common_ancestor_offsets_refusal_names_the_group(column):
     values, offsets = column
-    with pytest.raises(ValueError, match="group 2|2:"):
+    with pytest.raises(
+        ValueError, match=r"^group 2: empty input has no common ancestor"
+    ):
         mortie.common_ancestor(values, offsets=offsets)
 
 
@@ -191,7 +193,7 @@ def test_toc_reduce_offsets_none_is_the_whole_array_form():
 
 def test_toc_reduce_offsets_refuses_an_empty_group():
     words = np.array([mortie.time2toc(10**9)], dtype=np.uint64)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^group 0: tocs_reduce of an empty"):
         mortie.toc_reduce(words, offsets=np.array([0, 0, 1], dtype=np.int64))
 
 
@@ -257,7 +259,90 @@ def test_generate_morton_children_length_one_array_is_a_row():
     )
 
 
+def test_generate_morton_children_rejects_higher_rank():
+    parents = mortie.norm2mort(np.arange(4), np.zeros(4, dtype=int), 3)
+    with pytest.raises(ValueError, match=r"scalar or 1-D, got 2-D"):
+        mortie.generate_morton_children(parents.reshape(2, 2), 5)
+
+
+def test_generate_morton_children_scalar_honours_max_cells():
+    """The budget is refused pre-emptively in the scalar form too."""
+    parent = mortie.norm2mort(0, 0, 3)
+    with pytest.raises(ValueError, match=r"exceeding max_cells=4"):
+        mortie.generate_morton_children(parent, 8, max_cells=4)
+    assert mortie.generate_morton_children(parent, 5, max_cells=16).size == 16
+
+
+def test_decimal_to_word_zero_dim_input_returns_a_scalar():
+    """0-d in -> scalar out, the numpy semantics the API is meant to follow."""
+    got = mortie.decimal_to_word(np.array("12341"))
+    assert isinstance(got, np.uint64) and np.ndim(got) == 0
+    assert got == mortie.decimal_to_word("12341")
+
+
+def test_decimal_to_word_array_refuses_morton_index_scalar_dtype():
+    """MortonIndexScalar is a uint64 subclass, so it must be ruled out first."""
+    from mortie.morton_index import MortonIndexScalar
+
+    with pytest.raises(TypeError, match=r"always uint64"):
+        mortie.decimal_to_word(["12341"], dtype=MortonIndexScalar)
+
+
+# ---------------------------------------------------------------------------
+# Layout and budget edges shared by every ``offsets`` form
+# ---------------------------------------------------------------------------
+
+
+def test_offsets_accepts_a_plain_list(column):
+    values, offsets = column
+    got_v, got_o = mortie.moc_to_order(values, 4, offsets=list(map(int, offsets)))
+    want_v, want_o = mortie.moc_to_order(values, 4, offsets=offsets)
+    np.testing.assert_array_equal(got_v, want_v)
+    np.testing.assert_array_equal(got_o, want_o)
+
+
+def test_offsets_single_group_and_empty_column(column):
+    values, _ = column
+    one = np.array([0, len(values)], dtype=np.int64)
+    got_v, got_o = mortie.moc_to_order(values, 4, offsets=one)
+    np.testing.assert_array_equal(got_v, mortie.moc_to_order(values, 4))
+    np.testing.assert_array_equal(got_o, [0, len(got_v)])
+    # A column of zero MOCs is legal and yields nothing.
+    empty_v, empty_o = mortie.moc_to_order(
+        values[:0], 4, offsets=np.array([0], dtype=np.int64)
+    )
+    assert empty_v.size == 0
+    np.testing.assert_array_equal(empty_o, [0])
+
+
+def test_offsets_rejects_non_monotone_layout(column):
+    values, _ = column
+    bad = np.array([0, 5, 2, len(values)], dtype=np.int64)
+    with pytest.raises(ValueError):
+        mortie.moc_to_order(values, 4, offsets=bad)
+
+
+def test_offsets_honours_max_cells_none(column):
+    """``max_cells=None`` opts the whole column out, as it does one MOC."""
+    values, offsets = column
+    got_v, _ = mortie.moc_to_order(values, 12, max_cells=None, offsets=offsets)
+    assert got_v.size > (1 << 20)
+
+
+def test_moc_and_batch_operands_are_not_interchangeable(column):
+    """``a`` is the shared cover and ``b`` the column -- swapping asks a
+    different question, which is why the batch form is not commutative."""
+    values, offsets = column
+    shared = mortie.norm2mort(np.arange(8), np.zeros(8, dtype=int), 2)
+    _, out_off = mortie.moc_and(shared, values, offsets=offsets)
+    # Same group count, so the swap is silently well-formed rather than an error.
+    swapped_off = np.array([0, 2, 4, 6, len(shared)], dtype=np.int64)
+    _, other = mortie.moc_and(values, shared, offsets=swapped_off)
+    assert len(out_off) == len(other)
+    assert not np.array_equal(np.diff(out_off), np.diff(other))
+
+
 def test_generate_morton_children_array_honours_max_cells():
     parents = mortie.norm2mort(np.arange(4), np.zeros(4, dtype=int), 3)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"exceeding max_cells=4"):
         mortie.generate_morton_children(parents, 8, max_cells=4)

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -268,7 +268,7 @@ def toc_merge(a, b):
     return merged
 
 
-def toc_reduce(words):
+def toc_reduce(words, *, offsets=None):
     """Merge an array of toc words down to one word.
 
     The fold tree is unspecified (parallel under the hood) -- safe because
@@ -278,27 +278,40 @@ def toc_reduce(words):
     :func:`toc_merge`): each fold tree still answers deterministically, but
     the trees need not agree with one another.
 
+    **Batch vectorized** (issue #187): pass ``offsets`` and the same call
+    reduces a whole ragged column of groups, one word per group, in one
+    crossing.
+
     Parameters
     ----------
     words : array-like
-        Toc words (``uint64``), at least one.
+        Toc words (``uint64``), at least one.  With ``offsets``, the flat
+        concatenation of every group in the column.
+    offsets : array-like or None, optional
+        ``int64`` arrow list offsets selecting the segmented form: group ``i``
+        spans ``words[offsets[i]:offsets[i + 1]]``, and the offsets must
+        exactly cover ``words``.  ``None`` (default) is the whole-array form.
 
     Returns
     -------
-    int
-        The merged word.
+    int or numpy.ndarray
+        The merged word; with ``offsets``, a ``uint64`` array holding one
+        merged word per group.
 
     Raises
     ------
     ValueError
         If ``words`` is empty (the merge has no identity element), or is
-        negative or non-integer-typed.
+        negative or non-integer-typed.  With ``offsets``, an empty *group* is
+        refused for the same reason, naming the group.
 
     See Also
     --------
     toc_merge : the elementwise pairwise form.
-    tocs_reduce : the segmented form, one word per group.
+    tocs_reduce : the segmented kernel the ``offsets`` form delegates to.
     """
+    if offsets is not None:
+        return tocs_reduce(words, offsets)
     w = _as_u64(words, "words")
     return int(_rustie.rust_toc_reduce(np.ascontiguousarray(w.ravel())))
 

--- a/mortie/toc.py
+++ b/mortie/toc.py
@@ -106,6 +106,8 @@ def time2toc(t_ns):
     The word is ``t_ns`` with a 1 flag bit spliced in at position 31, so
     unsigned word order over timestamps is exactly the ns order.
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     t_ns : int or array-like
@@ -146,6 +148,8 @@ def span2toc(start_ns, end_ns):
     uniformly, including when ``end`` sits exactly on the 2^32 ns grid --
     so the encoded envelope always properly contains the interval.
     ``start_ns`` and ``end_ns`` broadcast against each other.
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------
@@ -193,6 +197,8 @@ def toc2time(words):
     strictly-greater ceiling guarantees this even for interval ends that
     sat exactly on the 2^32 ns grid).
 
+    **Batch vectorized**: array in, arrays out, elementwise.
+
     Parameters
     ----------
     words : int or array-like
@@ -234,6 +240,8 @@ def toc_merge(a, b):
     into a range word.  Exactly associative, commutative, and idempotent,
     so any fold tree over the same words produces the identical ``uint64``.
     ``a`` and ``b`` broadcast against each other.
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------
@@ -334,7 +342,12 @@ def tocs_reduce(words, offsets):
 
     Input is ragged in the arrow list layout the batch family uses; the
     **output is dense** — one ``uint64`` per group — because the reduction is
-    many→one per group, so there are no output offsets to carry.  The consumer
+    many→one per group, so there are no output offsets to carry.
+
+    **Batch native**: reached polymorphically by :func:`toc_reduce`'s
+    ``offsets`` form (issue #187).
+
+    The consumer
     this exists for is a per-cell fold: zagg's GEDI shot pooling and its ATL03
     overview envelopes-of-envelopes both run the scalar reduce once per cell
     (`zagg#410 <https://github.com/englacial/zagg/issues/410>`_), which is the
@@ -397,6 +410,8 @@ def tocs_reduce(words, offsets):
 def toc_is_range(words):
     """Test which variant each toc word is.
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     words : int or array-like
@@ -434,6 +449,9 @@ def toc_overlaps(words, q_start_ns, q_end_ns):
     interval doing so), and it **never under-reports**: every word whose
     real time content intersects the window tests True.  An empty window
     (``q_start_ns == q_end_ns``) matches nothing.
+
+    **Batch vectorized**: array in, array out, elementwise (one shared
+    window).
 
     Parameters
     ----------
@@ -474,6 +492,9 @@ def toc_contains(words, q_start_ns, q_end_ns):
     whose real interval fits the window but whose outward-rounded
     envelope spills past an edge tests False.  An empty window
     (``q_start_ns == q_end_ns``) contains nothing.
+
+    **Batch vectorized**: array in, array out, elementwise (one shared
+    window).
 
     Parameters
     ----------
@@ -601,6 +622,8 @@ def from_datetime64(when):
     the last 9 SI seconds of 1971 are not invertible (they alias early
     1972); conversion is exact and invertible from 1972 on.
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     when : datetime64, str, or array-like
@@ -660,6 +683,8 @@ def to_datetime64(t_ns):
     ``to_datetime64(from_datetime64(t))`` is exact for every ``datetime64``
     from 1972 on (no ``datetime64`` names a leap-second instant).
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     t_ns : int or array-like
@@ -702,6 +727,8 @@ def from_gps_ns(gps_ns):
     ICESat-2 ingest path (``delta_time`` + ``atlas_sdp_gps_epoch`` -> GPS
     ns) composes with this directly.
 
+    **Batch vectorized**: array in, array out, elementwise.
+
     Parameters
     ----------
     gps_ns : int or array-like
@@ -740,6 +767,8 @@ def to_gps_ns(t_ns):
 
     The exact inverse of :func:`from_gps_ns`.  Internal times before the
     GPS epoch have no non-negative GPS representation and are rejected.
+
+    **Batch vectorized**: array in, array out, elementwise.
 
     Parameters
     ----------


### PR DESCRIPTION
Refs #187.

Collapses the scalar/batch pairs to **one polymorphic function per operation**, per the leans ruled on the issue thread (https://github.com/espg/mortie/issues/187#issuecomment-5260514696): the un-suffixed singular name survives, the input shape selects the form, and the docstring says whether the function is batch vectorized.

## What this does

The plural twins in `mortie/batch.py` are the *kernels* — they already carry the ragged validation, the GIL release and the rayon fan-out, and their per-item results are byte-identical to the scalar. So the collapse is a delegation, not a reimplementation.

Two shapes of pair, and they need different spellings:

**(1) The item is itself an array** (every MOC operation, and the toc reduce). A mortie MOC *is* a `uint64` array, so the item and the column have the same rank and there is nothing for `asarray` coercion to discriminate on. These take a keyword-only `offsets=`:

```python
# mortie/moc.py
def moc_to_order(morton, order, max_cells=_FLAT_COVER_WARN_THRESHOLD, *,
                 offsets=None):
    if offsets is not None:
        return mocs_to_orders(morton, offsets, order, max_cells)
    ...
```

`offsets` is exactly how the plural already spells the batch, so the collapsed signature is the scalar's signature plus the one argument that distinguishes the forms, both call sites keep their shapes, and the arrow list layout that `polygons_to_morton_mocs` emits and `mocs_to_orders` consumes stays zero-copy. Keyword-only, so it can never be reached positionally by code written against the current signature.

**(2) The item is a genuine scalar** (`decimal_to_word`, `generate_morton_children`). Here numpy semantics apply literally and the *rank of the input* is the discriminator — no new argument at all.

## Phase 0 — inventory and classification (the P0 table)

Every scalar/plural pair on the public surface (`mortie/__init__.py`'s `__all__`). In-repo reference counts only — this routine's GitHub access is scoped to `espg/mortie`, so the zagg/moczarr caller counts the P0 plan asked for are **not** in this table; they need a human pass or a wider scope.

| operation | surviving name | retiring twin | shape of the pair | phase |
|---|---|---|---|---|
| densify MOC to a flat order | `moc_to_order` | `mocs_to_orders` | ragged column (`offsets`) | 1 ✅ |
| MOC intersection | `moc_and` | `mocs_and` | 1 × N broadcast (`offsets`) | 1 ✅ |
| MOC overlap predicate | `moc_intersects` | `mocs_intersect` | 1 × N broadcast (`offsets`) | 1 ✅ |
| deepest common ancestor | `common_ancestor` (alias `moc_min`) | `common_ancestors` | ragged column (`offsets`) | 1 ✅ |
| toc semilattice reduce | `toc_reduce` | `tocs_reduce` | ragged column (`offsets`) | 2 ✅ |
| decimal-string parse | `decimal_to_word` | `decimals_to_words` | true elementwise — numpy semantics literally | 2 ✅ |
| refine parents to children | `generate_morton_children` | `children_of` | elementwise, dense `(n, 4**d)` result | 2 ✅ |
| WKB ingest | `from_wkb` | `from_wkbs` | sequence of blobs — **see question (4)** | 4 |
| polygon coverage MOC | **`polygons_to_morton_mocs`** | `morton_coverage_moc` | ragged, batch-native signature — the *plural* survives here, per the ruling on question (3) of the plan | 4 |

Not pairs, recorded so the table is exhaustive:

- `moc_or`, `moc_minus`, `moc_xor`, `moc_not` — **no batch kernel exists**, so nothing to collapse. This is the gap PR #174 deferred and #194 routes back through this issue; it stays a separate question (an operation that does not batch, not a pair that needs collapsing). Phase 3's docstring marker now says so on each of them.
- `morton_coverage`, `compress_moc`, `split_base_cells`, `clip2order`, `orders_of`, `validate_morton`, the `convert.py` encoders — already array-in/array-out with no plural twin.
- `mortie.arrow.from_wkbs` / `mortie.arrow.polygons_to_morton_mocs` — the pyarrow skin is a third axis (issue #154) and is deliberately out of scope here.

## Phases

- [x] **Phase 1** (`fa0c559`) — the P0 table + the ragged MOC family: `moc_to_order`, `moc_and`, `moc_intersects`, `common_ancestor` / `moc_min`.
- [x] **Phase 2** (`d9352f3`) — the scalar-item pairs and the toc reduce: `toc_reduce`, `decimal_to_word`, `generate_morton_children`.
- [x] **Phase 3** (`725807c`) — the docstring sweep: **68 docstrings across 13 files** now state whether the function is batch vectorized, which is the explicit ask on the issue thread (*"we don't have full parity with all functions … so we need to note in the docstrings if the function is batch vectorized or not"*). Three markers: `**Batch vectorized**: array in, array out, elementwise.` (43), `**Not batch vectorized**: one <thing> per call.` (18, and the `moc_or`/`moc_minus`/`moc_xor` ones say there is no batch kernel behind them), and `**Batch native**: reached polymorphically by …` on the seven plural kernels. Two were deliberately left unmarked as ambiguous — see question (6).
- [x] **Review fold** (`6cb2a16`) — both adversarial reviews folded, including two blocking defects. Detail in https://github.com/espg/mortie/pull/195#issuecomment-5315339135.
- [ ] **Phase 4** — `from_wkb` / `morton_coverage_moc`, then P2 retirement of the redundant names. **Blocked on the rulings below.**

## How it was tested

`mortie/tests/test_polymorphic_api.py` (32 tests) asserts, per operation, that the polymorphic form is byte-identical **both** to the plural sibling and to a Python loop over the single-item form, over a ragged fixture that includes an empty MOC and a single-cell MOC; that the bare call is exactly the old scalar; that `offsets` cannot be passed positionally; that `moc_intersects(..., offsets=)` agrees slot-for-slot with the non-empty slots of `moc_and(..., offsets=)`; that the batch operands are *not* interchangeable; that `decimal_to_word` preserves input shape, keeps a bare `str` scalar, unwraps 0-d to a scalar, and refuses a `MortonIndexScalar` dtype on array input; that `generate_morton_children` gives `(4**d,)` for a scalar parent and `(n, 4**d)` for an array, refuses higher rank, and honours `max_cells` in both forms; plus the layout edges (plain-list offsets, single-group, zero-MOC column, non-monotone, `max_cells=None`). Every refusal is pinned to its actual message text, anchored.

Gates, on this branch at `6cb2a16`:

- `pytest` — **1576 passed, 16 skipped** (measured; baseline measured on `main` before branching: 1544 passed, 16 skipped).
- `flake8 mortie --select=E9,F63,F7,F82` — clean.
- `numpydoc lint mortie/*.py` — clean.
- No Rust change in any phase, so no `cargo` gate applies.

Two pre-existing style hits are left alone per §4 (both present on `main`, neither touched by this diff): `mortie/moc.py` has one 100-char line inside `moc_intersects`' docstring, and `F811` in `mortie/morton_index.py`.

One correction to an earlier version of this body: it claimed the "error surface passes through unchanged". That is false and the review caught it — with `offsets` the message text and the *validation precedence* both differ (`order=99, max_cells=-1` raises different errors with and without `offsets`, because the batch screens layout in its own pass first). What is unchanged is that every refusal is still a catchable `ValueError`.

## Questions for review

1. **Phase 4's retirement window — the main block.** The issue proposed landing the retirement "in the same breaking release as #186", but #186 closed on 2026-08-16 via PR #188 and `Cargo.toml` is at `0.9.9`. So: (a) the 1.0 release is still ahead and phase 4 removes the plural names outright in it — the original plan, and my lean if no `0.9.x` ships first; (b) a `0.9.x` ships before 1.0, so phase 4 adds `DeprecationWarning` shims now and the removal happens in 1.0; (c) keep the plural names permanently as documented aliases and drop the retirement.
2. **Is `offsets=` the spelling you want** for the ragged form on the singular names? The alternatives I can see (a sequence of arrays, an object array) either need a new dependency (§4) or lose the zero-copy arrow layout. (a) keep `offsets=` as implemented / (b) something else.
3. **`generate_morton_children` changes result *rank*, not just size** — scalar parent gives `(4**d,)`, an array gives `(n, 4**d)`. That is what numpy semantics imply and what `children_of` already returns, but it is **new behaviour, not a re-spelling**: an array previously coerced through `np.uint64` and described only its first element whenever `target_order` was finer than the parents' order. Confirm (a) numpy semantics as written, or (b) `generate_morton_children` keeps its 1-D contract and `children_of` survives as its own name.
4. **`from_wkb` / `from_wkbs` cannot use the same rank test, and I would rather not guess.** Two problems: (i) `from_wkb` takes "bytes, str, or buffer", and a `np.uint8` array of one blob's bytes is *both* a buffer and a sequence — so shape-sniffing is genuinely ambiguous here in a way it is not for `decimal_to_word`; (ii) `from_wkb` has `moc=False` and returns a flat cover, while `from_wkbs` has no `moc` argument and always returns ragged MOCs, so the batch form has no flat-cover counterpart to delegate to. Options: (a) treat only `list`/`tuple`/sequence-of-blobs as the batch form, keep buffers scalar, and make `from_wkb(seq, moc=False)` a clear `ValueError`; (b) give `from_wkb` an explicit `batch=False`; (c) leave `from_wkbs` as its own surviving name — this pair does not collapse cleanly. My lean is (a), but it is the one collapse where a wrong guess is worse than asking.
5. **Not in scope, surfaced while testing:** `norm2mort` squeezes a length-1 array input to a scalar (`np.shape(mortie.norm2mort(np.arange(1), np.zeros(1, dtype=int), 3)) == ()`). That is the opposite of the numpy semantics this issue endorses — array in should give array out. File as its own issue, or fold here?
6. **Two functions were left without a batch-vectorization marker in phase 3, deliberately.** `validate_morton` is typed `morton : int` but runs `np.atleast_1d` and validates every element through the kernel *while* checking `order` against `depths[0]` only — so array input is silently half-validated, and I did not want to document either reading as intended. `morton_index_type` takes no data at all, so the question does not apply. (a) mark `validate_morton` as batch vectorized and fix the `order` check to cover every element; (b) mark it not batch vectorized and make array input raise; (c) leave both unmarked.
